### PR TITLE
add animation-navigation E2E spec (23 tests, all green)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.56.0",
         "@tailwindcss/postcss": "4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -881,13 +881,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.56.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2292,7 +2292,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -2824,13 +2823,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.56.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2843,9 +2842,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.56.0",
     "@tailwindcss/postcss": "4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/tests/animation-navigation.spec.js
+++ b/tests/animation-navigation.spec.js
@@ -1,0 +1,455 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+/**
+ * Animation & Navigation Flow Tests
+ *
+ * Covers four areas:
+ *
+ *  A. App onload animation
+ *     The AppAnimationWrapper mounts with class="app-enter", which triggers the
+ *     appSlideUp keyframe (translateY 100%→0, opacity 0→1, 650 ms).
+ *
+ *  B. App onClose animation
+ *     pagehide / beforeunload listeners swap .app-enter → .app-exit, which
+ *     triggers the appSlideDown keyframe (translateY 0→100%, opacity 1→0, 450 ms).
+ *
+ *  C. Sidebar open/close (transition-transform duration-300)
+ *     On mobile the sidebar lives off-screen (-translate-x-full).  menu-toggle
+ *     flips it to translate-x-0; story selection flips it back.
+ *
+ *  D. Navigation depth permutations
+ *     D1 – 2-level (source → story list, e.g. Grimm)
+ *     D2 – 3-level (source → directory list → story list, e.g. Swiss)
+ *          Requires the story-directories feature flag to be enabled.
+ *
+ * Playwright is configured with reducedMotion:'reduce', so CSS animations
+ * (.app-enter / .app-exit) complete instantly and CSS transitions run
+ * at 0-duration.  Tests check class names and element visibility rather
+ * than elapsed time.
+ */
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/** Set the story-directories feature override in localStorage before the page
+ *  initialises so that it is read by the React hook on first render. */
+async function enableDirectoriesFlag(page) {
+  await page.addInitScript(() => {
+    const overrides = JSON.parse(localStorage.getItem('wr-feature-overrides') ?? '{}');
+    overrides['story-directories'] = true;
+    localStorage.setItem('wr-feature-overrides', JSON.stringify(overrides));
+  });
+}
+
+/** Click menu-toggle if it is visible (mobile), then wait for the 300 ms
+ *  transition to settle. */
+async function openSidebarIfNeeded(page) {
+  const toggle = page.locator('[data-testid="menu-toggle"]');
+  if (await toggle.isVisible()) {
+    await toggle.click();
+    await page.waitForTimeout(300);
+  }
+}
+
+/** Walk through every source button until one reveals directory-button items.
+ *  Returns true when a source with directories is active; false if none found. */
+async function drillIntoSourceWithDirectories(page) {
+  const sourceBtns = page.locator('[data-testid="source-button"]');
+  const count = await sourceBtns.count();
+  for (let i = 0; i < count; i++) {
+    await sourceBtns.nth(i).click();
+    await page.waitForTimeout(200);
+    const dirBtn = page.locator('[data-testid="directory-button"]').first();
+    if (await dirBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+      return true;
+    }
+    // Go back to source list and try the next source
+    const back = page.locator('[data-testid="back-to-sources"]');
+    if (await back.isVisible({ timeout: 300 }).catch(() => false)) {
+      await back.click();
+      await page.waitForTimeout(200);
+    }
+  }
+  return false;
+}
+
+// ─── A. App onload animation ─────────────────────────────────────────────────
+
+test.describe('A – App onload animation', () => {
+  test('wrapper has .app-enter on first paint', async ({ page }) => {
+    await page.goto('/app');
+    // Check class before networkidle so we catch it at the earliest possible moment
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('.app-enter').first()).toBeAttached();
+  });
+
+  test('.app-exit is absent on load', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('.app-exit')).not.toBeAttached();
+  });
+
+  test('wrapper rendered with width:100% height:100% inline styles', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    const styles = await page.locator('.app-enter').first().evaluate(el => ({
+      width: el.style.width,
+      height: el.style.height,
+    }));
+    expect(styles.width).toBe('100%');
+    expect(styles.height).toBe('100%');
+  });
+});
+
+// ─── B. App onClose animation ────────────────────────────────────────────────
+
+test.describe('B – App onClose animation', () => {
+  test('pagehide swaps .app-enter → .app-exit', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    // Initial state
+    await expect(page.locator('.app-enter').first()).toBeAttached();
+
+    // Simulate browser tab/window close
+    await page.evaluate(() => window.dispatchEvent(new Event('pagehide')));
+
+    await expect(page.locator('.app-exit').first()).toBeAttached();
+    await expect(page.locator('.app-enter')).not.toBeAttached();
+  });
+
+  test('beforeunload also triggers .app-exit', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    await page.evaluate(() => window.dispatchEvent(new Event('beforeunload')));
+
+    await expect(page.locator('.app-exit').first()).toBeAttached();
+  });
+
+  test('fresh navigation resets to .app-enter (no residual .app-exit)', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    // Trigger exit on first load
+    await page.evaluate(() => window.dispatchEvent(new Event('pagehide')));
+    await expect(page.locator('.app-exit').first()).toBeAttached();
+
+    // Navigate again — the component remounts with app-enter
+    await page.goto('/app');
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.locator('.app-enter').first()).toBeAttached();
+    await expect(page.locator('.app-exit')).not.toBeAttached();
+  });
+});
+
+// ─── C. Sidebar open/close animation ─────────────────────────────────────────
+
+test.describe('C – Sidebar open/close animation', () => {
+  test('sidebar carries transition-transform duration-300 classes', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    const sidebar = page.locator('aside').first();
+    await expect(sidebar).toHaveClass(/transition-transform/);
+    await expect(sidebar).toHaveClass(/duration-300/);
+  });
+
+  test('sidebar starts off-screen on mobile (-translate-x-full)', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    const sidebar = page.locator('aside').first();
+    await expect(sidebar).toHaveClass(/-translate-x-full/);
+  });
+
+  test('menu-toggle slides sidebar in (translate-x-0)', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('[data-testid="menu-toggle"]').click();
+    await page.waitForTimeout(300);
+
+    const sidebar = page.locator('aside').first();
+    await expect(sidebar).toHaveClass(/translate-x-0/);
+    await expect(sidebar).not.toHaveClass(/-translate-x-full/);
+  });
+
+  test('sidebar slides back out after selecting a story', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    // Open sidebar
+    await page.locator('[data-testid="menu-toggle"]').click();
+    await page.waitForTimeout(300);
+
+    // Drill to stories
+    const sourceBtn = page.locator('[data-testid="source-button"]').first();
+    await expect(sourceBtn).toBeVisible({ timeout: 3000 });
+    await sourceBtn.click();
+    await page.waitForTimeout(300);
+
+    // If directories are shown, drill one deeper
+    const dirBtn = page.locator('[data-testid="directory-button"]').first();
+    if (await dirBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+      await dirBtn.click();
+      await page.waitForTimeout(300);
+    }
+
+    // Select story — sidebar must close
+    const storyBtn = page.locator('[data-testid="story-button"]').first();
+    await expect(storyBtn).toBeVisible({ timeout: 5000 });
+    await storyBtn.click();
+    await page.waitForTimeout(300);
+
+    const sidebar = page.locator('aside').first();
+    await expect(sidebar).toHaveClass(/-translate-x-full/);
+  });
+
+  test('menu-toggle is hidden on desktop viewport (sidebar always visible)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    // menu-toggle has lg:hidden — not visible at desktop width
+    await expect(page.locator('[data-testid="menu-toggle"]')).not.toBeVisible();
+  });
+});
+
+// ─── D1. 2-level navigation (source → story) ─────────────────────────────────
+
+test.describe('D1 – 2-level navigation (source → story)', () => {
+  test('source list is visible on load; story list is not', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    await expect(page.locator('[data-testid="source-button"]').first()).toBeVisible({ timeout: 3000 });
+    // No story-button should be directly visible before drilling in
+    await expect(page.locator('[data-testid="story-button"]').first()).not.toBeVisible();
+  });
+
+  test('clicking a source renders back-to-sources and stories (or directories)', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    await page.locator('[data-testid="source-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('[data-testid="back-to-sources"]')).toBeVisible({ timeout: 3000 });
+    const itemCount = await page
+      .locator('[data-testid="story-button"], [data-testid="directory-button"]')
+      .count();
+    expect(itemCount).toBeGreaterThan(0);
+  });
+
+  test('back-to-sources returns to source list', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    await page.locator('[data-testid="source-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    await page.locator('[data-testid="back-to-sources"]').click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('[data-testid="source-button"]').first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="back-to-sources"]')).not.toBeVisible();
+  });
+
+  test('selecting a story opens the reader (page-content + page-counter visible)', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    // Find a 2-level source (Grimm has no directories)
+    const sourceBtns = page.locator('[data-testid="source-button"]');
+    const count = await sourceBtns.count();
+    let landed = false;
+    for (let i = 0; i < count; i++) {
+      await sourceBtns.nth(i).click();
+      await page.waitForTimeout(300);
+      // Skip if this source shows directories
+      if (await page.locator('[data-testid="directory-button"]').first().isVisible({ timeout: 300 }).catch(() => false)) {
+        await page.locator('[data-testid="back-to-sources"]').click();
+        await page.waitForTimeout(200);
+        continue;
+      }
+      landed = true;
+      break;
+    }
+    if (!landed) test.skip(true, 'No 2-level source found');
+
+    const storyBtn = page.locator('[data-testid="story-button"]').first();
+    await expect(storyBtn).toBeVisible({ timeout: 5000 });
+    await storyBtn.click();
+
+    await expect(page.locator('[data-testid="page-content"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="page-counter"]')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('multiple back-and-forth drills stay consistent', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    for (let round = 0; round < 3; round++) {
+      await page.locator('[data-testid="source-button"]').first().click();
+      await page.waitForTimeout(200);
+      await expect(page.locator('[data-testid="back-to-sources"]')).toBeVisible({ timeout: 3000 });
+
+      await page.locator('[data-testid="back-to-sources"]').click();
+      await page.waitForTimeout(200);
+      await expect(page.locator('[data-testid="source-button"]').first()).toBeVisible({ timeout: 3000 });
+    }
+  });
+});
+
+// ─── D2. 3-level navigation (source → directory → story) ─────────────────────
+
+test.describe('D2 – 3-level navigation (source → directory → story)', () => {
+  test.beforeEach(async ({ page }) => {
+    await enableDirectoriesFlag(page);
+  });
+
+  test('source with directories shows directory-button list (not story-button)', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    const found = await drillIntoSourceWithDirectories(page);
+    test.skip(!found, 'No source with directories found in this build');
+
+    await expect(page.locator('[data-testid="directory-button"]').first()).toBeVisible({ timeout: 3000 });
+    // Stories are not yet visible — we are at the directory level
+    await expect(page.locator('[data-testid="story-button"]').first()).not.toBeVisible();
+  });
+
+  test('clicking a directory renders back-to-directories and story list', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    const found = await drillIntoSourceWithDirectories(page);
+    test.skip(!found, 'No source with directories found in this build');
+
+    await page.locator('[data-testid="directory-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('[data-testid="back-to-directories"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="story-button"]').first()).toBeVisible({ timeout: 3000 });
+    // Directory buttons should no longer be visible
+    await expect(page.locator('[data-testid="directory-button"]').first()).not.toBeVisible();
+  });
+
+  test('back-to-directories returns to directory list', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    const found = await drillIntoSourceWithDirectories(page);
+    test.skip(!found, 'No source with directories found in this build');
+
+    await page.locator('[data-testid="directory-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    await page.locator('[data-testid="back-to-directories"]').click();
+    await page.waitForTimeout(300);
+
+    // Back at directory level: directories visible, back-to-sources visible,
+    // back-to-directories gone, stories gone
+    await expect(page.locator('[data-testid="directory-button"]').first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="back-to-sources"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="back-to-directories"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="story-button"]').first()).not.toBeVisible();
+  });
+
+  test('back-to-sources from directory level returns to source list', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    const found = await drillIntoSourceWithDirectories(page);
+    test.skip(!found, 'No source with directories found in this build');
+
+    await page.locator('[data-testid="back-to-sources"]').click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('[data-testid="source-button"]').first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="back-to-sources"]')).not.toBeVisible();
+  });
+
+  test('full 3-level flow: source → directory → story → reader', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    const found = await drillIntoSourceWithDirectories(page);
+    test.skip(!found, 'No source with directories found in this build');
+
+    // Depth 2 → depth 3
+    await page.locator('[data-testid="directory-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    const storyBtn = page.locator('[data-testid="story-button"]').first();
+    await expect(storyBtn).toBeVisible({ timeout: 5000 });
+    await storyBtn.click();
+
+    await expect(page.locator('[data-testid="page-content"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('[data-testid="page-counter"]')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('3-level: sidebar closes on story selection (mobile)', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('[data-testid="menu-toggle"]').click();
+    await page.waitForTimeout(300);
+
+    const found = await drillIntoSourceWithDirectories(page);
+    test.skip(!found, 'No source with directories found in this build');
+
+    await page.locator('[data-testid="directory-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    await page.locator('[data-testid="story-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    // Sidebar must have slid back off-screen
+    const sidebar = page.locator('aside').first();
+    await expect(sidebar).toHaveClass(/-translate-x-full/);
+  });
+
+  test('navigating back through all 3 levels leaves source list visible', async ({ page }) => {
+    await page.goto('/app');
+    await page.waitForLoadState('networkidle');
+    await openSidebarIfNeeded(page);
+
+    const found = await drillIntoSourceWithDirectories(page);
+    test.skip(!found, 'No source with directories found in this build');
+
+    // Drill to story level
+    await page.locator('[data-testid="directory-button"]').first().click();
+    await page.waitForTimeout(300);
+
+    // Back to directories
+    await page.locator('[data-testid="back-to-directories"]').click();
+    await page.waitForTimeout(300);
+
+    // Back to sources
+    await page.locator('[data-testid="back-to-sources"]').click();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('[data-testid="source-button"]').first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-testid="back-to-sources"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="back-to-directories"]')).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Tests cover:
  A – App onload: .app-enter present on mount, .app-exit absent
  B – App onClose: pagehide/beforeunload swap .app-enter → .app-exit
  C – Sidebar: transition classes, off-screen start, open/close on mobile,
      always-visible on desktop
  D1 – 2-level nav (source → story): drill-in, back, story load
  D2 – 3-level nav (source → directory → story, story-directories flag):
       directory list, back-to-directories, back-to-sources, full 3-level
       flow, sidebar close on selection, full back traversal

Also pins @playwright/test to ^1.56.0 (revision 1194, matching the
browser binary that is available in this environment).

https://claude.ai/code/session_01WwuP8FJRsroHd7PxT1TE3u