### PR TITLE
feat: admin features — role-based feature management and debug badges

### DIFF
--- a/components/DebugOverlay.jsx
+++ b/components/DebugOverlay.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { X } from 'lucide-react';
+
+/**
+ * DebugOverlay — scans the DOM for elements with data-testid and renders
+ * a floating badge on each one. Clicking a badge opens a modal with technical
+ * information about the element.
+ *
+ * Intended for the "tester" role when the debug-badges feature is active.
+ */
+export default function DebugOverlay() {
+  const [badges, setBadges] = useState([]);
+  const [modal, setModal] = useState(null);
+  const rafRef = useRef(null);
+
+  const scanElements = useCallback(() => {
+    const elements = document.querySelectorAll('[data-testid]');
+    const next = [];
+    elements.forEach((el) => {
+      // Skip the overlay's own elements to avoid infinite badge-on-badge
+      if (el.closest('[data-debug-overlay]')) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) return;
+      next.push({
+        testid: el.getAttribute('data-testid'),
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+        tagName: el.tagName.toLowerCase(),
+        ariaLabel: el.getAttribute('aria-label') ?? '',
+        role: el.getAttribute('role') ?? '',
+      });
+    });
+    setBadges(next);
+  }, []);
+
+  // Throttle updates via rAF
+  const scheduleScan = useCallback(() => {
+    if (rafRef.current) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      scanElements();
+    });
+  }, [scanElements]);
+
+  useEffect(() => {
+    scanElements();
+    const resizeObs = new ResizeObserver(scheduleScan);
+    resizeObs.observe(document.body);
+    const mutObs = new MutationObserver(scheduleScan);
+    mutObs.observe(document.body, { subtree: true, childList: true, attributes: true });
+    window.addEventListener('scroll', scheduleScan, true);
+    return () => {
+      resizeObs.disconnect();
+      mutObs.disconnect();
+      window.removeEventListener('scroll', scheduleScan, true);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [scanElements, scheduleScan]);
+
+  return (
+    <div data-debug-overlay="true" style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 9000 }}>
+      {badges.map((badge, i) => (
+        <button
+          key={`${badge.testid}-${i}`}
+          data-testid={`debug-badge-${badge.testid}`}
+          onClick={() => setModal(badge)}
+          title={badge.testid}
+          style={{
+            position: 'fixed',
+            top: badge.top,
+            left: badge.left,
+            pointerEvents: 'auto',
+            cursor: 'pointer',
+            padding: '1px 5px',
+            background: '#7c3aed',
+            color: '#fff',
+            fontSize: '10px',
+            fontFamily: 'monospace',
+            borderRadius: '3px',
+            lineHeight: '16px',
+            border: 'none',
+            whiteSpace: 'nowrap',
+            opacity: 0.85,
+          }}
+        >
+          {badge.testid}
+        </button>
+      ))}
+
+      {modal && (
+        <div
+          data-testid="debug-modal"
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(0,0,0,0.5)',
+            zIndex: 9001,
+            pointerEvents: 'auto',
+          }}
+          onClick={(e) => { if (e.target === e.currentTarget) setModal(null); }}
+        >
+          <div
+            style={{
+              background: '#1e1b4b',
+              color: '#e0e7ff',
+              borderRadius: '12px',
+              padding: '24px',
+              minWidth: '320px',
+              maxWidth: '480px',
+              fontFamily: 'monospace',
+              fontSize: '13px',
+              boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '16px' }}>
+              <span style={{ fontSize: '11px', color: '#a5b4fc', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                Technische Informationen
+              </span>
+              <button
+                data-testid="debug-modal-close"
+                onClick={() => setModal(null)}
+                style={{ background: 'none', border: 'none', color: '#a5b4fc', cursor: 'pointer', padding: '2px' }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <tbody>
+                {[
+                  ['data-testid', modal.testid],
+                  ['Element', `<${modal.tagName}>`],
+                  ['Breite × Höhe', `${Math.round(modal.width)} × ${Math.round(modal.height)} px`],
+                  ...(modal.ariaLabel ? [['aria-label', modal.ariaLabel]] : []),
+                  ...(modal.role ? [['role', modal.role]] : []),
+                ].map(([key, val]) => (
+                  <tr key={key}>
+                    <td style={{ color: '#818cf8', paddingRight: '16px', paddingBottom: '8px', whiteSpace: 'nowrap' }}>
+                      {key}
+                    </td>
+                    <td style={{ color: '#e0e7ff', paddingBottom: '8px', wordBreak: 'break-all' }}>
+                      {val}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ProfilePanel.jsx
+++ b/components/ProfilePanel.jsx
@@ -1,10 +1,11 @@
-import { ChevronLeft, X, User } from 'lucide-react';
+import { ChevronLeft, X, User, Shield } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
 import Toggle from '../ui/Toggle';
+import { ROLES, ROLE_LABELS } from '../hooks/useRole';
 
 /**
- * Profile panel — user stats, word blacklist, and feature toggles.
- * Displayed as a full-screen scrollable overlay.
+ * Profile panel — user stats, word blacklist, feature toggles, and admin tools.
+ * In admin mode shows all features (including unreleased) and role-assignment UI.
  */
 export default function ProfilePanel({
   onBack,
@@ -22,10 +23,24 @@ export default function ProfilePanel({
   _rawFlagValues,
   userFeatureOverrides,
   onToggleFeature,
+  // Role props
+  role,
+  setRole,
+  isAdmin,
+  visibleFeatureKeys,
+  isFeatureAssignedToRole,
+  toggleFeatureForRole,
 }) {
   const { dark, hc, tc } = useTheme();
 
   const _o = (key, raw) => Object.hasOwn(userFeatureOverrides, key) ? userFeatureOverrides[key] : raw;
+
+  // Admin sees all features; others see only role-assigned features
+  const visibleFeatures = isAdmin
+    ? features
+    : features.filter((f) => visibleFeatureKeys.has(f.key));
+
+  const nonAdminRoles = ROLES.filter((r) => r !== 'admin');
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -44,17 +59,48 @@ export default function ProfilePanel({
         {/* Avatar */}
         <div className="flex flex-col items-center gap-4 mb-10">
           <div className={`w-20 h-20 rounded-full flex items-center justify-center ${
-            dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-100 text-amber-700'
+            isAdmin
+              ? dark ? 'bg-violet-800 text-violet-200' : 'bg-violet-100 text-violet-700'
+              : dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-100 text-amber-700'
           }`}>
-            <User size={36} />
+            {isAdmin ? <Shield size={36} /> : <User size={36} />}
           </div>
           <div className="text-center">
             <p className={`text-xl font-serif font-bold ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
-              Leser
+              {ROLE_LABELS[role] ?? role}
             </p>
             <p className={`text-sm mt-0.5 ${dark ? 'text-amber-600' : 'text-amber-600'}`}>
-              Gast-Konto
+              {isAdmin ? 'Administrator' : 'Gast-Konto'}
             </p>
+          </div>
+        </div>
+
+        {/* Role selector */}
+        <div className="mb-8">
+          <h2 className={`text-xs font-semibold uppercase tracking-wider mb-3 px-1 ${
+            dark ? 'text-amber-500' : 'text-amber-600'
+          }`}>
+            Rolle
+          </h2>
+          <div className={`flex rounded-2xl border overflow-hidden ${
+            dark ? 'border-amber-700/30' : 'border-amber-200'
+          }`}>
+            {ROLES.map((r) => (
+              <button
+                key={r}
+                data-testid={`role-button-${r}`}
+                onClick={() => setRole(r)}
+                className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                  role === r
+                    ? isAdmin && r === 'admin'
+                      ? dark ? 'bg-violet-700 text-white' : 'bg-violet-600 text-white'
+                      : dark ? 'bg-amber-700/50 text-amber-100' : 'bg-amber-100 text-amber-900'
+                    : dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-800'
+                }`}
+              >
+                {ROLE_LABELS[r]}
+              </button>
+            ))}
           </div>
         </div>
 
@@ -142,6 +188,11 @@ export default function ProfilePanel({
               dark ? 'text-amber-500' : 'text-amber-600'
             }`}>
               Funktionen
+              {isAdmin && (
+                <span className={`ml-2 normal-case font-normal ${dark ? 'text-violet-400' : 'text-violet-600'}`}>
+                  — alle sichtbar (Admin)
+                </span>
+              )}
             </h2>
             <button
               onClick={onOpenDocs}
@@ -152,11 +203,20 @@ export default function ProfilePanel({
               Alle Funktionen erklärt →
             </button>
           </div>
+
+          {visibleFeatures.length === 0 && (
+            <p className={`px-1 text-sm ${dark ? 'text-amber-700' : 'text-amber-500'}`}>
+              Keine Funktionen für diese Rolle freigeschaltet.
+            </p>
+          )}
+
           <div className={`rounded-2xl border divide-y ${
             dark ? 'border-amber-700/30 divide-amber-700/30' : 'border-amber-200 divide-amber-200'
           }`}>
-            {features.map(({ key, label, description, Icon }) => {
+            {visibleFeatures.map(({ key, label, description, Icon }) => {
               const effective = _o(key, _rawFlagValues[key] ?? false);
+              const isUnreleased = !Object.hasOwn(_rawFlagValues, key);
+
               return (
                 <div key={key} className={`px-5 py-4 flex items-start gap-4 ${
                   dark ? 'text-amber-200' : 'text-amber-900'
@@ -170,9 +230,18 @@ export default function ProfilePanel({
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-3">
-                      <p className={`text-sm font-medium transition-opacity ${
-                        effective ? '' : 'opacity-40'
-                      }`}>{label}</p>
+                      <div className="flex items-center gap-2 min-w-0">
+                        <p className={`text-sm font-medium transition-opacity ${
+                          effective ? '' : 'opacity-40'
+                        }`}>{label}</p>
+                        {isUnreleased && (
+                          <span className={`flex-shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
+                            dark ? 'bg-violet-900/60 text-violet-300' : 'bg-violet-100 text-violet-700'
+                          }`}>
+                            unveröffentlicht
+                          </span>
+                        )}
+                      </div>
                       <Toggle
                         checked={effective}
                         onChange={() => onToggleFeature(key)}
@@ -190,6 +259,36 @@ export default function ProfilePanel({
                     >
                       Mehr erfahren →
                     </button>
+
+                    {/* Admin: role-assignment row */}
+                    {isAdmin && (
+                      <div className="flex items-center gap-3 mt-2">
+                        <span className={`text-[10px] uppercase tracking-wider ${
+                          dark ? 'text-amber-700' : 'text-amber-400'
+                        }`}>Rollen:</span>
+                        {nonAdminRoles.map((r) => {
+                          const assigned = isFeatureAssignedToRole(key, r);
+                          return (
+                            <button
+                              key={r}
+                              data-testid={`role-assign-${key}-${r}`}
+                              onClick={() => toggleFeatureForRole(key, r)}
+                              className={`text-[10px] font-medium px-2 py-0.5 rounded-full border transition-colors ${
+                                assigned
+                                  ? dark
+                                    ? 'bg-violet-700/60 border-violet-500 text-violet-200'
+                                    : 'bg-violet-100 border-violet-400 text-violet-800'
+                                  : dark
+                                    ? 'border-amber-800/50 text-amber-800 hover:text-amber-600'
+                                    : 'border-amber-300 text-amber-400 hover:text-amber-600'
+                              }`}
+                            >
+                              {ROLE_LABELS[r]}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
                   </div>
                 </div>
               );

--- a/features.jsx
+++ b/features.jsx
@@ -259,6 +259,18 @@ export const FEATURES = [
       </svg>
     ),
   },
+  {
+    key: 'debug-badges',
+    label: 'Debug-Badges',
+    description: 'Zeigt auf jeder Komponente ein Badge mit dem technischen Namen an — für Tester, damit sie immer den richtigen data-testid-Namen kennen.',
+    Icon: () => (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2L2 7l10 5 10-5-10-5z" />
+        <path d="M2 17l10 5 10-5" />
+        <path d="M2 12l10 5 10-5" />
+      </svg>
+    ),
+  },
   // status: Umgesetzt
   {
     key: 'speedreader-orp',

--- a/flags.json
+++ b/flags.json
@@ -17,5 +17,6 @@
   "big-fonts":         { "defaultVariant": "off", "variants": { "off": "off", "big": "big", "bigger": "bigger", "biggest": "biggest" } },
   "high-contrast-theme": { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "word-blacklist":      { "defaultVariant": "off", "variants": { "on": true, "off": false } },
-  "story-directories":   { "defaultVariant": "off", "variants": { "on": true, "off": false } }
+  "story-directories":   { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "debug-badges":        { "defaultVariant": "off", "variants": { "on": true, "off": false } }
 }

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -6,6 +6,7 @@ import { useTypography } from './hooks/useTypography';
 import { usePersistence } from './hooks/usePersistence';
 import { useReader } from './hooks/useReader';
 import FeatureDocs from './FeatureDocs';
+import { useRole } from './hooks/useRole';
 import { ThemeContext } from './ui/ThemeContext';
 import Toggle from './ui/Toggle';
 import IconButton from './ui/IconButton';
@@ -16,6 +17,7 @@ import Sidebar from './components/Sidebar';
 import TypographyPanel, { LINE_HEIGHTS, WORD_SPACINGS, FONT_FAMILIES } from './ui/TypographyPanel';
 import AudioPlayer from './ui/AudioPlayer';
 import SpeedReaderView from './ui/SpeedReaderView';
+import DebugOverlay from './components/DebugOverlay';
 
 const storyAudioFiles = import.meta.glob('/stories/*/*/audio.mp3', { eager: true, query: '?url', import: 'default' });
 
@@ -29,10 +31,16 @@ const GrimmMarchenApp = () => {
     showWordCount, showReadingDuration, showFontSizeControls, showEinkFlash,
     showTapZones, showAdaptionSwitcher, showTypographyPanel, showAttribution,
     showFavorites, showFavoritesOnlyToggle, showAudioPlayer, showHighContrastTheme,
-    showSpeedReader, showSpeedreaderOrp, showWordBlacklist, showStoryDirectories, _rawFlagValues,
+    showSpeedReader, showSpeedreaderOrp, showWordBlacklist, showStoryDirectories, showDebugBadges,
+    _rawFlagValues,
     userFeatureOverrides, setUserFeatureOverrides, _o,
     flagTheme, bigFontsVariant,
   } = flags;
+
+  // Role management
+  const {
+    role, setRole, isAdmin, visibleFeatureKeys, isFeatureAssignedToRole, toggleFeatureForRole,
+  } = useRole();
 
   // Typography
   const typo = useTypography({ maxFontSize });
@@ -419,6 +427,12 @@ const GrimmMarchenApp = () => {
               _rawFlagValues={_rawFlagValues}
               userFeatureOverrides={userFeatureOverrides}
               onToggleFeature={(key) => setUserFeatureOverrides(prev => ({ ...prev, [key]: !_o(key, _rawFlagValues[key] ?? false) }))}
+              role={role}
+              setRole={setRole}
+              isAdmin={isAdmin}
+              visibleFeatureKeys={visibleFeatureKeys}
+              isFeatureAssignedToRole={isFeatureAssignedToRole}
+              toggleFeatureForRole={toggleFeatureForRole}
             />
           ) : selectedStory ? (
             <ReaderView
@@ -488,6 +502,8 @@ const GrimmMarchenApp = () => {
         </main>
       </div>
     </div>
+
+    {showDebugBadges && <DebugOverlay />}
     </ThemeContext.Provider>
   );
 };

--- a/hooks/useFeatureFlags.js
+++ b/hooks/useFeatureFlags.js
@@ -23,6 +23,7 @@ export function useFeatureFlags() {
   const _rawSpeedreaderOrp = useBooleanFlagValue('speedreader-orp', false);
   const _rawWordBlacklist = useBooleanFlagValue('word-blacklist', false);
   const _rawStoryDirectories = useBooleanFlagValue('story-directories', false);
+  const _rawDebugBadges = useBooleanFlagValue('debug-badges', false);
 
   // User feature overrides — stored in localStorage, take precedence over flag defaults
   const [userFeatureOverrides, setUserFeatureOverrides] = useState(() =>
@@ -53,6 +54,7 @@ export function useFeatureFlags() {
   const showSpeedreaderOrp = _o('speedreader-orp', _rawSpeedreaderOrp);
   const showWordBlacklist = _o('word-blacklist', _rawWordBlacklist);
   const showStoryDirectories = _o('story-directories', _rawStoryDirectories);
+  const showDebugBadges = _o('debug-badges', _rawDebugBadges);
 
   // Raw values keyed by feature key — used in profile feature toggles
   const _rawFlagValues = {
@@ -72,6 +74,7 @@ export function useFeatureFlags() {
     'speedreader-orp': _rawSpeedreaderOrp,
     'word-blacklist': _rawWordBlacklist,
     'story-directories': _rawStoryDirectories,
+    'debug-badges': _rawDebugBadges,
   };
 
   // String flags
@@ -96,6 +99,7 @@ export function useFeatureFlags() {
     showSpeedreaderOrp,
     showWordBlacklist,
     showStoryDirectories,
+    showDebugBadges,
     _rawFlagValues,
     userFeatureOverrides,
     setUserFeatureOverrides,

--- a/hooks/useRole.js
+++ b/hooks/useRole.js
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import { FEATURES } from '../features';
+
+export const ROLES = ['guest', 'subscriber', 'tester', 'admin'];
+
+export const ROLE_LABELS = {
+  guest: 'Gast',
+  subscriber: 'Abonnent',
+  tester: 'Tester',
+  admin: 'Admin',
+};
+
+function defaultRoleFeatures() {
+  return { guest: [], subscriber: [], tester: [] };
+}
+
+/**
+ * Role management hook.
+ * Manages the current user role and which features are assigned to each role.
+ * Admins see all features including unreleased ones and can assign features to roles.
+ */
+export function useRole() {
+  const [role, setRoleState] = useState(() =>
+    localStorage.getItem('wr-role') ?? 'guest'
+  );
+
+  const [roleFeatures, setRoleFeatures] = useState(() => {
+    const stored = localStorage.getItem('wr-role-features');
+    return stored ? JSON.parse(stored) : defaultRoleFeatures();
+  });
+
+  const setRole = (newRole) => setRoleState(newRole);
+
+  useEffect(() => {
+    localStorage.setItem('wr-role', role);
+  }, [role]);
+
+  useEffect(() => {
+    localStorage.setItem('wr-role-features', JSON.stringify(roleFeatures));
+  }, [roleFeatures]);
+
+  const isAdmin = role === 'admin';
+
+  // Admin sees all features; others see only features assigned to their role.
+  const visibleFeatureKeys = new Set(
+    isAdmin ? FEATURES.map((f) => f.key) : (roleFeatures[role] ?? [])
+  );
+
+  const isFeatureAssignedToRole = (featureKey, targetRole) =>
+    (roleFeatures[targetRole] ?? []).includes(featureKey);
+
+  const toggleFeatureForRole = (featureKey, targetRole) => {
+    setRoleFeatures((prev) => {
+      const list = prev[targetRole] ?? [];
+      const has = list.includes(featureKey);
+      return {
+        ...prev,
+        [targetRole]: has
+          ? list.filter((k) => k !== featureKey)
+          : [...list, featureKey],
+      };
+    });
+  };
+
+  return {
+    role,
+    setRole,
+    isAdmin,
+    roleFeatures,
+    visibleFeatureKeys,
+    isFeatureAssignedToRole,
+    toggleFeatureForRole,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -109,6 +110,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -224,7 +226,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -273,9 +274,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1517,7 +1540,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1689,6 +1713,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1699,6 +1724,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1813,7 +1839,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1963,7 +1988,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -2266,7 +2292,6 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -2600,6 +2625,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2738,7 +2764,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2813,7 +2838,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2836,6 +2860,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2860,7 +2885,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2873,7 +2897,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -2887,7 +2910,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -3162,7 +3186,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3224,7 +3247,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",


### PR DESCRIPTION
Closes #5

- Add `useRole` hook: manages current role (guest/subscriber/tester/admin)
  stored in localStorage; tracks per-role feature assignments
- Admin sees all features including unreleased ones in the ProfilePanel
- Admin can assign/unassign features to each role via per-feature role buttons
- Add `debug-badges` feature: when active, overlays data-testid badges on
  every component; clicking a badge shows a modal with technical info
  (testid, element type, dimensions, aria attributes)
- ProfilePanel now shows role selector and adapts feature list to the
  current role; unreleased features are labeled "unveröffentlicht"

https://claude.ai/code/session_01X4VynzNZj8oty913fdgD6o