### PR TITLE
Improve CI pipeline

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: Node.js CI
 
 on:
@@ -10,23 +7,52 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  # ── Unit tests + build ────────────────────────────────────────────────────
+  # Fast, no browser needed. Gates E2E so a broken unit test doesn't waste
+  # time on the Playwright browser download.
+  unit:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npx playwright install --with-deps chromium
-    - run: npm run build --if-present
-    - run: npm run test
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:unit
+
+  # ── E2E tests ─────────────────────────────────────────────────────────────
+  # Only runs when unit passes. Caches the Playwright browser binary so
+  # subsequent runs skip the ~30 s download.
+  e2e:
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.2
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - run: npm run test
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec  # v4.6.1
+        with:
+          name: playwright-report
+          path: test-results/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Overhaul of `.github/workflows/node.js.yml` based on a CI expert review.

## Changes

**Correctness**
- Drop Node 18 (EOL) and 20 from the matrix — both are incompatible with Vite 8 + Vitest 4; single target `22.x` is correct for an app
- Add missing `npm run test:unit` step
- Remove `--if-present` misuse on `npm run build`

**Speed**
- Split into two jobs: `unit` (build + vitest) gates `e2e` (playwright) via `needs:` — a fast unit failure stops the run before the browser download starts
- Cache Playwright browser binary keyed on `hashFiles('package-lock.json')` — saves ~30 s on warm runs

**DX**
- Upload `test-results/` as an artifact for 7 days on E2E failure — inspect Playwright traces without re-running locally

**Security**
- All `actions/*` references pinned to full commit SHAs instead of mutable `@v4` tags

https://claude.ai/code/session_01WwuP8FJRsroHd7PxT1TE3u