### PR TITLE
docs: add extended user personas and product strategy

### DIFF
--- a/components/PersonasDocsView.jsx
+++ b/components/PersonasDocsView.jsx
@@ -1,25 +1,27 @@
 import { useState, useEffect } from 'react';
-import { ChevronLeft, ExternalLink, Users } from 'lucide-react';
+import { ChevronLeft, ExternalLink } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
 
 const BRANCH = 'claude/extended-user-personas-ZD1hR';
 const RAW_BASE = `https://raw.githubusercontent.com/tweakch/webreader/${BRANCH}/`;
 const WEB_BASE = `https://github.com/tweakch/webreader/blob/${BRANCH}/`;
 
+// ── Manifests ──────────────────────────────────────────────────────────────
+
 const PERSONAS = [
-  { id: '01-pre-readers',       label: 'Pre-Readers',        emoji: '👶', path: 'docs/personas/01-pre-readers.md' },
-  { id: '02-parents',           label: 'Parents',            emoji: '👨‍👩‍👧', path: 'docs/personas/02-parents.md' },
-  { id: '03-teachers',          label: 'Teachers',           emoji: '🧑‍🏫', path: 'docs/personas/03-teachers.md' },
-  { id: '04-culture-explorers', label: 'Culture Explorers',  emoji: '🌍', path: 'docs/personas/04-culture-explorers.md' },
-  { id: '05-therapeutic',       label: 'Therapeutic',        emoji: '🧘', path: 'docs/personas/05-therapeutic.md' },
-  { id: '06-creatives',         label: 'Creatives',          emoji: '🎭', path: 'docs/personas/06-creatives.md' },
-  { id: '07-passive-consumers', label: 'Passive Consumers',  emoji: '🎧', path: 'docs/personas/07-passive-consumers.md' },
-  { id: '08-developers',        label: 'Developers',         emoji: '🧑‍💻', path: 'docs/personas/08-developers.md' },
-  { id: '09-seniors',           label: 'Seniors',            emoji: '🧓', path: 'docs/personas/09-seniors.md' },
-  { id: '10-gamified-explorers',label: 'Gamified Explorers', emoji: '🧩', path: 'docs/personas/10-gamified-explorers.md' },
+  { id: '01-pre-readers',        label: 'Pre-Readers',        emoji: '👶', path: 'docs/personas/01-pre-readers.md' },
+  { id: '02-parents',            label: 'Parents',            emoji: '👨‍👩‍👧', path: 'docs/personas/02-parents.md' },
+  { id: '03-teachers',           label: 'Teachers',           emoji: '🧑‍🏫', path: 'docs/personas/03-teachers.md' },
+  { id: '04-culture-explorers',  label: 'Culture Explorers',  emoji: '🌍', path: 'docs/personas/04-culture-explorers.md' },
+  { id: '05-therapeutic',        label: 'Therapeutic',        emoji: '🧘', path: 'docs/personas/05-therapeutic.md' },
+  { id: '06-creatives',          label: 'Creatives',          emoji: '🎭', path: 'docs/personas/06-creatives.md' },
+  { id: '07-passive-consumers',  label: 'Passive Consumers',  emoji: '🎧', path: 'docs/personas/07-passive-consumers.md' },
+  { id: '08-developers',         label: 'Developers',         emoji: '🧑‍💻', path: 'docs/personas/08-developers.md' },
+  { id: '09-seniors',            label: 'Seniors',            emoji: '🧓', path: 'docs/personas/09-seniors.md' },
+  { id: '10-gamified-explorers', label: 'Gamified Explorers', emoji: '🧩', path: 'docs/personas/10-gamified-explorers.md' },
 ];
 
-const FEATURES = [
+const STRATEGIC_FEATURES = [
   { id: 'word-highlighting',    label: 'Word Highlighting',    status: 'vision',    path: 'docs/features/word-highlighting.md' },
   { id: 'audio-narration',      label: 'Audio Narration',      status: 'near-term', path: 'docs/features/audio-narration.md' },
   { id: 'bedtime-mode',         label: 'Bedtime Mode',         status: 'mvp',       path: 'docs/features/bedtime-mode.md' },
@@ -38,8 +40,52 @@ const FEATURES = [
   { id: 'choice-narratives',    label: 'Choice Narratives',    status: 'vision',    path: 'docs/features/choice-narratives.md' },
 ];
 
-// persona id sets per feature
-const MATRIX = {
+// lifecycle → display badge
+const APP_FEATURES = [
+  // reader-core
+  { id: 'favorites',             label: 'Favorites',            lifecycle: 'STABLE',     group: 'Reader Core',     path: 'docs/features/favorites.md' },
+  { id: 'favorites-only-toggle', label: 'Favorites-Only Toggle',lifecycle: 'STABLE',     group: 'Reader Core',     path: 'docs/features/favorites-only-toggle.md' },
+  // reader-stats
+  { id: 'word-count',            label: 'Word Count',           lifecycle: 'STABLE',     group: 'Reader Stats',    path: 'docs/features/word-count.md' },
+  { id: 'reading-duration',      label: 'Reading Duration',     lifecycle: 'STABLE',     group: 'Reader Stats',    path: 'docs/features/reading-duration.md' },
+  // reader-ui
+  { id: 'font-size-controls',    label: 'Font Size Controls',   lifecycle: 'STABLE',     group: 'Reader UI',       path: 'docs/features/font-size-controls.md' },
+  { id: 'pinch-font-size',       label: 'Pinch Font Size',      lifecycle: 'EXPERIMENT', group: 'Reader UI',       path: 'docs/features/pinch-font-size.md' },
+  { id: 'eink-flash',            label: 'E-Ink Flash',          lifecycle: 'STABLE',     group: 'Reader UI',       path: 'docs/features/eink-flash.md' },
+  { id: 'tap-zones',             label: 'Tap Zones',            lifecycle: 'STABLE',     group: 'Reader UI',       path: 'docs/features/tap-zones.md' },
+  { id: 'tap-middle-toggle',     label: 'Tap Middle Toggle',    lifecycle: 'STABLE',     group: 'Reader UI',       path: 'docs/features/tap-middle-toggle.md' },
+  // appearance
+  { id: 'theme',                 label: 'Theme',                lifecycle: 'STABLE',     group: 'Appearance',      path: 'docs/features/theme.md' },
+  { id: 'high-contrast-theme',   label: 'High Contrast',        lifecycle: 'STABLE',     group: 'Appearance',      path: 'docs/features/high-contrast-theme.md' },
+  { id: 'big-fonts',             label: 'Big Fonts',            lifecycle: 'EXPERIMENT', group: 'Appearance',      path: 'docs/features/big-fonts.md' },
+  { id: 'simplified-ui',         label: 'Simplified UI',        lifecycle: 'EXPERIMENT', group: 'Appearance',      path: 'docs/features/simplified-ui.md' },
+  // typography
+  { id: 'adaption-switcher',     label: 'Adaption Switcher',    lifecycle: 'STABLE',     group: 'Typography',      path: 'docs/features/adaption-switcher.md' },
+  { id: 'typography-panel',      label: 'Typography Panel',     lifecycle: 'STABLE',     group: 'Typography',      path: 'docs/features/typography-panel.md' },
+  { id: 'subscriber-fonts',      label: 'Subscriber Fonts',     lifecycle: 'EXPERIMENT', group: 'Typography',      path: 'docs/features/subscriber-fonts.md' },
+  // navigation & search
+  { id: 'story-directories',     label: 'Story Directories',    lifecycle: 'EXPERIMENT', group: 'Navigation',      path: 'docs/features/story-directories.md' },
+  { id: 'deep-search',           label: 'Deep Search',          lifecycle: 'EXPERIMENT', group: 'Navigation',      path: 'docs/features/deep-search.md' },
+  // advanced reading
+  { id: 'speed-reader',          label: 'Speed Reader',         lifecycle: 'EXPERIMENT', group: 'Advanced Reading',path: 'docs/features/speed-reader.md' },
+  { id: 'speedreader-orp',       label: 'ORP Enhancement',      lifecycle: 'EXPERIMENT', group: 'Advanced Reading',path: 'docs/features/speedreader-orp.md' },
+  { id: 'audio-player',          label: 'Audio Player',         lifecycle: 'EXPERIMENT', group: 'Advanced Reading',path: 'docs/features/audio-player.md' },
+  { id: 'text-to-speech',        label: 'Text-to-Speech',       lifecycle: 'EXPERIMENT', group: 'Advanced Reading',path: 'docs/features/text-to-speech.md' },
+  // gen-alpha
+  { id: 'read-along',            label: 'Read-Along',           lifecycle: 'EXPERIMENT', group: 'Gen Alpha',       path: 'docs/features/read-along.md' },
+  { id: 'illustrations',         label: 'Illustrations',        lifecycle: 'EXPERIMENT', group: 'Gen Alpha',       path: 'docs/features/illustrations.md' },
+  { id: 'child-profile',         label: 'Child Profile',        lifecycle: 'EXPERIMENT', group: 'Gen Alpha',       path: 'docs/features/child-profile.md' },
+  { id: 'story-quiz',            label: 'Story Quiz',           lifecycle: 'EXPERIMENT', group: 'Gen Alpha',       path: 'docs/features/story-quiz.md' },
+  // misc
+  { id: 'word-blacklist',        label: 'Word Blacklist',       lifecycle: 'EXPERIMENT', group: 'Tools',           path: 'docs/features/word-blacklist.md' },
+  { id: 'attribution',           label: 'Attribution',          lifecycle: 'STABLE',     group: 'Tools',           path: 'docs/features/attribution.md' },
+  // debug
+  { id: 'debug-badges',          label: 'Debug Badges',         lifecycle: 'EXPERIMENT', group: 'Debug',           path: 'docs/features/debug-badges.md' },
+  { id: 'error-page-simulator',  label: 'Error Page Simulator', lifecycle: 'EXPERIMENT', group: 'Debug',           path: 'docs/features/error-page-simulator.md' },
+];
+
+// strategic feature → persona id set
+const STRATEGIC_MATRIX = {
   'word-highlighting':    ['01-pre-readers'],
   'audio-narration':      ['01-pre-readers','02-parents','04-culture-explorers','07-passive-consumers','09-seniors'],
   'bedtime-mode':         ['02-parents','07-passive-consumers'],
@@ -58,24 +104,105 @@ const MATRIX = {
   'choice-narratives':    ['01-pre-readers','06-creatives','10-gamified-explorers'],
 };
 
-const STATUS_LABELS = { mvp: 'MVP', 'near-term': 'Near-term', vision: 'Vision' };
-const STATUS_COLORS = {
-  mvp:        { light: 'bg-emerald-100 text-emerald-800', dark: 'bg-emerald-900/40 text-emerald-300' },
-  'near-term':{ light: 'bg-amber-100 text-amber-800',     dark: 'bg-amber-900/40 text-amber-300' },
-  vision:     { light: 'bg-violet-100 text-violet-800',   dark: 'bg-violet-900/40 text-violet-300' },
+// app feature → persona id set
+const APP_MATRIX = {
+  'favorites':             ['05-therapeutic','07-passive-consumers','09-seniors','10-gamified-explorers'],
+  'favorites-only-toggle': ['07-passive-consumers','09-seniors','10-gamified-explorers'],
+  'word-count':            ['03-teachers','10-gamified-explorers'],
+  'reading-duration':      ['02-parents','03-teachers','09-seniors','10-gamified-explorers'],
+  'font-size-controls':    ['09-seniors'],
+  'pinch-font-size':       ['01-pre-readers','09-seniors'],
+  'eink-flash':            ['09-seniors'],
+  'tap-zones':             ['01-pre-readers','07-passive-consumers','09-seniors'],
+  'tap-middle-toggle':     ['07-passive-consumers'],
+  'theme':                 ['05-therapeutic','07-passive-consumers','09-seniors'],
+  'high-contrast-theme':   ['09-seniors'],
+  'big-fonts':             ['01-pre-readers','02-parents','09-seniors'],
+  'simplified-ui':         ['02-parents','09-seniors'],
+  'adaption-switcher':     ['03-teachers','04-culture-explorers','06-creatives','10-gamified-explorers'],
+  'typography-panel':      ['05-therapeutic','06-creatives','09-seniors'],
+  'subscriber-fonts':      ['05-therapeutic','06-creatives'],
+  'story-directories':     ['04-culture-explorers','08-developers','10-gamified-explorers'],
+  'deep-search':           ['03-teachers','04-culture-explorers','06-creatives','08-developers'],
+  'speed-reader':          ['06-creatives','07-passive-consumers'],
+  'speedreader-orp':       ['06-creatives','07-passive-consumers'],
+  'audio-player':          ['01-pre-readers','02-parents','07-passive-consumers','09-seniors'],
+  'text-to-speech':        ['07-passive-consumers','09-seniors'],
+  'read-along':            ['01-pre-readers','02-parents'],
+  'illustrations':         ['01-pre-readers','02-parents'],
+  'child-profile':         ['01-pre-readers','02-parents'],
+  'story-quiz':            ['01-pre-readers','03-teachers'],
+  'word-blacklist':        [],
+  'attribution':           ['03-teachers','04-culture-explorers','08-developers'],
+  'debug-badges':          ['08-developers'],
+  'error-page-simulator':  ['08-developers'],
 };
 
-// Resolve a relative .md link from a current doc path to an absolute repo path
-function resolvePath(currentPath, relativePath) {
+// ── Status / lifecycle badge styles ────────────────────────────────────────
+
+const STRATEGIC_STATUS = { mvp: 'MVP', 'near-term': 'Near-term', vision: 'Vision' };
+const STRATEGIC_COLORS = {
+  mvp:        { l: 'bg-emerald-100 text-emerald-800', d: 'bg-emerald-900/40 text-emerald-300' },
+  'near-term':{ l: 'bg-amber-100 text-amber-800',     d: 'bg-amber-900/40 text-amber-300' },
+  vision:     { l: 'bg-violet-100 text-violet-800',   d: 'bg-violet-900/40 text-violet-300' },
+};
+const LIFECYCLE_COLORS = {
+  STABLE:     { l: 'bg-blue-100 text-blue-800',      d: 'bg-blue-900/40 text-blue-300' },
+  EXPERIMENT: { l: 'bg-orange-100 text-orange-800',  d: 'bg-orange-900/40 text-orange-300' },
+  ROLLOUT:    { l: 'bg-teal-100 text-teal-800',      d: 'bg-teal-900/40 text-teal-300' },
+  DEPRECATE:  { l: 'bg-red-100 text-red-800',        d: 'bg-red-900/40 text-red-300' },
+};
+
+// ── Frontmatter parser ─────────────────────────────────────────────────────
+
+function parseFrontmatter(src) {
+  if (!src.startsWith('---\n')) return { meta: {}, body: src };
+  const end = src.indexOf('\n---', 4);
+  if (end === -1) return { meta: {}, body: src };
+  const yaml = src.slice(4, end);
+  const body = src.slice(end + 4).trimStart();
+  const meta = {};
+  const lines = yaml.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim() || line.startsWith('#')) { i++; continue; }
+    const m = line.match(/^([\w-]+):\s*(.*)$/);
+    if (m) {
+      const [, key, val] = m;
+      const trimmed = val.trim().replace(/^["']|["']$/g, '');
+      if (trimmed === '' || trimmed === 'null') {
+        const arr = [];
+        let j = i + 1;
+        while (j < lines.length && /^\s+-\s+/.test(lines[j])) {
+          arr.push(lines[j].replace(/^\s+-\s+"?|"?$/g, '').replace(/^["']|["']$/g, '').trim());
+          j++;
+        }
+        meta[key] = arr.length > 0 ? arr : null;
+        i = arr.length > 0 ? j : i + 1;
+      } else {
+        meta[key] = trimmed;
+        i++;
+      }
+    } else { i++; }
+  }
+  return { meta, body };
+}
+
+// ── Path resolver ──────────────────────────────────────────────────────────
+
+function resolvePath(currentPath, rel) {
+  if (rel.startsWith('http')) return null; // external
   const base = currentPath.split('/').slice(0, -1);
-  for (const part of relativePath.split('/')) {
+  for (const part of rel.split('/')) {
     if (part === '..') base.pop();
-    else base.push(part);
+    else if (part !== '.') base.push(part);
   }
   return base.join('/');
 }
 
-// ── Inline markdown parser ──────────────────────────────────────────────────
+// ── Inline markdown ────────────────────────────────────────────────────────
+
 function parseInline(text, onDocLink, dark) {
   const tokens = text.split(/(\*\*[^*]+\*\*|\*[^*]+\*|\[.+?\]\([^)]+\)|`[^`]+`)/g);
   return tokens.map((tok, i) => {
@@ -84,124 +211,67 @@ function parseInline(text, onDocLink, dark) {
     if (tok.startsWith('*') && tok.endsWith('*'))
       return <em key={i}>{tok.slice(1, -1)}</em>;
     if (tok.startsWith('`') && tok.endsWith('`'))
-      return (
-        <code key={i} className={`text-xs font-mono px-1 py-0.5 rounded ${dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-50 text-amber-800'}`}>
-          {tok.slice(1, -1)}
-        </code>
-      );
+      return <code key={i} className={`text-xs font-mono px-1 py-0.5 rounded ${dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-50 text-amber-800'}`}>{tok.slice(1, -1)}</code>;
     const lm = tok.match(/^\[(.+?)\]\((.+?)\)$/);
     if (lm) {
       const [, linkText, href] = lm;
       if (!href.startsWith('http') && href.endsWith('.md') && onDocLink) {
-        return (
-          <button
-            key={i}
-            onClick={() => onDocLink(href)}
-            className={`underline underline-offset-2 hover:no-underline transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}
-          >
-            {linkText}
-          </button>
-        );
+        return <button key={i} onClick={() => onDocLink(href)} className={`underline underline-offset-2 transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}>{linkText}</button>;
       }
-      return (
-        <a key={i} href={href} target="_blank" rel="noopener noreferrer"
-          className={`underline underline-offset-2 hover:no-underline transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}>
-          {linkText}
-        </a>
-      );
+      return <a key={i} href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}>{linkText}</a>;
     }
     return tok;
   });
 }
 
-// ── Block markdown renderer ─────────────────────────────────────────────────
-function MarkdownRenderer({ src, currentPath, onDocLink, dark }) {
-  const lines = src.split('\n');
-  const elements = [];
-  let i = 0;
+// ── Block markdown renderer ────────────────────────────────────────────────
 
-  const inline = (text) => parseInline(text, (rel) => onDocLink(resolvePath(currentPath, rel)), dark);
+function MarkdownBody({ src, currentPath, onDocLink, dark }) {
+  const lines = src.split('\n');
+  const out = [];
+  let i = 0;
+  const inline = (t) => parseInline(t, (rel) => onDocLink(resolvePath(currentPath, rel)), dark);
 
   while (i < lines.length) {
     const line = lines[i];
-
-    if (line.startsWith('# ')) {
-      elements.push(
-        <h1 key={i} className={`text-2xl font-serif font-bold mt-6 mb-3 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
-          {inline(line.slice(2))}
-        </h1>
-      );
-      i++; continue;
-    }
-    if (line.startsWith('## ')) {
-      elements.push(
-        <h2 key={i} className={`text-lg font-semibold mt-6 mb-2 ${dark ? 'text-amber-300' : 'text-amber-800'}`}>
-          {inline(line.slice(3))}
-        </h2>
-      );
-      i++; continue;
-    }
-    if (line.startsWith('### ')) {
-      elements.push(
-        <h3 key={i} className={`text-base font-semibold mt-4 mb-1.5 ${dark ? 'text-amber-400' : 'text-amber-700'}`}>
-          {inline(line.slice(4))}
-        </h3>
-      );
-      i++; continue;
-    }
+    if (line.startsWith('# '))  { out.push(<h1 key={i} className={`text-2xl font-serif font-bold mt-4 mb-3 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>{inline(line.slice(2))}</h1>); i++; continue; }
+    if (line.startsWith('## ')) { out.push(<h2 key={i} className={`text-base font-semibold mt-6 mb-2 ${dark ? 'text-amber-300' : 'text-amber-800'}`}>{inline(line.slice(3))}</h2>); i++; continue; }
+    if (line.startsWith('### ')){ out.push(<h3 key={i} className={`text-sm font-semibold mt-4 mb-1.5 ${dark ? 'text-amber-400' : 'text-amber-700'}`}>{inline(line.slice(4))}</h3>); i++; continue; }
 
     // Table
     if (line.startsWith('|')) {
       const rows = [];
-      while (i < lines.length && lines[i].startsWith('|')) {
-        rows.push(lines[i]);
-        i++;
-      }
-      const isSep = (row) => row.replace(/[|\s:-]/g, '') === '';
-      const cells = (row) => row.split('|').slice(1, -1).map((c) => c.trim());
-      const header = cells(rows[0]);
-      const body = rows.slice(2).filter((r) => !isSep(r));
-      elements.push(
-        <div key={`t-${i}`} className="overflow-x-auto my-4">
+      while (i < lines.length && lines[i].startsWith('|')) { rows.push(lines[i]); i++; }
+      const cells = (r) => r.split('|').slice(1, -1).map(c => c.trim());
+      const isSep = (r) => r.replace(/[|\s:-]/g, '') === '';
+      const hdr = cells(rows[0]);
+      const body = rows.slice(2).filter(r => !isSep(r));
+      out.push(
+        <div key={`t${i}`} className="overflow-x-auto my-4">
           <table className="w-full text-sm border-collapse">
-            <thead>
-              <tr className={`border-b ${dark ? 'border-amber-700/40' : 'border-amber-200'}`}>
-                {header.map((h, j) => (
-                  <th key={j} className={`text-left py-2 pr-4 font-medium ${dark ? 'text-amber-400' : 'text-amber-700'}`}>
-                    {inline(h)}
-                  </th>
-                ))}
+            <thead><tr className={`border-b ${dark ? 'border-amber-700/40' : 'border-amber-200'}`}>
+              {hdr.map((h, j) => <th key={j} className={`text-left py-2 pr-4 font-medium ${dark ? 'text-amber-400' : 'text-amber-700'}`}>{inline(h)}</th>)}
+            </tr></thead>
+            <tbody>{body.map((row, ri) => (
+              <tr key={ri} className={`border-b last:border-0 ${dark ? 'border-amber-800/30' : 'border-amber-100'}`}>
+                {cells(row).map((c, ci) => <td key={ci} className={`py-2 pr-4 align-top ${dark ? 'text-amber-200' : 'text-amber-900'}`}>{inline(c)}</td>)}
               </tr>
-            </thead>
-            <tbody>
-              {body.map((row, ri) => (
-                <tr key={ri} className={`border-b last:border-0 ${dark ? 'border-amber-800/30' : 'border-amber-100'}`}>
-                  {cells(row).map((c, ci) => (
-                    <td key={ci} className={`py-2 pr-4 align-top ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
-                      {inline(c)}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
+            ))}</tbody>
           </table>
         </div>
       );
       continue;
     }
 
-    // Bullet list
-    if (line.startsWith('- ') || line.startsWith('* ')) {
+    // List
+    if (/^[-*] /.test(line)) {
       const items = [];
-      while (i < lines.length && (lines[i].startsWith('- ') || lines[i].startsWith('* '))) {
-        items.push(lines[i].slice(2));
-        i++;
-      }
-      elements.push(
-        <ul key={`ul-${i}`} className="my-3 space-y-1 pl-4">
+      while (i < lines.length && /^[-*] /.test(lines[i])) { items.push(lines[i].slice(2)); i++; }
+      out.push(
+        <ul key={`ul${i}`} className="my-3 space-y-1 pl-4">
           {items.map((item, j) => (
             <li key={j} className={`text-sm flex gap-2 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
-              <span className={`mt-1.5 flex-shrink-0 w-1 h-1 rounded-full ${dark ? 'bg-amber-500' : 'bg-amber-600'}`} />
+              <span className={`mt-2 flex-shrink-0 w-1 h-1 rounded-full ${dark ? 'bg-amber-500' : 'bg-amber-600'}`} />
               <span>{inline(item)}</span>
             </li>
           ))}
@@ -210,220 +280,239 @@ function MarkdownRenderer({ src, currentPath, onDocLink, dark }) {
       continue;
     }
 
-    // Horizontal rule
-    if (line.trim() === '---') {
-      elements.push(<hr key={i} className={`my-6 ${dark ? 'border-amber-800/40' : 'border-amber-200'}`} />);
-      i++; continue;
-    }
-
-    // Empty line
+    if (line.trim() === '---') { out.push(<hr key={i} className={`my-6 ${dark ? 'border-amber-800/40' : 'border-amber-200'}`} />); i++; continue; }
     if (line.trim() === '') { i++; continue; }
-
-    // Paragraph
-    elements.push(
-      <p key={i} className={`text-sm leading-relaxed my-2 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
-        {inline(line)}
-      </p>
-    );
+    out.push(<p key={i} className={`text-sm leading-relaxed my-2 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>{inline(line)}</p>);
     i++;
   }
-
-  return <div>{elements}</div>;
+  return <div>{out}</div>;
 }
 
-// ── Doc detail view ──────────────────────────────────────────────────────────
-function DocDetail({ path, onBack, onNavTo, dark, tc }) {
-  const [content, setContent] = useState('');
+// ── Frontmatter metadata panel ─────────────────────────────────────────────
+
+function MetaPanel({ meta, onDocLink, dark }) {
+  if (!meta || Object.keys(meta).length === 0) return null;
+
+  const pill = (text, color) => (
+    <span className={`inline-block text-[11px] font-medium px-2 py-0.5 rounded-full ${color}`}>{text}</span>
+  );
+
+  const linkList = (ids, pathPrefix) => {
+    if (!ids || ids.length === 0) return <span className={`text-xs ${dark ? 'text-amber-700' : 'text-amber-400'}`}>—</span>;
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {ids.map((id) => {
+          const path = `${pathPrefix}/${id}.md`;
+          return (
+            <button key={id} onClick={() => onDocLink(path)}
+              className={`text-[11px] underline underline-offset-2 transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}>
+              {id}
+            </button>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const rows = [];
+
+  if (meta.type) {
+    const isApp = meta.type === 'app';
+    rows.push(['Type', pill(meta.type, isApp
+      ? (dark ? 'bg-blue-900/40 text-blue-300' : 'bg-blue-100 text-blue-800')
+      : (dark ? 'bg-violet-900/40 text-violet-300' : 'bg-violet-100 text-violet-800'))]);
+  }
+  if (meta.lifecycle) {
+    const lc = LIFECYCLE_COLORS[meta.lifecycle] ?? LIFECYCLE_COLORS.EXPERIMENT;
+    rows.push(['Lifecycle', pill(meta.lifecycle, dark ? lc.d : lc.l)]);
+  }
+  if (meta.status) {
+    const sc = STRATEGIC_COLORS[meta.status] ?? STRATEGIC_COLORS.vision;
+    rows.push(['Status', pill(STRATEGIC_STATUS[meta.status] ?? meta.status, dark ? sc.d : sc.l)]);
+  }
+  if (meta.flag_key) rows.push(['Flag key', <code key="fk" className={`text-xs font-mono px-1 py-0.5 rounded ${dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-50 text-amber-800'}`}>{meta.flag_key}</code>]);
+  if (meta.flag_default) rows.push(['Default', <code key="fd" className={`text-xs font-mono px-1 py-0.5 rounded ${dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-50 text-amber-800'}`}>{meta.flag_default}</code>]);
+  if (meta.category) rows.push(['Category', <span key="cat" className={`text-xs ${dark ? 'text-amber-300' : 'text-amber-800'}`}>{meta.category}</span>]);
+  if (meta.job) rows.push(['Job-to-be-done', <span key="job" className={`text-xs italic ${dark ? 'text-amber-300' : 'text-amber-800'}`}>"{meta.job}"</span>]);
+  if (meta.opportunity) rows.push(['Opportunity', <span key="opp" className={`text-xs ${dark ? 'text-amber-400' : 'text-amber-700'}`}>{meta.opportunity}</span>]);
+  if (meta.personas?.length > 0) rows.push(['Personas', linkList(meta.personas, 'docs/personas')]);
+  if (meta.strategic_features?.length > 0) rows.push(['Strategic features', linkList(meta.strategic_features, 'docs/features')]);
+  if (meta.app_features?.length > 0) rows.push(['App features', linkList(meta.app_features, 'docs/features')]);
+  if (meta.related_personas?.length > 0) rows.push(['Related personas', linkList(meta.related_personas, 'docs/personas')]);
+  if (meta.related_features?.length > 0) rows.push(['Related features', linkList(meta.related_features, 'docs/features')]);
+  if (meta.parent) rows.push(['Parent', linkList([meta.parent], 'docs/features')]);
+  if (meta.children?.length > 0) rows.push(['Children', linkList(meta.children, 'docs/features')]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className={`rounded-xl border divide-y mb-6 ${dark ? 'border-amber-700/30 divide-amber-800/30' : 'border-amber-200 divide-amber-100'}`}>
+      {rows.map(([label, value], idx) => (
+        <div key={idx} className={`flex gap-3 px-4 py-2.5 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+          <span className={`flex-shrink-0 w-36 text-xs pt-0.5 ${dark ? 'text-amber-600' : 'text-amber-500'}`}>{label}</span>
+          <div className="flex-1 min-w-0">{value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Doc detail view ────────────────────────────────────────────────────────
+
+function DocDetail({ path, onBack, onNavTo, dark }) {
+  const [rawContent, setRawContent] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    setLoading(true);
-    setError(null);
-    setContent('');
+    setLoading(true); setError(null); setRawContent('');
     fetch(RAW_BASE + path)
-      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.text(); })
-      .then((text) => { setContent(text); setLoading(false); })
-      .catch((err) => { setError(err.message); setLoading(false); });
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.text(); })
+      .then(text => { setRawContent(text); setLoading(false); })
+      .catch(err => { setError(err.message); setLoading(false); });
   }, [path]);
+
+  const { meta, body } = rawContent ? parseFrontmatter(rawContent) : { meta: {}, body: '' };
 
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-2xl mx-auto px-6 py-8">
-        {/* Header row */}
         <div className="flex items-center justify-between mb-6">
-          <button
-            onClick={onBack}
-            className={`flex items-center gap-2 text-sm font-medium transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}
-          >
-            <ChevronLeft size={16} />
-            Feature Matrix
+          <button onClick={onBack} className={`flex items-center gap-2 text-sm font-medium transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}>
+            <ChevronLeft size={16} />Feature Matrix
           </button>
-          <a
-            href={WEB_BASE + path}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`flex items-center gap-1.5 text-xs transition-colors ${dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-700'}`}
-          >
-            <ExternalLink size={12} />
-            View on GitHub
+          <a href={WEB_BASE + path} target="_blank" rel="noopener noreferrer"
+            className={`flex items-center gap-1.5 text-xs transition-colors ${dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-700'}`}>
+            <ExternalLink size={12} />View on GitHub
           </a>
         </div>
-
-        {loading && (
-          <div className={`text-sm ${dark ? 'text-amber-600' : 'text-amber-500'}`}>Loading…</div>
-        )}
-        {error && (
-          <div className={`text-sm ${dark ? 'text-red-400' : 'text-red-600'}`}>
-            Could not load <code className="font-mono">{path}</code>: {error}
-          </div>
-        )}
+        {loading && <p className={`text-sm ${dark ? 'text-amber-600' : 'text-amber-500'}`}>Loading…</p>}
+        {error && <p className={`text-sm ${dark ? 'text-red-400' : 'text-red-600'}`}>Could not load <code>{path}</code>: {error}</p>}
         {!loading && !error && (
-          <MarkdownRenderer
-            src={content}
-            currentPath={path}
-            onDocLink={onNavTo}
-            dark={dark}
-          />
+          <>
+            <MetaPanel meta={meta} onDocLink={onNavTo} dark={dark} />
+            <MarkdownBody src={body} currentPath={path} onDocLink={onNavTo} dark={dark} />
+          </>
         )}
       </div>
     </div>
   );
 }
 
-// ── Landing: feature matrix ─────────────────────────────────────────────────
-function MatrixLanding({ onOpenDoc, onBack, dark }) {
-  const matrixSets = Object.fromEntries(
-    Object.entries(MATRIX).map(([fid, pids]) => [fid, new Set(pids)])
+// ── Matrix row ─────────────────────────────────────────────────────────────
+
+function MatrixRow({ feature, personaSet, badge, onOpenDoc, dark, isLast }) {
+  return (
+    <tr className={`${!isLast ? `border-b ${dark ? 'border-amber-800/30' : 'border-amber-100'}` : ''} ${dark ? 'hover:bg-amber-900/10' : 'hover:bg-amber-50/50'}`}>
+      <td className="py-2 px-4 whitespace-nowrap">
+        <button onClick={() => onOpenDoc(feature.path)}
+          className={`text-xs font-medium hover:underline underline-offset-2 transition-colors ${dark ? 'text-amber-300 hover:text-amber-100' : 'text-amber-800 hover:text-amber-600'}`}>
+          {feature.label}
+        </button>
+      </td>
+      <td className="py-2 px-2 text-center">{badge}</td>
+      {PERSONAS.map(p => (
+        <td key={p.id} className="py-2 px-2 text-center">
+          {personaSet.has(p.id)
+            ? <button onClick={() => onOpenDoc(feature.path)} title={`${feature.label} × ${p.label}`}
+                className={`text-sm leading-none hover:scale-125 transition-transform ${dark ? 'text-amber-500' : 'text-amber-600'}`}>✓</button>
+            : <span className={`text-xs ${dark ? 'text-amber-900' : 'text-amber-200'}`}>·</span>}
+        </td>
+      ))}
+    </tr>
   );
+}
+
+// ── Landing: full matrix ───────────────────────────────────────────────────
+
+function MatrixLanding({ onOpenDoc, onBack, dark }) {
+  const appGroups = [...new Set(APP_FEATURES.map(f => f.group))];
+
+  const tableHeader = (
+    <thead>
+      <tr className={`border-b ${dark ? 'border-amber-700/30 bg-amber-900/20' : 'border-amber-200 bg-amber-50'}`}>
+        <th className={`text-left py-3 px-4 font-semibold text-xs ${dark ? 'text-amber-400' : 'text-amber-700'}`}>Feature</th>
+        <th className={`py-3 px-2 text-center text-xs font-medium ${dark ? 'text-amber-500' : 'text-amber-600'}`}>Status</th>
+        {PERSONAS.map(p => (
+          <th key={p.id} className="py-3 px-2 text-center">
+            <button onClick={() => onOpenDoc(p.path)} title={p.label} className="text-base hover:scale-110 transition-transform block mx-auto">{p.emoji}</button>
+          </th>
+        ))}
+      </tr>
+    </thead>
+  );
+
+  const sectionHeader = (label, colspan) => (
+    <tr key={`sec-${label}`}>
+      <td colSpan={colspan} className={`py-1.5 px-4 text-[10px] font-bold uppercase tracking-widest ${dark ? 'bg-amber-950/40 text-amber-600' : 'bg-amber-100/70 text-amber-500'}`}>
+        {label}
+      </td>
+    </tr>
+  );
+
+  const colSpan = 2 + PERSONAS.length;
 
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-5xl mx-auto px-6 py-8">
-        {/* Header */}
         <div className="flex items-center justify-between mb-8">
-          <button
-            onClick={onBack}
-            className={`flex items-center gap-2 text-sm font-medium transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}
-          >
-            <ChevronLeft size={16} />
-            Zurück
+          <button onClick={onBack} className={`flex items-center gap-2 text-sm font-medium transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}>
+            <ChevronLeft size={16} />Zurück
           </button>
-          <a
-            href={`${WEB_BASE}docs/personas.md`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`flex items-center gap-1.5 text-xs transition-colors ${dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-700'}`}
-          >
-            <ExternalLink size={12} />
-            View on GitHub
+          <a href={`${WEB_BASE}docs/personas.md`} target="_blank" rel="noopener noreferrer"
+            className={`flex items-center gap-1.5 text-xs transition-colors ${dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-700'}`}>
+            <ExternalLink size={12} />View on GitHub
           </a>
         </div>
 
-        <div className="mb-6">
-          <h1 className={`text-2xl font-serif font-bold ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
-            Product Vision
-          </h1>
-          <p className={`mt-1 text-sm ${dark ? 'text-amber-600' : 'text-amber-500'}`}>
-            10 personas · 16 features — click any name to read the full doc
-          </p>
+        <div className="mb-2">
+          <h1 className={`text-2xl font-serif font-bold ${dark ? 'text-amber-200' : 'text-amber-900'}`}>Product Vision</h1>
+          <p className={`mt-1 text-sm ${dark ? 'text-amber-600' : 'text-amber-500'}`}>10 personas · 16 strategic features · 30 app features — click any name to read the full doc</p>
         </div>
 
-        {/* Persona quick-links */}
-        <div className="flex flex-wrap gap-2 mb-8">
-          {PERSONAS.map((p) => (
-            <button
-              key={p.id}
-              onClick={() => onOpenDoc(p.path)}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-                dark
-                  ? 'bg-amber-800/30 text-amber-300 hover:bg-amber-700/40'
-                  : 'bg-amber-100 text-amber-800 hover:bg-amber-200'
-              }`}
-            >
+        {/* Persona pills */}
+        <div className="flex flex-wrap gap-2 my-6">
+          {PERSONAS.map(p => (
+            <button key={p.id} onClick={() => onOpenDoc(p.path)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${dark ? 'bg-amber-800/30 text-amber-300 hover:bg-amber-700/40' : 'bg-amber-100 text-amber-800 hover:bg-amber-200'}`}>
               {p.emoji} {p.label}
             </button>
           ))}
         </div>
 
-        {/* Feature matrix table */}
+        {/* Matrix table */}
         <div className={`rounded-2xl border overflow-hidden ${dark ? 'border-amber-700/30' : 'border-amber-200'}`}>
           <div className="overflow-x-auto">
             <table className="w-full text-xs border-collapse">
-              <thead>
-                <tr className={`border-b ${dark ? 'border-amber-700/30 bg-amber-900/20' : 'border-amber-200 bg-amber-50'}`}>
-                  <th className={`text-left py-3 px-4 font-semibold whitespace-nowrap ${dark ? 'text-amber-400' : 'text-amber-700'}`}>
-                    Feature
-                  </th>
-                  <th className={`py-3 px-2 text-center font-medium ${dark ? 'text-amber-500' : 'text-amber-600'}`}>
-                    Status
-                  </th>
-                  {PERSONAS.map((p) => (
-                    <th key={p.id} className="py-3 px-2 text-center">
-                      <button
-                        onClick={() => onOpenDoc(p.path)}
-                        title={p.label}
-                        className={`text-base hover:scale-110 transition-transform block mx-auto`}
-                      >
-                        {p.emoji}
-                      </button>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
+              {tableHeader}
               <tbody>
-                {FEATURES.map((f, fi) => {
-                  const personas = matrixSets[f.id] ?? new Set();
-                  const sc = STATUS_COLORS[f.status];
-                  return (
-                    <tr
-                      key={f.id}
-                      className={`border-b last:border-0 ${
-                        dark ? 'border-amber-800/30 hover:bg-amber-900/10' : 'border-amber-100 hover:bg-amber-50/50'
-                      }`}
-                    >
-                      <td className="py-2.5 px-4 whitespace-nowrap">
-                        <button
-                          onClick={() => onOpenDoc(f.path)}
-                          className={`text-xs font-medium hover:underline underline-offset-2 transition-colors ${dark ? 'text-amber-300 hover:text-amber-100' : 'text-amber-800 hover:text-amber-600'}`}
-                        >
-                          {f.label}
-                        </button>
-                      </td>
-                      <td className="py-2.5 px-2 text-center">
-                        <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${dark ? sc.dark : sc.light}`}>
-                          {STATUS_LABELS[f.status]}
-                        </span>
-                      </td>
-                      {PERSONAS.map((p) => (
-                        <td key={p.id} className="py-2.5 px-2 text-center">
-                          {personas.has(p.id) ? (
-                            <button
-                              onClick={() => onOpenDoc(f.path)}
-                              title={`${f.label} × ${p.label}`}
-                              className={`text-base hover:scale-110 transition-transform ${dark ? 'text-amber-500' : 'text-amber-600'}`}
-                            >
-                              ✓
-                            </button>
-                          ) : (
-                            <span className={`${dark ? 'text-amber-900' : 'text-amber-200'}`}>·</span>
-                          )}
-                        </td>
-                      ))}
-                    </tr>
-                  );
+                {/* Strategic features section */}
+                {sectionHeader('Strategic Features — Roadmap', colSpan)}
+                {STRATEGIC_FEATURES.map((f, idx) => {
+                  const sc = STRATEGIC_COLORS[f.status] ?? STRATEGIC_COLORS.vision;
+                  const badge = <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${dark ? sc.d : sc.l}`}>{STRATEGIC_STATUS[f.status]}</span>;
+                  return <MatrixRow key={f.id} feature={f} personaSet={new Set(STRATEGIC_MATRIX[f.id] ?? [])} badge={badge} onOpenDoc={onOpenDoc} dark={dark} isLast={false} />;
+                })}
+                {/* App features — one section per group */}
+                {appGroups.map(group => {
+                  const groupFeatures = APP_FEATURES.filter(f => f.group === group);
+                  return [
+                    sectionHeader(`App Features — ${group}`, colSpan),
+                    ...groupFeatures.map((f, idx) => {
+                      const lc = LIFECYCLE_COLORS[f.lifecycle] ?? LIFECYCLE_COLORS.EXPERIMENT;
+                      const badge = <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${dark ? lc.d : lc.l}`}>{f.lifecycle}</span>;
+                      return <MatrixRow key={f.id} feature={f} personaSet={new Set(APP_MATRIX[f.id] ?? [])} badge={badge} onOpenDoc={onOpenDoc} dark={dark} isLast={idx === groupFeatures.length - 1} />;
+                    }),
+                  ];
                 })}
               </tbody>
             </table>
           </div>
         </div>
 
-        {/* Strategy link */}
         <div className="mt-6">
-          <button
-            onClick={() => onOpenDoc('docs/product-strategy.md')}
-            className={`text-sm underline underline-offset-2 hover:no-underline transition-colors ${dark ? 'text-amber-500 hover:text-amber-300' : 'text-amber-600 hover:text-amber-800'}`}
-          >
+          <button onClick={() => onOpenDoc('docs/product-strategy.md')}
+            className={`text-sm underline underline-offset-2 hover:no-underline transition-colors ${dark ? 'text-amber-500 hover:text-amber-300' : 'text-amber-600 hover:text-amber-800'}`}>
             Product Strategy →
           </button>
         </div>
@@ -432,28 +521,14 @@ function MatrixLanding({ onOpenDoc, onBack, dark }) {
   );
 }
 
-// ── Root export ──────────────────────────────────────────────────────────────
+// ── Root export ────────────────────────────────────────────────────────────
+
 export default function PersonasDocsView({ onBack }) {
-  const { dark, tc } = useTheme();
+  const { dark } = useTheme();
   const [currentPath, setCurrentPath] = useState(null);
 
   if (currentPath) {
-    return (
-      <DocDetail
-        path={currentPath}
-        onBack={() => setCurrentPath(null)}
-        onNavTo={setCurrentPath}
-        dark={dark}
-        tc={tc}
-      />
-    );
+    return <DocDetail path={currentPath} onBack={() => setCurrentPath(null)} onNavTo={setCurrentPath} dark={dark} />;
   }
-
-  return (
-    <MatrixLanding
-      onOpenDoc={setCurrentPath}
-      onBack={onBack}
-      dark={dark}
-    />
-  );
+  return <MatrixLanding onOpenDoc={setCurrentPath} onBack={onBack} dark={dark} />;
 }

--- a/components/PersonasDocsView.jsx
+++ b/components/PersonasDocsView.jsx
@@ -1,0 +1,459 @@
+import { useState, useEffect } from 'react';
+import { ChevronLeft, ExternalLink, Users } from 'lucide-react';
+import { useTheme } from '../ui/ThemeContext';
+
+const BRANCH = 'claude/extended-user-personas-ZD1hR';
+const RAW_BASE = `https://raw.githubusercontent.com/tweakch/webreader/${BRANCH}/`;
+const WEB_BASE = `https://github.com/tweakch/webreader/blob/${BRANCH}/`;
+
+const PERSONAS = [
+  { id: '01-pre-readers',       label: 'Pre-Readers',        emoji: '👶', path: 'docs/personas/01-pre-readers.md' },
+  { id: '02-parents',           label: 'Parents',            emoji: '👨‍👩‍👧', path: 'docs/personas/02-parents.md' },
+  { id: '03-teachers',          label: 'Teachers',           emoji: '🧑‍🏫', path: 'docs/personas/03-teachers.md' },
+  { id: '04-culture-explorers', label: 'Culture Explorers',  emoji: '🌍', path: 'docs/personas/04-culture-explorers.md' },
+  { id: '05-therapeutic',       label: 'Therapeutic',        emoji: '🧘', path: 'docs/personas/05-therapeutic.md' },
+  { id: '06-creatives',         label: 'Creatives',          emoji: '🎭', path: 'docs/personas/06-creatives.md' },
+  { id: '07-passive-consumers', label: 'Passive Consumers',  emoji: '🎧', path: 'docs/personas/07-passive-consumers.md' },
+  { id: '08-developers',        label: 'Developers',         emoji: '🧑‍💻', path: 'docs/personas/08-developers.md' },
+  { id: '09-seniors',           label: 'Seniors',            emoji: '🧓', path: 'docs/personas/09-seniors.md' },
+  { id: '10-gamified-explorers',label: 'Gamified Explorers', emoji: '🧩', path: 'docs/personas/10-gamified-explorers.md' },
+];
+
+const FEATURES = [
+  { id: 'word-highlighting',    label: 'Word Highlighting',    status: 'vision',    path: 'docs/features/word-highlighting.md' },
+  { id: 'audio-narration',      label: 'Audio Narration',      status: 'near-term', path: 'docs/features/audio-narration.md' },
+  { id: 'bedtime-mode',         label: 'Bedtime Mode',         status: 'mvp',       path: 'docs/features/bedtime-mode.md' },
+  { id: 'age-filter',           label: 'Age Filter',           status: 'mvp',       path: 'docs/features/age-filter.md' },
+  { id: 'discussion-questions', label: 'Discussion Questions', status: 'near-term', path: 'docs/features/discussion-questions.md' },
+  { id: 'parallel-texts',       label: 'Parallel Texts',       status: 'near-term', path: 'docs/features/parallel-texts.md' },
+  { id: 'cultural-annotations', label: 'Cultural Annotations', status: 'near-term', path: 'docs/features/cultural-annotations.md' },
+  { id: 'symbol-analysis',      label: 'Symbol Analysis',      status: 'vision',    path: 'docs/features/symbol-analysis.md' },
+  { id: 'journaling-prompts',   label: 'Journaling Prompts',   status: 'near-term', path: 'docs/features/journaling-prompts.md' },
+  { id: 'mood-recommendations', label: 'Mood Recommendations', status: 'vision',    path: 'docs/features/mood-recommendations.md' },
+  { id: 'story-remix',          label: 'Story Remix',          status: 'vision',    path: 'docs/features/story-remix.md' },
+  { id: 'sleep-timer',          label: 'Sleep Timer',          status: 'mvp',       path: 'docs/features/sleep-timer.md' },
+  { id: 'story-api',            label: 'Story API',            status: 'vision',    path: 'docs/features/story-api.md' },
+  { id: 'story-map',            label: 'Story Map',            status: 'vision',    path: 'docs/features/story-map.md' },
+  { id: 'achievements',         label: 'Achievements',         status: 'near-term', path: 'docs/features/achievements.md' },
+  { id: 'choice-narratives',    label: 'Choice Narratives',    status: 'vision',    path: 'docs/features/choice-narratives.md' },
+];
+
+// persona id sets per feature
+const MATRIX = {
+  'word-highlighting':    ['01-pre-readers'],
+  'audio-narration':      ['01-pre-readers','02-parents','04-culture-explorers','07-passive-consumers','09-seniors'],
+  'bedtime-mode':         ['02-parents','07-passive-consumers'],
+  'age-filter':           ['01-pre-readers','02-parents'],
+  'discussion-questions': ['03-teachers','05-therapeutic'],
+  'parallel-texts':       ['03-teachers','04-culture-explorers'],
+  'cultural-annotations': ['03-teachers','04-culture-explorers'],
+  'symbol-analysis':      ['03-teachers','05-therapeutic','06-creatives'],
+  'journaling-prompts':   ['05-therapeutic'],
+  'mood-recommendations': ['05-therapeutic'],
+  'story-remix':          ['06-creatives','08-developers'],
+  'sleep-timer':          ['02-parents','07-passive-consumers','09-seniors'],
+  'story-api':            ['08-developers'],
+  'story-map':            ['04-culture-explorers','10-gamified-explorers'],
+  'achievements':         ['10-gamified-explorers'],
+  'choice-narratives':    ['01-pre-readers','06-creatives','10-gamified-explorers'],
+};
+
+const STATUS_LABELS = { mvp: 'MVP', 'near-term': 'Near-term', vision: 'Vision' };
+const STATUS_COLORS = {
+  mvp:        { light: 'bg-emerald-100 text-emerald-800', dark: 'bg-emerald-900/40 text-emerald-300' },
+  'near-term':{ light: 'bg-amber-100 text-amber-800',     dark: 'bg-amber-900/40 text-amber-300' },
+  vision:     { light: 'bg-violet-100 text-violet-800',   dark: 'bg-violet-900/40 text-violet-300' },
+};
+
+// Resolve a relative .md link from a current doc path to an absolute repo path
+function resolvePath(currentPath, relativePath) {
+  const base = currentPath.split('/').slice(0, -1);
+  for (const part of relativePath.split('/')) {
+    if (part === '..') base.pop();
+    else base.push(part);
+  }
+  return base.join('/');
+}
+
+// ── Inline markdown parser ──────────────────────────────────────────────────
+function parseInline(text, onDocLink, dark) {
+  const tokens = text.split(/(\*\*[^*]+\*\*|\*[^*]+\*|\[.+?\]\([^)]+\)|`[^`]+`)/g);
+  return tokens.map((tok, i) => {
+    if (tok.startsWith('**') && tok.endsWith('**'))
+      return <strong key={i}>{tok.slice(2, -2)}</strong>;
+    if (tok.startsWith('*') && tok.endsWith('*'))
+      return <em key={i}>{tok.slice(1, -1)}</em>;
+    if (tok.startsWith('`') && tok.endsWith('`'))
+      return (
+        <code key={i} className={`text-xs font-mono px-1 py-0.5 rounded ${dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-50 text-amber-800'}`}>
+          {tok.slice(1, -1)}
+        </code>
+      );
+    const lm = tok.match(/^\[(.+?)\]\((.+?)\)$/);
+    if (lm) {
+      const [, linkText, href] = lm;
+      if (!href.startsWith('http') && href.endsWith('.md') && onDocLink) {
+        return (
+          <button
+            key={i}
+            onClick={() => onDocLink(href)}
+            className={`underline underline-offset-2 hover:no-underline transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}
+          >
+            {linkText}
+          </button>
+        );
+      }
+      return (
+        <a key={i} href={href} target="_blank" rel="noopener noreferrer"
+          className={`underline underline-offset-2 hover:no-underline transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}>
+          {linkText}
+        </a>
+      );
+    }
+    return tok;
+  });
+}
+
+// ── Block markdown renderer ─────────────────────────────────────────────────
+function MarkdownRenderer({ src, currentPath, onDocLink, dark }) {
+  const lines = src.split('\n');
+  const elements = [];
+  let i = 0;
+
+  const inline = (text) => parseInline(text, (rel) => onDocLink(resolvePath(currentPath, rel)), dark);
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.startsWith('# ')) {
+      elements.push(
+        <h1 key={i} className={`text-2xl font-serif font-bold mt-6 mb-3 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+          {inline(line.slice(2))}
+        </h1>
+      );
+      i++; continue;
+    }
+    if (line.startsWith('## ')) {
+      elements.push(
+        <h2 key={i} className={`text-lg font-semibold mt-6 mb-2 ${dark ? 'text-amber-300' : 'text-amber-800'}`}>
+          {inline(line.slice(3))}
+        </h2>
+      );
+      i++; continue;
+    }
+    if (line.startsWith('### ')) {
+      elements.push(
+        <h3 key={i} className={`text-base font-semibold mt-4 mb-1.5 ${dark ? 'text-amber-400' : 'text-amber-700'}`}>
+          {inline(line.slice(4))}
+        </h3>
+      );
+      i++; continue;
+    }
+
+    // Table
+    if (line.startsWith('|')) {
+      const rows = [];
+      while (i < lines.length && lines[i].startsWith('|')) {
+        rows.push(lines[i]);
+        i++;
+      }
+      const isSep = (row) => row.replace(/[|\s:-]/g, '') === '';
+      const cells = (row) => row.split('|').slice(1, -1).map((c) => c.trim());
+      const header = cells(rows[0]);
+      const body = rows.slice(2).filter((r) => !isSep(r));
+      elements.push(
+        <div key={`t-${i}`} className="overflow-x-auto my-4">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className={`border-b ${dark ? 'border-amber-700/40' : 'border-amber-200'}`}>
+                {header.map((h, j) => (
+                  <th key={j} className={`text-left py-2 pr-4 font-medium ${dark ? 'text-amber-400' : 'text-amber-700'}`}>
+                    {inline(h)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {body.map((row, ri) => (
+                <tr key={ri} className={`border-b last:border-0 ${dark ? 'border-amber-800/30' : 'border-amber-100'}`}>
+                  {cells(row).map((c, ci) => (
+                    <td key={ci} className={`py-2 pr-4 align-top ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+                      {inline(c)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+      continue;
+    }
+
+    // Bullet list
+    if (line.startsWith('- ') || line.startsWith('* ')) {
+      const items = [];
+      while (i < lines.length && (lines[i].startsWith('- ') || lines[i].startsWith('* '))) {
+        items.push(lines[i].slice(2));
+        i++;
+      }
+      elements.push(
+        <ul key={`ul-${i}`} className="my-3 space-y-1 pl-4">
+          {items.map((item, j) => (
+            <li key={j} className={`text-sm flex gap-2 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+              <span className={`mt-1.5 flex-shrink-0 w-1 h-1 rounded-full ${dark ? 'bg-amber-500' : 'bg-amber-600'}`} />
+              <span>{inline(item)}</span>
+            </li>
+          ))}
+        </ul>
+      );
+      continue;
+    }
+
+    // Horizontal rule
+    if (line.trim() === '---') {
+      elements.push(<hr key={i} className={`my-6 ${dark ? 'border-amber-800/40' : 'border-amber-200'}`} />);
+      i++; continue;
+    }
+
+    // Empty line
+    if (line.trim() === '') { i++; continue; }
+
+    // Paragraph
+    elements.push(
+      <p key={i} className={`text-sm leading-relaxed my-2 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+        {inline(line)}
+      </p>
+    );
+    i++;
+  }
+
+  return <div>{elements}</div>;
+}
+
+// ── Doc detail view ──────────────────────────────────────────────────────────
+function DocDetail({ path, onBack, onNavTo, dark, tc }) {
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setContent('');
+    fetch(RAW_BASE + path)
+      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.text(); })
+      .then((text) => { setContent(text); setLoading(false); })
+      .catch((err) => { setError(err.message); setLoading(false); });
+  }, [path]);
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-2xl mx-auto px-6 py-8">
+        {/* Header row */}
+        <div className="flex items-center justify-between mb-6">
+          <button
+            onClick={onBack}
+            className={`flex items-center gap-2 text-sm font-medium transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}
+          >
+            <ChevronLeft size={16} />
+            Feature Matrix
+          </button>
+          <a
+            href={WEB_BASE + path}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`flex items-center gap-1.5 text-xs transition-colors ${dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-700'}`}
+          >
+            <ExternalLink size={12} />
+            View on GitHub
+          </a>
+        </div>
+
+        {loading && (
+          <div className={`text-sm ${dark ? 'text-amber-600' : 'text-amber-500'}`}>Loading…</div>
+        )}
+        {error && (
+          <div className={`text-sm ${dark ? 'text-red-400' : 'text-red-600'}`}>
+            Could not load <code className="font-mono">{path}</code>: {error}
+          </div>
+        )}
+        {!loading && !error && (
+          <MarkdownRenderer
+            src={content}
+            currentPath={path}
+            onDocLink={onNavTo}
+            dark={dark}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Landing: feature matrix ─────────────────────────────────────────────────
+function MatrixLanding({ onOpenDoc, onBack, dark }) {
+  const matrixSets = Object.fromEntries(
+    Object.entries(MATRIX).map(([fid, pids]) => [fid, new Set(pids)])
+  );
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-5xl mx-auto px-6 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <button
+            onClick={onBack}
+            className={`flex items-center gap-2 text-sm font-medium transition-colors ${dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'}`}
+          >
+            <ChevronLeft size={16} />
+            Zurück
+          </button>
+          <a
+            href={`${WEB_BASE}docs/personas.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`flex items-center gap-1.5 text-xs transition-colors ${dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-700'}`}
+          >
+            <ExternalLink size={12} />
+            View on GitHub
+          </a>
+        </div>
+
+        <div className="mb-6">
+          <h1 className={`text-2xl font-serif font-bold ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+            Product Vision
+          </h1>
+          <p className={`mt-1 text-sm ${dark ? 'text-amber-600' : 'text-amber-500'}`}>
+            10 personas · 16 features — click any name to read the full doc
+          </p>
+        </div>
+
+        {/* Persona quick-links */}
+        <div className="flex flex-wrap gap-2 mb-8">
+          {PERSONAS.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => onOpenDoc(p.path)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                dark
+                  ? 'bg-amber-800/30 text-amber-300 hover:bg-amber-700/40'
+                  : 'bg-amber-100 text-amber-800 hover:bg-amber-200'
+              }`}
+            >
+              {p.emoji} {p.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Feature matrix table */}
+        <div className={`rounded-2xl border overflow-hidden ${dark ? 'border-amber-700/30' : 'border-amber-200'}`}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs border-collapse">
+              <thead>
+                <tr className={`border-b ${dark ? 'border-amber-700/30 bg-amber-900/20' : 'border-amber-200 bg-amber-50'}`}>
+                  <th className={`text-left py-3 px-4 font-semibold whitespace-nowrap ${dark ? 'text-amber-400' : 'text-amber-700'}`}>
+                    Feature
+                  </th>
+                  <th className={`py-3 px-2 text-center font-medium ${dark ? 'text-amber-500' : 'text-amber-600'}`}>
+                    Status
+                  </th>
+                  {PERSONAS.map((p) => (
+                    <th key={p.id} className="py-3 px-2 text-center">
+                      <button
+                        onClick={() => onOpenDoc(p.path)}
+                        title={p.label}
+                        className={`text-base hover:scale-110 transition-transform block mx-auto`}
+                      >
+                        {p.emoji}
+                      </button>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {FEATURES.map((f, fi) => {
+                  const personas = matrixSets[f.id] ?? new Set();
+                  const sc = STATUS_COLORS[f.status];
+                  return (
+                    <tr
+                      key={f.id}
+                      className={`border-b last:border-0 ${
+                        dark ? 'border-amber-800/30 hover:bg-amber-900/10' : 'border-amber-100 hover:bg-amber-50/50'
+                      }`}
+                    >
+                      <td className="py-2.5 px-4 whitespace-nowrap">
+                        <button
+                          onClick={() => onOpenDoc(f.path)}
+                          className={`text-xs font-medium hover:underline underline-offset-2 transition-colors ${dark ? 'text-amber-300 hover:text-amber-100' : 'text-amber-800 hover:text-amber-600'}`}
+                        >
+                          {f.label}
+                        </button>
+                      </td>
+                      <td className="py-2.5 px-2 text-center">
+                        <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${dark ? sc.dark : sc.light}`}>
+                          {STATUS_LABELS[f.status]}
+                        </span>
+                      </td>
+                      {PERSONAS.map((p) => (
+                        <td key={p.id} className="py-2.5 px-2 text-center">
+                          {personas.has(p.id) ? (
+                            <button
+                              onClick={() => onOpenDoc(f.path)}
+                              title={`${f.label} × ${p.label}`}
+                              className={`text-base hover:scale-110 transition-transform ${dark ? 'text-amber-500' : 'text-amber-600'}`}
+                            >
+                              ✓
+                            </button>
+                          ) : (
+                            <span className={`${dark ? 'text-amber-900' : 'text-amber-200'}`}>·</span>
+                          )}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Strategy link */}
+        <div className="mt-6">
+          <button
+            onClick={() => onOpenDoc('docs/product-strategy.md')}
+            className={`text-sm underline underline-offset-2 hover:no-underline transition-colors ${dark ? 'text-amber-500 hover:text-amber-300' : 'text-amber-600 hover:text-amber-800'}`}
+          >
+            Product Strategy →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Root export ──────────────────────────────────────────────────────────────
+export default function PersonasDocsView({ onBack }) {
+  const { dark, tc } = useTheme();
+  const [currentPath, setCurrentPath] = useState(null);
+
+  if (currentPath) {
+    return (
+      <DocDetail
+        path={currentPath}
+        onBack={() => setCurrentPath(null)}
+        onNavTo={setCurrentPath}
+        dark={dark}
+        tc={tc}
+      />
+    );
+  }
+
+  return (
+    <MatrixLanding
+      onOpenDoc={setCurrentPath}
+      onBack={onBack}
+      dark={dark}
+    />
+  );
+}

--- a/components/ProfilePanel.jsx
+++ b/components/ProfilePanel.jsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, X, User, Shield, FlameKindling } from 'lucide-react';
+import { ChevronLeft, X, User, Shield, FlameKindling, Users } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
 import Toggle from '../ui/Toggle';
 import { ROLES, ROLE_LABELS } from '../hooks/useRole';
@@ -10,6 +10,7 @@ import { ROLES, ROLE_LABELS } from '../hooks/useRole';
 export default function ProfilePanel({
   onBack,
   onOpenDocs,
+  onOpenPersonasDocs,
   favorites,
   completedStories,
   totalStories,
@@ -124,6 +125,26 @@ export default function ProfilePanel({
             </div>
           ))}
         </div>
+
+        {/* Product Vision link */}
+        {onOpenPersonasDocs && (
+          <button
+            onClick={onOpenPersonasDocs}
+            className={`mt-6 w-full flex items-center justify-between px-5 py-3.5 rounded-2xl border transition-colors ${
+              dark
+                ? 'border-amber-700/30 text-amber-300 hover:bg-amber-900/20'
+                : 'border-amber-200 text-amber-800 hover:bg-amber-50'
+            }`}
+          >
+            <div className="flex items-center gap-3">
+              <Users size={16} className={dark ? 'text-amber-500' : 'text-amber-600'} />
+              <span className="text-sm font-medium">Product Vision</span>
+            </div>
+            <span className={`text-xs ${dark ? 'text-amber-600' : 'text-amber-500'}`}>
+              Personas & Feature Map →
+            </span>
+          </button>
+        )}
 
         {/* Word Blacklist */}
         {showWordBlacklist && (

--- a/docs/features/achievements.md
+++ b/docs/features/achievements.md
@@ -1,0 +1,28 @@
+# Achievements
+
+**Status:** Near-term  
+**Personas:** [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+Badges and milestones awarded for reading activity, breadth, and discovery.
+
+## Achievement Categories
+
+| Category | Examples |
+|---|---|
+| Streaks | 3-day · 7-day · 30-day reading streak |
+| Breadth | Read stories from 5 / 10 / all sources |
+| Depth | Complete all stories from a single source |
+| Discovery | First story from a new canton / country / motif |
+| Completion | Finish 10 · 50 · 100 stories |
+
+## Implementation Notes
+
+- Achievement definitions are a static JSON manifest checked against `completedStories` and `readingHistory`
+- The existing `completedStories` (a `Set` in `usePersistence`) is the primary data source
+- Achievements rendered in a dedicated section of `ProfilePanel`
+- Optional: unlock badge → share card generation
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Story Map](story-map.md)

--- a/docs/features/achievements.md
+++ b/docs/features/achievements.md
@@ -1,6 +1,23 @@
+---
+id: "achievements"
+name: "Achievements"
+type: "strategic"
+status: "near-term"
+category: "gamification"
+personas:
+  - "10-gamified-explorers"
+related_features:
+  - "story-map"
+  - "favorites"
+  - "reading-duration"
+  - "word-count"
+parent: "story-map"
+children: []
+---
+
 # Achievements
 
-**Status:** Near-term  
+**Status:** Near-term
 **Personas:** [Gamified Explorers](../personas/10-gamified-explorers.md)
 
 Badges and milestones awarded for reading activity, breadth, and discovery.
@@ -25,4 +42,6 @@ Badges and milestones awarded for reading activity, breadth, and discovery.
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
-- [Story Map](story-map.md)
+- [Story Map](story-map.md) — parent feature
+- [Favorites](favorites.md) — existing app flag
+- [Reading Duration](reading-duration.md) — existing app flag

--- a/docs/features/adaption-switcher.md
+++ b/docs/features/adaption-switcher.md
@@ -1,0 +1,40 @@
+---
+id: "adaption-switcher"
+name: "Adaption Switcher"
+type: "app"
+flag_key: "adaption-switcher"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "typography"
+personas:
+  - "03-teachers"
+  - "04-culture-explorers"
+  - "06-creatives"
+  - "10-gamified-explorers"
+related_features:
+  - "parallel-texts"
+  - "choice-narratives"
+  - "story-remix"
+parent: null
+children: []
+---
+
+# Adaption Switcher
+
+**Flag:** `adaption-switcher` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Teachers](../personas/03-teachers.md) · [Culture Explorers](../personas/04-culture-explorers.md) · [Creatives](../personas/06-creatives.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+A dropdown in the reader that switches between the original story and alternative adaptations or variants.
+
+## Behavior
+
+- Variants tracked in `adaptionsByParent` — stories with a shared parent ID
+- `VariantSwitcher` component renders a dropdown above the reader area
+- Switching variant reloads the story content without leaving the reader
+- Foundation for [Parallel Texts](parallel-texts.md) (show two variants side-by-side)
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Parallel Texts](parallel-texts.md) — strategic extension
+- [Story Remix](story-remix.md) — AI-generated variants surface here

--- a/docs/features/age-filter.md
+++ b/docs/features/age-filter.md
@@ -1,6 +1,23 @@
+---
+id: "age-filter"
+name: "Age Filter"
+type: "strategic"
+status: "mvp"
+category: "accessibility"
+personas:
+  - "01-pre-readers"
+  - "02-parents"
+related_features:
+  - "bedtime-mode"
+  - "child-profile"
+  - "adaption-switcher"
+parent: null
+children: []
+---
+
 # Age Filter
 
-**Status:** MVP  
+**Status:** MVP
 **Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md)
 
 Surface only age-appropriate stories by filtering on a configured child age range.
@@ -16,3 +33,5 @@ Surface only age-appropriate stories by filtering on a configured child age rang
 
 - [Back to Feature Matrix](../personas.md)
 - [Bedtime Mode](bedtime-mode.md)
+- [Child Profile](child-profile.md) — existing app flag
+- [Adaption Switcher](adaption-switcher.md) — existing app flag

--- a/docs/features/age-filter.md
+++ b/docs/features/age-filter.md
@@ -1,0 +1,18 @@
+# Age Filter
+
+**Status:** MVP  
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md)
+
+Surface only age-appropriate stories by filtering on a configured child age range.
+
+## Implementation Notes
+
+- Add `ageMin` / `ageMax` YAML frontmatter fields to `content.md` during crawl
+- Store the configured age range in `localStorage` (same pattern as existing user preferences)
+- Filter applied in `getStoryIndex` or as a derived list in `grimm-reader.jsx`
+- Adaption switcher already shows variants — age-rated variants can be a first-class option
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Bedtime Mode](bedtime-mode.md)

--- a/docs/features/attribution.md
+++ b/docs/features/attribution.md
@@ -1,0 +1,37 @@
+---
+id: "attribution"
+name: "Attribution"
+type: "app"
+flag_key: "attribution"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "ui"
+personas:
+  - "03-teachers"
+  - "04-culture-explorers"
+  - "08-developers"
+related_features:
+  - "cultural-annotations"
+  - "story-api"
+parent: null
+children: []
+---
+
+# Attribution
+
+**Flag:** `attribution` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Teachers](../personas/03-teachers.md) · [Culture Explorers](../personas/04-culture-explorers.md) · [Developers](../personas/08-developers.md)
+
+Displays the author and source on the last page of each story.
+
+## Behavior
+
+- Shown on the final page of the reader via `EndOfStoryButtons` component
+- Attribution text sourced from story frontmatter (`author`, `source` fields)
+- Critical for academic and educational use cases
+- Metadata exposed in the [Story API](story-api.md)
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Cultural Annotations](cultural-annotations.md) — contextual companion

--- a/docs/features/audio-narration.md
+++ b/docs/features/audio-narration.md
@@ -1,6 +1,30 @@
+---
+id: "audio-narration"
+name: "Audio Narration"
+type: "strategic"
+status: "near-term"
+category: "audio"
+personas:
+  - "01-pre-readers"
+  - "02-parents"
+  - "04-culture-explorers"
+  - "07-passive-consumers"
+  - "09-seniors"
+related_features:
+  - "word-highlighting"
+  - "sleep-timer"
+  - "audio-player"
+  - "text-to-speech"
+  - "read-along"
+parent: null
+children:
+  - "word-highlighting"
+  - "sleep-timer"
+---
+
 # Audio Narration
 
-**Status:** Near-term  
+**Status:** Near-term
 **Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md) · [Culture Explorers](../personas/04-culture-explorers.md) · [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md)
 
 Full-story audio narration with optional AI character voices.
@@ -25,3 +49,5 @@ Full-story audio narration with optional AI character voices.
 - [Back to Feature Matrix](../personas.md)
 - [Word Highlighting](word-highlighting.md) — pairs with narration
 - [Sleep Timer](sleep-timer.md) — companion feature
+- [Audio Player](audio-player.md) — existing app flag
+- [Text-to-Speech](text-to-speech.md) — existing app flag

--- a/docs/features/audio-narration.md
+++ b/docs/features/audio-narration.md
@@ -1,0 +1,27 @@
+# Audio Narration
+
+**Status:** Near-term  
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md) · [Culture Explorers](../personas/04-culture-explorers.md) · [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md)
+
+Full-story audio narration with optional AI character voices.
+
+## Variants
+
+| Variant | Description |
+|---|---|
+| Single narrator | One TTS voice reads the full story |
+| Character voices | Distinct AI voices assigned per story character |
+| Original-language | Native-language audio for cultural authenticity |
+| Slow-paced | Deliberate narration with natural pauses (Seniors) |
+
+## Implementation Notes
+
+- The `audio-player` feature flag and `AudioPlayer` UI component already exist in the codebase
+- Story audio files are tracked in `storyAudioFiles` state (loaded via `loadStoryAudioMap`)
+- TTS generation can be pre-rendered at crawl time and stored alongside `content.md` in `stories/{source}/{slug}/`
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Word Highlighting](word-highlighting.md) — pairs with narration
+- [Sleep Timer](sleep-timer.md) — companion feature

--- a/docs/features/audio-player.md
+++ b/docs/features/audio-player.md
@@ -1,0 +1,42 @@
+---
+id: "audio-player"
+name: "Audio Player"
+type: "app"
+flag_key: "audio-player"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "advanced-reading"
+personas:
+  - "01-pre-readers"
+  - "02-parents"
+  - "07-passive-consumers"
+  - "09-seniors"
+related_features:
+  - "audio-narration"
+  - "sleep-timer"
+  - "text-to-speech"
+  - "word-highlighting"
+parent: null
+children: []
+---
+
+# Audio Player
+
+**Flag:** `audio-player` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md) · [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md)
+
+Displays an embedded audio player when a recorded audio file exists for the current story.
+
+## Behavior
+
+- `AudioPlayer` component rendered in the reader area when `storyAudioFiles` has an entry for the current story
+- Audio files tracked via `loadStoryAudioMap` at app load
+- Supports play/pause, seek, and volume
+- Foundation for [Audio Narration](audio-narration.md) strategic feature
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Audio Narration](audio-narration.md) — strategic roadmap feature
+- [Text-to-Speech](text-to-speech.md) — TTS narration complement
+- [Sleep Timer](sleep-timer.md) — companion feature

--- a/docs/features/bedtime-mode.md
+++ b/docs/features/bedtime-mode.md
@@ -1,0 +1,25 @@
+# Bedtime Mode
+
+**Status:** MVP  
+**Personas:** [Parents](../personas/02-parents.md) · [Passive Consumers](../personas/07-passive-consumers.md)
+
+One-tap ritual mode: curated story queue, fixed session length, screen-dimming, and auto-stop.
+
+## User Flow
+
+1. Tap "Bedtime" → choose 5 / 10 / 15 min
+2. App selects an age-appropriate story and begins reading or narration
+3. Screen dims after 30 s of inactivity
+4. At session end (or [Sleep Timer](sleep-timer.md) expiry), audio fades out and app locks
+
+## Implementation Notes
+
+- Session length maps to approximate word count using the existing `readingDuration` calculation
+- Story selection draws from the filtered library (respects [Age Filter](age-filter.md) if enabled)
+- Screen dimming: CSS `filter: brightness()` transition on the reader area
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Sleep Timer](sleep-timer.md)
+- [Age Filter](age-filter.md)

--- a/docs/features/bedtime-mode.md
+++ b/docs/features/bedtime-mode.md
@@ -1,6 +1,25 @@
+---
+id: "bedtime-mode"
+name: "Bedtime Mode"
+type: "strategic"
+status: "mvp"
+category: "ritual"
+personas:
+  - "02-parents"
+  - "07-passive-consumers"
+related_features:
+  - "sleep-timer"
+  - "age-filter"
+  - "audio-narration"
+  - "reading-duration"
+parent: null
+children:
+  - "sleep-timer"
+---
+
 # Bedtime Mode
 
-**Status:** MVP  
+**Status:** MVP
 **Personas:** [Parents](../personas/02-parents.md) · [Passive Consumers](../personas/07-passive-consumers.md)
 
 One-tap ritual mode: curated story queue, fixed session length, screen-dimming, and auto-stop.
@@ -23,3 +42,4 @@ One-tap ritual mode: curated story queue, fixed session length, screen-dimming, 
 - [Back to Feature Matrix](../personas.md)
 - [Sleep Timer](sleep-timer.md)
 - [Age Filter](age-filter.md)
+- [Reading Duration](reading-duration.md) — existing app flag

--- a/docs/features/big-fonts.md
+++ b/docs/features/big-fonts.md
@@ -1,0 +1,40 @@
+---
+id: "big-fonts"
+name: "Big Fonts"
+type: "app"
+flag_key: "big-fonts"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "appearance"
+personas:
+  - "09-seniors"
+  - "01-pre-readers"
+  - "02-parents"
+related_features:
+  - "font-size-controls"
+  - "high-contrast-theme"
+  - "typography-panel"
+parent: null
+children: []
+---
+
+# Big Fonts
+
+**Flag:** `big-fonts` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Variants:** `off` · `big` · `bigger` · `biggest`
+**Personas:** [Seniors](../personas/09-seniors.md) · [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md)
+
+Sets a larger base font size globally, making all text easier to read without per-story adjustment.
+
+## Behavior
+
+- `bigFontsVariant` from `useFeatureFlags` drives a global font size multiplier
+- `big`: 1.15× · `bigger`: 1.3× · `biggest`: 1.5×
+- Affects `maxFontSize` ceiling in `useTypography`, keeping the per-story controls in range
+- Useful for shared reading (parent + child) and users with low vision
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Font Size Controls](font-size-controls.md) — per-story size adjustment
+- [High Contrast Theme](high-contrast-theme.md) — accessibility companion

--- a/docs/features/child-profile.md
+++ b/docs/features/child-profile.md
@@ -1,0 +1,41 @@
+---
+id: "child-profile"
+name: "Child Profile"
+type: "app"
+flag_key: "child-profile"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "gen-alpha"
+personas:
+  - "01-pre-readers"
+  - "02-parents"
+related_features:
+  - "age-filter"
+  - "simplified-ui"
+  - "illustrations"
+  - "read-along"
+  - "big-fonts"
+parent: null
+children: []
+---
+
+# Child Profile
+
+**Flag:** `child-profile` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md)
+
+A dedicated reading profile for children with a simplified interface, age-appropriate defaults, and safe content settings.
+
+## Behavior
+
+- Activating child profile enables: big fonts, simplified UI, illustrations, age filter, read-along
+- Advanced settings (feature toggles, word blacklist, profile panel) are hidden
+- Parents switch into child mode by tapping a dedicated button; a PIN or gesture exits it
+- App icon can optionally change to a child-friendly variant
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Age Filter](age-filter.md) — content safety
+- [Simplified UI](simplified-ui.md) — UI simplification
+- [Read-Along](read-along.md) — reading support

--- a/docs/features/choice-narratives.md
+++ b/docs/features/choice-narratives.md
@@ -1,6 +1,24 @@
+---
+id: "choice-narratives"
+name: "Choice Narratives"
+type: "strategic"
+status: "vision"
+category: "interactive"
+personas:
+  - "01-pre-readers"
+  - "06-creatives"
+  - "10-gamified-explorers"
+related_features:
+  - "story-remix"
+  - "adaption-switcher"
+  - "achievements"
+parent: null
+children: []
+---
+
 # Choice Narratives
 
-**Status:** Vision  
+**Status:** Vision
 **Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Creatives](../personas/06-creatives.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
 
 Branching story experiences where reader decisions shape the narrative path.
@@ -24,3 +42,4 @@ Stories are authored as a decision graph:
 
 - [Back to Feature Matrix](../personas.md)
 - [Story Remix](story-remix.md) — AI can generate branch options from a linear story
+- [Adaption Switcher](adaption-switcher.md) — existing app flag (variant infrastructure)

--- a/docs/features/choice-narratives.md
+++ b/docs/features/choice-narratives.md
@@ -1,0 +1,26 @@
+# Choice Narratives
+
+**Status:** Vision  
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Creatives](../personas/06-creatives.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+Branching story experiences where reader decisions shape the narrative path.
+
+## Story Format
+
+Stories are authored as a decision graph:
+- Each node is a story segment (Markdown content block)
+- Each segment ends with 2–3 choices
+- Choices link to child nodes
+- Terminal nodes are story endings (multiple possible outcomes)
+
+## Implementation Notes
+
+- Story format extension: `content.branches.json` alongside `content.md`, describing the graph
+- The reader displays choice buttons at page-turn points instead of the normal next-page control
+- State: `currentNodeId` replaces `currentPage` when branch mode is active
+- `buildPages` runs on the current node's content only — same algorithm, smaller input
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Story Remix](story-remix.md) — AI can generate branch options from a linear story

--- a/docs/features/cultural-annotations.md
+++ b/docs/features/cultural-annotations.md
@@ -1,0 +1,26 @@
+# Cultural Annotations
+
+**Status:** Near-term  
+**Personas:** [Teachers](../personas/03-teachers.md) · [Culture Explorers](../personas/04-culture-explorers.md)
+
+Inline contextual notes about idioms, customs, historical context, and regional significance.
+
+## Annotation Types
+
+| Type | Example |
+|---|---|
+| Linguistic | "Rumpelstiltskin: the name derives from a type of goblin in German folklore" |
+| Historical | "Spinning wheels were symbols of female labour and fate in 16th-century Germany" |
+| Regional | "This Swiss variant reflects Appenzell independence traditions" |
+| Comparative | "In the French version (Tom Thumb), the woodcutter is a charcoal burner" |
+
+## Implementation Notes
+
+- Annotations stored as `annotations.json` in the story directory, keyed by word offset or phrase
+- Rendered as tooltip/popover on tap/hover over annotated spans
+- Generated at crawl time using a structured Claude API prompt over the story text
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Parallel Texts](parallel-texts.md)

--- a/docs/features/cultural-annotations.md
+++ b/docs/features/cultural-annotations.md
@@ -1,6 +1,23 @@
+---
+id: "cultural-annotations"
+name: "Cultural Annotations"
+type: "strategic"
+status: "near-term"
+category: "culture"
+personas:
+  - "03-teachers"
+  - "04-culture-explorers"
+related_features:
+  - "parallel-texts"
+  - "attribution"
+  - "symbol-analysis"
+parent: null
+children: []
+---
+
 # Cultural Annotations
 
-**Status:** Near-term  
+**Status:** Near-term
 **Personas:** [Teachers](../personas/03-teachers.md) · [Culture Explorers](../personas/04-culture-explorers.md)
 
 Inline contextual notes about idioms, customs, historical context, and regional significance.
@@ -24,3 +41,4 @@ Inline contextual notes about idioms, customs, historical context, and regional 
 
 - [Back to Feature Matrix](../personas.md)
 - [Parallel Texts](parallel-texts.md)
+- [Attribution](attribution.md) — existing app flag

--- a/docs/features/debug-badges.md
+++ b/docs/features/debug-badges.md
@@ -1,0 +1,34 @@
+---
+id: "debug-badges"
+name: "Debug Badges"
+type: "app"
+flag_key: "debug-badges"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "debug"
+personas:
+  - "08-developers"
+related_features:
+  - "error-page-simulator"
+parent: null
+children: []
+---
+
+# Debug Badges
+
+**Flag:** `debug-badges` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Developers](../personas/08-developers.md)
+
+Overlays each UI element with a badge showing its `data-testid` attribute value.
+
+## Behavior
+
+- `DebugOverlay` component wraps the app when enabled
+- Every element with a `data-testid` gets a small visible label
+- Helps testers identify the correct selector without inspecting the DOM
+- Useful during Playwright test authoring
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Error Page Simulator](error-page-simulator.md) — debug companion

--- a/docs/features/deep-search.md
+++ b/docs/features/deep-search.md
@@ -1,0 +1,40 @@
+---
+id: "deep-search"
+name: "Deep Search"
+type: "app"
+flag_key: "deep-search"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "search"
+personas:
+  - "03-teachers"
+  - "04-culture-explorers"
+  - "06-creatives"
+  - "08-developers"
+related_features:
+  - "story-directories"
+  - "story-api"
+  - "story-map"
+parent: null
+children: []
+---
+
+# Deep Search
+
+**Flag:** `deep-search` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Teachers](../personas/03-teachers.md) · [Culture Explorers](../personas/04-culture-explorers.md) · [Creatives](../personas/06-creatives.md) · [Developers](../personas/08-developers.md)
+
+Extends search from story titles to the full text of every story in the library.
+
+## Behavior
+
+- Sidebar search input runs against story body content, not just metadata
+- Slower on large libraries — progressive indexing recommended
+- Foundation for [Story API](story-api.md) search endpoint
+- Enables motif hunting and cross-story research for Creatives and Teachers
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Story Directories](story-directories.md) — navigation companion
+- [Story API](story-api.md) — strategic extension

--- a/docs/features/discussion-questions.md
+++ b/docs/features/discussion-questions.md
@@ -1,0 +1,27 @@
+# Discussion Questions
+
+**Status:** Near-term  
+**Personas:** [Teachers](../personas/03-teachers.md) · [Therapeutic](../personas/05-therapeutic.md)
+
+AI-generated Socratic discussion prompts and guided inquiry questions per story.
+
+## Question Types
+
+| Type | Example |
+|---|---|
+| Comprehension | "Why did the miller's daughter agree to spin gold?" |
+| Interpretation | "What does the spinning wheel represent in this story?" |
+| Personal | "Have you ever felt pressure to do something impossible?" |
+| Cross-cultural | "How does this version differ from the French variant?" |
+
+## Implementation Notes
+
+- Generated at crawl time and stored as `questions.json` in `stories/{source}/{slug}/`
+- Or generated on-demand via a Claude API call with the story text as context
+- Display as a collapsible panel below the story in `ReaderView`
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Symbol Analysis](symbol-analysis.md)
+- [Journaling Prompts](journaling-prompts.md)

--- a/docs/features/discussion-questions.md
+++ b/docs/features/discussion-questions.md
@@ -1,6 +1,24 @@
+---
+id: "discussion-questions"
+name: "Discussion Questions"
+type: "strategic"
+status: "near-term"
+category: "education"
+personas:
+  - "03-teachers"
+  - "05-therapeutic"
+related_features:
+  - "symbol-analysis"
+  - "journaling-prompts"
+  - "story-quiz"
+parent: null
+children:
+  - "journaling-prompts"
+---
+
 # Discussion Questions
 
-**Status:** Near-term  
+**Status:** Near-term
 **Personas:** [Teachers](../personas/03-teachers.md) · [Therapeutic](../personas/05-therapeutic.md)
 
 AI-generated Socratic discussion prompts and guided inquiry questions per story.
@@ -25,3 +43,4 @@ AI-generated Socratic discussion prompts and guided inquiry questions per story.
 - [Back to Feature Matrix](../personas.md)
 - [Symbol Analysis](symbol-analysis.md)
 - [Journaling Prompts](journaling-prompts.md)
+- [Story Quiz](story-quiz.md) — existing app flag (simpler variant)

--- a/docs/features/eink-flash.md
+++ b/docs/features/eink-flash.md
@@ -1,0 +1,34 @@
+---
+id: "eink-flash"
+name: "E-Ink Flash"
+type: "app"
+flag_key: "eink-flash"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "reader-ui"
+personas:
+  - "09-seniors"
+related_features:
+  - "tap-zones"
+parent: null
+children: []
+---
+
+# E-Ink Flash
+
+**Flag:** `eink-flash` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Seniors](../personas/09-seniors.md)
+
+A brief full-screen flash on page turn, replicating the refresh effect of e-ink displays.
+
+## Behavior
+
+- `EInkFlashOverlay` component renders a white flash overlay on page navigation
+- Flash duration: ~150 ms, CSS opacity transition
+- Provides tactile feedback rhythm familiar to e-reader users (Kindle, Kobo)
+- Can be disabled for users who find it distracting
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Tap Zones](tap-zones.md) — page-turn trigger

--- a/docs/features/error-page-simulator.md
+++ b/docs/features/error-page-simulator.md
@@ -1,0 +1,34 @@
+---
+id: "error-page-simulator"
+name: "Error Page Simulator"
+type: "app"
+flag_key: "error-page-simulator"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "debug"
+personas:
+  - "08-developers"
+related_features:
+  - "debug-badges"
+parent: null
+children: []
+---
+
+# Error Page Simulator
+
+**Flag:** `error-page-simulator` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Developers](../personas/08-developers.md)
+
+Shows buttons in the Profile Panel to intentionally trigger 404 and 500 error pages.
+
+## Behavior
+
+- Adds an "Error Simulator" section in `ProfilePanel` when active
+- **404**: navigates to a non-existent URL (`/does-not-exist`)
+- **500**: throws an exception that triggers the `ErrorBoundary`
+- Used to verify that error pages render correctly in testing and CI
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Debug Badges](debug-badges.md) — debug companion

--- a/docs/features/favorites-only-toggle.md
+++ b/docs/features/favorites-only-toggle.md
@@ -1,0 +1,35 @@
+---
+id: "favorites-only-toggle"
+name: "Favorites-Only Toggle"
+type: "app"
+flag_key: "favorites-only-toggle"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "reader-core"
+personas:
+  - "07-passive-consumers"
+  - "09-seniors"
+  - "10-gamified-explorers"
+related_features:
+  - "favorites"
+parent: "favorites"
+children: []
+---
+
+# Favorites-Only Toggle
+
+**Flag:** `favorites-only-toggle` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+A toggle in the sidebar that filters the story list to saved favorites only.
+
+## Behavior
+
+- Appears as a filter icon or toggle in the sidebar header
+- When active, the sidebar story list shows only stories in the favorites set
+- Requires [Favorites](favorites.md) to be enabled
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Favorites](favorites.md) — parent feature

--- a/docs/features/favorites.md
+++ b/docs/features/favorites.md
@@ -1,0 +1,40 @@
+---
+id: "favorites"
+name: "Favorites"
+type: "app"
+flag_key: "favorites"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "reader-core"
+personas:
+  - "07-passive-consumers"
+  - "09-seniors"
+  - "10-gamified-explorers"
+  - "05-therapeutic"
+related_features:
+  - "favorites-only-toggle"
+  - "achievements"
+  - "mood-recommendations"
+parent: null
+children:
+  - "favorites-only-toggle"
+---
+
+# Favorites
+
+**Flag:** `favorites` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md) · [Gamified Explorers](../personas/10-gamified-explorers.md) · [Therapeutic](../personas/05-therapeutic.md)
+
+Save stories with a heart icon and access them as a personal collection.
+
+## Behavior
+
+- Heart button appears in the story list and in the reader toolbar
+- Favorites persisted to `localStorage` via `usePersistence`
+- Combined with [Favorites-Only Toggle](favorites-only-toggle.md) to filter the sidebar to saved stories
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Favorites-Only Toggle](favorites-only-toggle.md) — child feature
+- [Achievements](achievements.md) — collecting favorites counts toward milestones

--- a/docs/features/font-size-controls.md
+++ b/docs/features/font-size-controls.md
@@ -1,0 +1,39 @@
+---
+id: "font-size-controls"
+name: "Font Size Controls"
+type: "app"
+flag_key: "font-size-controls"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "reader-ui"
+personas:
+  - "09-seniors"
+related_features:
+  - "pinch-font-size"
+  - "big-fonts"
+  - "typography-panel"
+parent: null
+children:
+  - "pinch-font-size"
+---
+
+# Font Size Controls
+
+**Flag:** `font-size-controls` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Seniors](../personas/09-seniors.md)
+
+Plus and minus buttons in the nav bar to increase or decrease the reading font size.
+
+## Behavior
+
+- `data-testid`: `font-increase`, `font-decrease`
+- Font size clamped between `min` and `maxFontSize` (from `useFeatureFlags`)
+- Persisted to `localStorage` via `useTypography`
+- Re-triggers `buildPages` after resize to reflow content
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Pinch Font Size](pinch-font-size.md) — gesture-based sibling
+- [Big Fonts](big-fonts.md) — base size variant
+- [Typography Panel](typography-panel.md) — full controls

--- a/docs/features/high-contrast-theme.md
+++ b/docs/features/high-contrast-theme.md
@@ -1,0 +1,37 @@
+---
+id: "high-contrast-theme"
+name: "High Contrast Theme"
+type: "app"
+flag_key: "high-contrast-theme"
+lifecycle: "STABLE"
+flag_default: "off"
+category: "appearance"
+personas:
+  - "09-seniors"
+related_features:
+  - "theme"
+  - "big-fonts"
+  - "simplified-ui"
+parent: "theme"
+children: []
+---
+
+# High Contrast Theme
+
+**Flag:** `high-contrast-theme` · **Lifecycle:** STABLE · **Default:** off
+**Personas:** [Seniors](../personas/09-seniors.md)
+
+Adds `light-hc` and `dark-hc` theme variants — black background with white text and sharp borders for maximum legibility.
+
+## Behavior
+
+- When enabled, the theme cycle expands to include high-contrast variants
+- `light-hc`: white background, black text, stark borders
+- `dark-hc`: black background, white text, high-contrast borders
+- Designed for users with low vision or sensitivity to low-contrast interfaces
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Theme](theme.md) — parent feature
+- [Big Fonts](big-fonts.md) — accessibility companion

--- a/docs/features/illustrations.md
+++ b/docs/features/illustrations.md
@@ -1,0 +1,36 @@
+---
+id: "illustrations"
+name: "Illustrations"
+type: "app"
+flag_key: "illustrations"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "gen-alpha"
+personas:
+  - "01-pre-readers"
+  - "02-parents"
+related_features:
+  - "read-along"
+  - "child-profile"
+parent: null
+children: []
+---
+
+# Illustrations
+
+**Flag:** `illustrations` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md)
+
+Displays story-appropriate illustrations when available, shown alongside or between text.
+
+## Behavior
+
+- Illustration files stored in `stories/{source}/{slug}/` alongside `content.md`
+- Images rendered at natural breakpoints (between paragraphs or at page boundaries)
+- Responsive sizing — fills reading column width
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Read-Along](read-along.md) — pairs with narration for immersive experience
+- [Child Profile](child-profile.md) — illustrations always on in child mode

--- a/docs/features/journaling-prompts.md
+++ b/docs/features/journaling-prompts.md
@@ -1,6 +1,22 @@
+---
+id: "journaling-prompts"
+name: "Journaling Prompts"
+type: "strategic"
+status: "near-term"
+category: "wellness"
+personas:
+  - "05-therapeutic"
+related_features:
+  - "mood-recommendations"
+  - "symbol-analysis"
+  - "discussion-questions"
+parent: "discussion-questions"
+children: []
+---
+
 # Journaling Prompts
 
-**Status:** Near-term  
+**Status:** Near-term
 **Personas:** [Therapeutic](../personas/05-therapeutic.md)
 
 Post-reading reflection questions designed for personal journaling and self-inquiry.
@@ -24,3 +40,4 @@ Post-reading reflection questions designed for personal journaling and self-inqu
 - [Back to Feature Matrix](../personas.md)
 - [Mood Recommendations](mood-recommendations.md)
 - [Symbol Analysis](symbol-analysis.md)
+- [Discussion Questions](discussion-questions.md) — parent feature

--- a/docs/features/journaling-prompts.md
+++ b/docs/features/journaling-prompts.md
@@ -1,0 +1,26 @@
+# Journaling Prompts
+
+**Status:** Near-term  
+**Personas:** [Therapeutic](../personas/05-therapeutic.md)
+
+Post-reading reflection questions designed for personal journaling and self-inquiry.
+
+## Prompt Examples
+
+- "Which character did you identify with most, and why?"
+- "What part of this story made you uncomfortable?"
+- "If you could change one decision a character made, what would it be?"
+- "What does the forest in this story mean to you personally?"
+
+## Implementation Notes
+
+- Prompts stored in `questions.json` alongside [Discussion Questions](discussion-questions.md)
+- Differentiated by a `type: journal` flag vs. `type: discussion`
+- Optional: a simple in-app text area for writing responses, stored in `localStorage`
+- Mood integration: prompts can be filtered by the user's selected mood state
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Mood Recommendations](mood-recommendations.md)
+- [Symbol Analysis](symbol-analysis.md)

--- a/docs/features/mood-recommendations.md
+++ b/docs/features/mood-recommendations.md
@@ -1,0 +1,28 @@
+# Mood Recommendations
+
+**Status:** Vision  
+**Personas:** [Therapeutic](../personas/05-therapeutic.md)
+
+Story suggestions driven by the user's current emotional state.
+
+## Mood → Story Mapping
+
+| Mood | Story Type | Example |
+|---|---|---|
+| Anxious | Calming, resolved endings | Cinderella, Sleeping Beauty |
+| Sad | Transformative, hopeful | The Ugly Duckling |
+| Angry | Trickster satisfaction | Rumpelstiltskin |
+| Curious | Adventure, discovery | Alice-type journeys |
+| Nostalgic | Classic canonical versions | Brothers Grimm originals |
+
+## Implementation Notes
+
+- User selects a mood from a simple emoji-based picker
+- Mood-to-story affinity scores stored in story frontmatter or a separate `mood-map.json`
+- Scores generated via Claude API analysis of story tone, resolution, and archetype
+- Pairs naturally with [Journaling Prompts](journaling-prompts.md) post-read
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Journaling Prompts](journaling-prompts.md)

--- a/docs/features/mood-recommendations.md
+++ b/docs/features/mood-recommendations.md
@@ -1,6 +1,22 @@
+---
+id: "mood-recommendations"
+name: "Mood Recommendations"
+type: "strategic"
+status: "vision"
+category: "wellness"
+personas:
+  - "05-therapeutic"
+related_features:
+  - "journaling-prompts"
+  - "symbol-analysis"
+  - "favorites"
+parent: null
+children: []
+---
+
 # Mood Recommendations
 
-**Status:** Vision  
+**Status:** Vision
 **Personas:** [Therapeutic](../personas/05-therapeutic.md)
 
 Story suggestions driven by the user's current emotional state.
@@ -26,3 +42,4 @@ Story suggestions driven by the user's current emotional state.
 
 - [Back to Feature Matrix](../personas.md)
 - [Journaling Prompts](journaling-prompts.md)
+- [Symbol Analysis](symbol-analysis.md)

--- a/docs/features/parallel-texts.md
+++ b/docs/features/parallel-texts.md
@@ -1,0 +1,24 @@
+# Parallel Texts
+
+**Status:** Near-term  
+**Personas:** [Teachers](../personas/03-teachers.md) · [Culture Explorers](../personas/04-culture-explorers.md)
+
+Side-by-side reading of the same story in two languages or across cultural variants.
+
+## Layout
+
+- Left column: source language (e.g. German original)
+- Right column: target language or cultural variant
+- Synchronized scrolling / page-turning between columns
+- Tap a word in either column to highlight the corresponding segment
+
+## Implementation Notes
+
+- Requires parallel story files: `content.de.md`, `content.en.md` in the same story directory
+- The adaption switcher (`adaptionsByParent`) already tracks variants — parallel view is a two-pane mode using the same data
+- `buildPages` must run for both columns simultaneously with shared height constraints
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Cultural Annotations](cultural-annotations.md)

--- a/docs/features/parallel-texts.md
+++ b/docs/features/parallel-texts.md
@@ -1,6 +1,22 @@
+---
+id: "parallel-texts"
+name: "Parallel Texts"
+type: "strategic"
+status: "near-term"
+category: "culture"
+personas:
+  - "03-teachers"
+  - "04-culture-explorers"
+related_features:
+  - "cultural-annotations"
+  - "adaption-switcher"
+parent: null
+children: []
+---
+
 # Parallel Texts
 
-**Status:** Near-term  
+**Status:** Near-term
 **Personas:** [Teachers](../personas/03-teachers.md) · [Culture Explorers](../personas/04-culture-explorers.md)
 
 Side-by-side reading of the same story in two languages or across cultural variants.
@@ -22,3 +38,4 @@ Side-by-side reading of the same story in two languages or across cultural varia
 
 - [Back to Feature Matrix](../personas.md)
 - [Cultural Annotations](cultural-annotations.md)
+- [Adaption Switcher](adaption-switcher.md) — existing app flag (foundation)

--- a/docs/features/pinch-font-size.md
+++ b/docs/features/pinch-font-size.md
@@ -1,0 +1,35 @@
+---
+id: "pinch-font-size"
+name: "Pinch Font Size"
+type: "app"
+flag_key: "pinch-font-size"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "reader-ui"
+personas:
+  - "09-seniors"
+  - "01-pre-readers"
+related_features:
+  - "font-size-controls"
+parent: "font-size-controls"
+children: []
+---
+
+# Pinch Font Size
+
+**Flag:** `pinch-font-size` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Seniors](../personas/09-seniors.md) · [Pre-Readers](../personas/01-pre-readers.md)
+
+Adjust reading font size with a two-finger pinch gesture on the reader area.
+
+## Behavior
+
+- Touch `pinchstart` / `pinchmove` events detected on `readerAreaRef`
+- Scale delta mapped to font size steps
+- Same min/max constraints as [Font Size Controls](font-size-controls.md)
+- Particularly useful on tablets where button targets are small
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Font Size Controls](font-size-controls.md) — parent feature

--- a/docs/features/read-along.md
+++ b/docs/features/read-along.md
@@ -1,0 +1,38 @@
+---
+id: "read-along"
+name: "Read-Along"
+type: "app"
+flag_key: "read-along"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "gen-alpha"
+personas:
+  - "01-pre-readers"
+  - "02-parents"
+related_features:
+  - "word-highlighting"
+  - "audio-player"
+  - "text-to-speech"
+parent: null
+children: []
+---
+
+# Read-Along
+
+**Flag:** `read-along` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Parents](../personas/02-parents.md)
+
+Simultaneous narration and synchronized word-by-word highlighting — the app-flag implementation of the [Word Highlighting](word-highlighting.md) strategic feature.
+
+## Behavior
+
+- Audio plays (via [Audio Player](audio-player.md) or [Text-to-Speech](text-to-speech.md)) while the current word is highlighted in the reader
+- Designed for children learning to read — connects spoken words to written form
+- Label: "Vorlesen mit Markierung" (Read aloud with highlighting)
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Word Highlighting](word-highlighting.md) — strategic feature this implements
+- [Audio Player](audio-player.md) — audio source
+- [Text-to-Speech](text-to-speech.md) — TTS audio source

--- a/docs/features/reading-duration.md
+++ b/docs/features/reading-duration.md
@@ -1,0 +1,38 @@
+---
+id: "reading-duration"
+name: "Reading Duration"
+type: "app"
+flag_key: "reading-duration"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "reader-stats"
+personas:
+  - "02-parents"
+  - "03-teachers"
+  - "09-seniors"
+  - "10-gamified-explorers"
+related_features:
+  - "word-count"
+  - "bedtime-mode"
+parent: null
+children: []
+---
+
+# Reading Duration
+
+**Flag:** `reading-duration` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Parents](../personas/02-parents.md) · [Teachers](../personas/03-teachers.md) · [Seniors](../personas/09-seniors.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+Estimates reading time based on 200 words per minute, displayed as "~X min" in the sidebar.
+
+## Behavior
+
+- Shown alongside the story title in the sidebar
+- Calculation: `Math.ceil(wordCount / 200)` minutes
+- Used by Bedtime Mode to select stories matching a target session length
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Word Count](word-count.md) — sibling stat feature
+- [Bedtime Mode](bedtime-mode.md) — consumes this data

--- a/docs/features/simplified-ui.md
+++ b/docs/features/simplified-ui.md
@@ -1,0 +1,38 @@
+---
+id: "simplified-ui"
+name: "Simplified UI"
+type: "app"
+flag_key: "simplified-ui"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "appearance"
+personas:
+  - "09-seniors"
+  - "02-parents"
+related_features:
+  - "big-fonts"
+  - "high-contrast-theme"
+  - "child-profile"
+parent: null
+children: []
+---
+
+# Simplified UI
+
+**Flag:** `simplified-ui` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Seniors](../personas/09-seniors.md) · [Parents](../personas/02-parents.md)
+
+Hides advanced settings, enlarges interactive elements, and reduces visual complexity.
+
+## Behavior
+
+- Advanced feature toggles hidden from ProfilePanel
+- Larger tap targets on nav buttons and sidebar items
+- Fewer sidebar options — only story list and search visible
+- Pairs with [Big Fonts](big-fonts.md) and [High Contrast Theme](high-contrast-theme.md) for a fully accessible experience
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Big Fonts](big-fonts.md)
+- [Child Profile](child-profile.md) — child-specific variant of this concept

--- a/docs/features/sleep-timer.md
+++ b/docs/features/sleep-timer.md
@@ -1,6 +1,24 @@
+---
+id: "sleep-timer"
+name: "Sleep Timer"
+type: "strategic"
+status: "mvp"
+category: "audio"
+personas:
+  - "02-parents"
+  - "07-passive-consumers"
+  - "09-seniors"
+related_features:
+  - "bedtime-mode"
+  - "audio-narration"
+  - "audio-player"
+parent: "bedtime-mode"
+children: []
+---
+
 # Sleep Timer
 
-**Status:** MVP  
+**Status:** MVP
 **Personas:** [Parents](../personas/02-parents.md) · [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md)
 
 Auto-stop audio playback after a configurable duration.
@@ -20,5 +38,6 @@ Auto-stop audio playback after a configurable duration.
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
-- [Bedtime Mode](bedtime-mode.md)
+- [Bedtime Mode](bedtime-mode.md) — parent feature
 - [Audio Narration](audio-narration.md)
+- [Audio Player](audio-player.md) — existing app flag

--- a/docs/features/sleep-timer.md
+++ b/docs/features/sleep-timer.md
@@ -1,0 +1,24 @@
+# Sleep Timer
+
+**Status:** MVP  
+**Personas:** [Parents](../personas/02-parents.md) · [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md)
+
+Auto-stop audio playback after a configurable duration.
+
+## Options
+
+- 15 min · 30 min · 45 min · end of current story
+- Volume fade-out in the last 60 seconds
+- Optional: resume from last position on next open
+
+## Implementation Notes
+
+- Timer state lives alongside `speedReaderMode` in `grimm-reader.jsx`
+- Audio fade: `AudioPlayer` exposes a volume prop; tween it down over 60 s using `requestAnimationFrame`
+- "End of story" option: stop when `currentPage === totalPages` and the story is marked complete
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Bedtime Mode](bedtime-mode.md)
+- [Audio Narration](audio-narration.md)

--- a/docs/features/speed-reader.md
+++ b/docs/features/speed-reader.md
@@ -1,0 +1,37 @@
+---
+id: "speed-reader"
+name: "Speed Reader"
+type: "app"
+flag_key: "speed-reader"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "advanced-reading"
+personas:
+  - "07-passive-consumers"
+  - "06-creatives"
+related_features:
+  - "speedreader-orp"
+  - "audio-player"
+parent: null
+children:
+  - "speedreader-orp"
+---
+
+# Speed Reader
+
+**Flag:** `speed-reader` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Passive Consumers](../personas/07-passive-consumers.md) · [Creatives](../personas/06-creatives.md)
+
+RSVP (Rapid Serial Visual Presentation) mode — displays words one at a time at a configurable pace.
+
+## Behavior
+
+- `data-testid`: `speed-reader-toggle`, `speed-reader-word`, `speed-reader-play`, `speed-reader-back`, `speed-reader-wpm-decrease`, `speed-reader-wpm-increase`
+- WPM range configurable; sentence boundaries trigger micro-pauses
+- `SpeedReaderView` component replaces the page content area
+- Useful for research scanning (Creatives) and rapid consumption (Passive Consumers)
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [ORP Enhancement](speedreader-orp.md) — child feature

--- a/docs/features/speedreader-orp.md
+++ b/docs/features/speedreader-orp.md
@@ -1,0 +1,34 @@
+---
+id: "speedreader-orp"
+name: "ORP Enhancement"
+type: "app"
+flag_key: "speedreader-orp"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "advanced-reading"
+personas:
+  - "07-passive-consumers"
+  - "06-creatives"
+related_features:
+  - "speed-reader"
+parent: "speed-reader"
+children: []
+---
+
+# ORP Enhancement (Speed Reader)
+
+**Flag:** `speedreader-orp` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Passive Consumers](../personas/07-passive-consumers.md) · [Creatives](../personas/06-creatives.md)
+
+Highlights the Optimal Recognition Point (ORP) of each word and aligns it to a fixed fixation point, with configurable guide bars.
+
+## Behavior
+
+- `data-testid`: `orp-panel-toggle`, `orp-preview`, `orp-method-second-letter`, `orp-method-center`, `orp-method-fixed-index`, `orp-letter-index-input`, `orp-highlight-toggle`, `orp-color-input`, `orp-bars-toggle`, `orp-bar-length`, `orp-marker-toggle`, `orp-fixation-x`, `orp-fixation-y`
+- Requires [Speed Reader](speed-reader.md) to be active
+- ORP method: second letter · center · fixed index
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Speed Reader](speed-reader.md) — parent feature

--- a/docs/features/story-api.md
+++ b/docs/features/story-api.md
@@ -1,0 +1,33 @@
+# Story API
+
+**Status:** Vision  
+**Personas:** [Developers](../personas/08-developers.md)
+
+Public REST/GraphQL API exposing story content, metadata, and semantic graph data.
+
+## Endpoints (Proposed)
+
+| Endpoint | Description |
+|---|---|
+| `GET /stories` | Paginated story list with metadata |
+| `GET /stories/{id}` | Full story content and frontmatter |
+| `GET /stories/{id}/analysis` | Symbol analysis, archetypes, motifs |
+| `GET /motifs` | All motifs in the knowledge graph |
+| `GET /motifs/{id}/stories` | Stories containing a given motif |
+| `POST /remix` | Generate a remix variant (AI) |
+
+## Implementation Notes
+
+- The crawler pipeline (`SourceAdapter`, `crawlers/core.ts`) is the natural backend
+- `graphify-out/` provides the semantic graph layer
+- Authentication: API key per developer account
+- Rate limiting: standard tiered by plan
+
+## Embeddable Reader
+
+A `<story-reader src="story-id">` web component that developers can drop into any page — same reader engine, zero dependencies.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Story Remix](story-remix.md)

--- a/docs/features/story-api.md
+++ b/docs/features/story-api.md
@@ -1,6 +1,24 @@
+---
+id: "story-api"
+name: "Story API"
+type: "strategic"
+status: "vision"
+category: "platform"
+personas:
+  - "08-developers"
+related_features:
+  - "story-remix"
+  - "story-map"
+  - "story-directories"
+  - "deep-search"
+parent: null
+children:
+  - "story-remix"
+---
+
 # Story API
 
-**Status:** Vision  
+**Status:** Vision
 **Personas:** [Developers](../personas/08-developers.md)
 
 Public REST/GraphQL API exposing story content, metadata, and semantic graph data.
@@ -31,3 +49,5 @@ A `<story-reader src="story-id">` web component that developers can drop into an
 
 - [Back to Feature Matrix](../personas.md)
 - [Story Remix](story-remix.md)
+- [Story Directories](story-directories.md) — existing app flag (structural foundation)
+- [Deep Search](deep-search.md) — existing app flag (search layer)

--- a/docs/features/story-directories.md
+++ b/docs/features/story-directories.md
@@ -1,0 +1,44 @@
+---
+id: "story-directories"
+name: "Story Directories"
+type: "app"
+flag_key: "story-directories"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "navigation"
+personas:
+  - "04-culture-explorers"
+  - "08-developers"
+  - "10-gamified-explorers"
+related_features:
+  - "story-map"
+  - "deep-search"
+  - "story-api"
+parent: null
+children: []
+---
+
+# Story Directories
+
+**Flag:** `story-directories` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Culture Explorers](../personas/04-culture-explorers.md) · [Developers](../personas/08-developers.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+Displays stories in a three-level directory hierarchy: source → directory → story.
+
+## Behavior
+
+- When enabled, sidebar shows an intermediate directory level between source and story list
+- `data-testid`: `directory-button`, `back-to-directories`
+- Swiss canton stories already use the 3-level structure (`stories/swiss/{canton}/{slug}/`)
+- `activeDirectory` state in `grimm-reader.jsx` tracks the current drill-down level
+
+## Foundation For
+
+- [Story Map](story-map.md) geographic browsing (directories = regions)
+- [Story API](story-api.md) structured content hierarchy
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Story Map](story-map.md) — strategic extension
+- [Deep Search](deep-search.md) — search companion

--- a/docs/features/story-map.md
+++ b/docs/features/story-map.md
@@ -1,0 +1,28 @@
+# Story Map
+
+**Status:** Vision  
+**Personas:** [Culture Explorers](../personas/04-culture-explorers.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+A visual geographic and thematic map for discovering stories by origin, motif, or region.
+
+## Map Modes
+
+| Mode | Description |
+|---|---|
+| Geographic | Stories pinned to their cultural origin on a world map |
+| Motif graph | Network view of stories connected by shared archetypes |
+| Timeline | Stories plotted by era of first written record |
+| Completion | Personal progress overlay — read vs. unread |
+
+## Implementation Notes
+
+- Geographic coordinates can be added to story frontmatter during crawl
+- The Swiss canton structure (`stories/swiss/{canton}/`) already has built-in geographic metadata
+- `graphify-out/` knowledge graph maps naturally to the motif network view
+- Completion overlay uses the existing `completedStories` set from `usePersistence`
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Achievements](achievements.md)
+- [Cultural Annotations](cultural-annotations.md)

--- a/docs/features/story-map.md
+++ b/docs/features/story-map.md
@@ -1,6 +1,25 @@
+---
+id: "story-map"
+name: "Story Map"
+type: "strategic"
+status: "vision"
+category: "discovery"
+personas:
+  - "04-culture-explorers"
+  - "10-gamified-explorers"
+related_features:
+  - "achievements"
+  - "cultural-annotations"
+  - "story-directories"
+  - "symbol-analysis"
+parent: null
+children:
+  - "achievements"
+---
+
 # Story Map
 
-**Status:** Vision  
+**Status:** Vision
 **Personas:** [Culture Explorers](../personas/04-culture-explorers.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
 
 A visual geographic and thematic map for discovering stories by origin, motif, or region.
@@ -26,3 +45,4 @@ A visual geographic and thematic map for discovering stories by origin, motif, o
 - [Back to Feature Matrix](../personas.md)
 - [Achievements](achievements.md)
 - [Cultural Annotations](cultural-annotations.md)
+- [Story Directories](story-directories.md) — existing app flag (geographic foundation)

--- a/docs/features/story-quiz.md
+++ b/docs/features/story-quiz.md
@@ -1,0 +1,39 @@
+---
+id: "story-quiz"
+name: "Story Quiz"
+type: "app"
+flag_key: "story-quiz"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "gen-alpha"
+personas:
+  - "01-pre-readers"
+  - "03-teachers"
+related_features:
+  - "discussion-questions"
+  - "achievements"
+  - "child-profile"
+parent: null
+children: []
+---
+
+# Story Quiz
+
+**Flag:** `story-quiz` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Teachers](../personas/03-teachers.md)
+
+Simple comprehension questions displayed at the end of a story — making reading interactive.
+
+## Behavior
+
+- 3–5 multiple-choice or true/false questions per story
+- Shown on the end-of-story screen via `EndOfStoryButtons` area
+- Questions stored as `quiz.json` in the story directory
+- Score tracked per story; contributes to [Achievements](achievements.md)
+- Simpler variant of [Discussion Questions](discussion-questions.md) — no AI generation required
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Discussion Questions](discussion-questions.md) — strategic extension
+- [Achievements](achievements.md) — quiz scores feed achievements

--- a/docs/features/story-remix.md
+++ b/docs/features/story-remix.md
@@ -1,6 +1,24 @@
+---
+id: "story-remix"
+name: "Story Remix"
+type: "strategic"
+status: "vision"
+category: "creative"
+personas:
+  - "06-creatives"
+  - "08-developers"
+related_features:
+  - "story-api"
+  - "adaption-switcher"
+  - "choice-narratives"
+  - "symbol-analysis"
+parent: null
+children: []
+---
+
 # Story Remix
 
-**Status:** Vision  
+**Status:** Vision
 **Personas:** [Creatives](../personas/06-creatives.md) · [Developers](../personas/08-developers.md)
 
 AI-assisted story transformation: retelling, style transfer, genre shift, and mashup.
@@ -26,3 +44,4 @@ AI-assisted story transformation: retelling, style transfer, genre shift, and ma
 
 - [Back to Feature Matrix](../personas.md)
 - [Story API](story-api.md)
+- [Adaption Switcher](adaption-switcher.md) — existing app flag (surface for output)

--- a/docs/features/story-remix.md
+++ b/docs/features/story-remix.md
@@ -1,0 +1,28 @@
+# Story Remix
+
+**Status:** Vision  
+**Personas:** [Creatives](../personas/06-creatives.md) · [Developers](../personas/08-developers.md)
+
+AI-assisted story transformation: retelling, style transfer, genre shift, and mashup.
+
+## Remix Modes
+
+| Mode | Description |
+|---|---|
+| Style transfer | Grimm → Sci-Fi · Modern · Horror · Romance |
+| Character swap | Replace characters with user-defined ones |
+| Mashup | Combine two story archetypes into one new tale |
+| Continuation | Generate a sequel or alternate ending |
+| Simplification | Adapt a classic for younger readers |
+
+## Implementation Notes
+
+- Claude API call with the source story + a structured remix prompt
+- Output rendered directly in the reader with a "Remixed" badge in the variant switcher
+- Remix variants stored ephemerally (session) or saved to a user library
+- For [Developers](../personas/08-developers.md): expose remix as an API endpoint
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Story API](story-api.md)

--- a/docs/features/subscriber-fonts.md
+++ b/docs/features/subscriber-fonts.md
@@ -1,0 +1,34 @@
+---
+id: "subscriber-fonts"
+name: "Subscriber Fonts"
+type: "app"
+flag_key: "subscriber-fonts"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "typography"
+personas:
+  - "05-therapeutic"
+  - "06-creatives"
+related_features:
+  - "typography-panel"
+parent: "typography-panel"
+children: []
+---
+
+# Subscriber Fonts
+
+**Flag:** `subscriber-fonts` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Therapeutic](../personas/05-therapeutic.md) · [Creatives](../personas/06-creatives.md)
+
+Expands the Typography Panel with additional font choices: more variants per family (Serif, Sans, Cursive) and a new Mono family.
+
+## Behavior
+
+- When enabled, `FONT_FAMILIES` in `TypographyPanel` includes extended options
+- `maxFontSize` ceiling may adjust to accommodate different font metrics
+- Mono family supports code-style reading for [Developers](../personas/08-developers.md)
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Typography Panel](typography-panel.md) — parent feature

--- a/docs/features/symbol-analysis.md
+++ b/docs/features/symbol-analysis.md
@@ -1,6 +1,27 @@
+---
+id: "symbol-analysis"
+name: "Symbol Analysis"
+type: "strategic"
+status: "vision"
+category: "analysis"
+personas:
+  - "03-teachers"
+  - "05-therapeutic"
+  - "06-creatives"
+related_features:
+  - "discussion-questions"
+  - "journaling-prompts"
+  - "story-remix"
+  - "story-map"
+parent: null
+children:
+  - "discussion-questions"
+  - "journaling-prompts"
+---
+
 # Symbol Analysis
 
-**Status:** Vision  
+**Status:** Vision
 **Personas:** [Teachers](../personas/03-teachers.md) · [Therapeutic](../personas/05-therapeutic.md) · [Creatives](../personas/06-creatives.md)
 
 Jungian archetype mapping, motif identification, and structural literary analysis per story.
@@ -26,3 +47,4 @@ Jungian archetype mapping, motif identification, and structural literary analysi
 - [Back to Feature Matrix](../personas.md)
 - [Discussion Questions](discussion-questions.md)
 - [Journaling Prompts](journaling-prompts.md)
+- [Story Map](story-map.md) — motif graph view

--- a/docs/features/symbol-analysis.md
+++ b/docs/features/symbol-analysis.md
@@ -1,0 +1,28 @@
+# Symbol Analysis
+
+**Status:** Vision  
+**Personas:** [Teachers](../personas/03-teachers.md) · [Therapeutic](../personas/05-therapeutic.md) · [Creatives](../personas/06-creatives.md)
+
+Jungian archetype mapping, motif identification, and structural literary analysis per story.
+
+## Analysis Layers
+
+| Layer | Description |
+|---|---|
+| Archetypes | Hero, Shadow, Trickster, Anima/Animus, Wise Elder |
+| Motifs | Transformation, forbidden room, three trials, helpful animal |
+| Structure | Propp's morphology (departure, test, return, etc.) |
+| Cross-references | Other stories sharing the same motif or archetype |
+
+## Implementation Notes
+
+- Analysis generated via Claude API at crawl time; stored as `analysis.json`
+- The existing `graphify-out/` knowledge graph is a natural home for motif relationships
+- UI: a dedicated analysis panel accessible from the story end-screen or reader toolbar
+- Symbol Graph: a visual network of archetypes and motifs across the corpus
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Discussion Questions](discussion-questions.md)
+- [Journaling Prompts](journaling-prompts.md)

--- a/docs/features/tap-middle-toggle.md
+++ b/docs/features/tap-middle-toggle.md
@@ -1,0 +1,34 @@
+---
+id: "tap-middle-toggle"
+name: "Tap Middle Toggle"
+type: "app"
+flag_key: "tap-middle-toggle"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "reader-ui"
+personas:
+  - "07-passive-consumers"
+related_features:
+  - "tap-zones"
+parent: "tap-zones"
+children: []
+---
+
+# Tap Middle Toggle
+
+**Flag:** `tap-middle-toggle` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Passive Consumers](../personas/07-passive-consumers.md)
+
+Tapping the center of the screen hides the nav bar and header for a distraction-free reading experience.
+
+## Behavior
+
+- Requires [Tap Zones](tap-zones.md) to be enabled
+- Center tap toggles `controlsVisible` state in `grimm-reader.jsx`
+- Nav bar and header slide out; full screen given to the reading area
+- Tap center again to restore UI chrome
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Tap Zones](tap-zones.md) — parent feature

--- a/docs/features/tap-zones.md
+++ b/docs/features/tap-zones.md
@@ -1,0 +1,39 @@
+---
+id: "tap-zones"
+name: "Tap Zones"
+type: "app"
+flag_key: "tap-zones"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "reader-ui"
+personas:
+  - "01-pre-readers"
+  - "07-passive-consumers"
+  - "09-seniors"
+related_features:
+  - "tap-middle-toggle"
+  - "eink-flash"
+parent: null
+children:
+  - "tap-middle-toggle"
+---
+
+# Tap Zones
+
+**Flag:** `tap-zones` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md) · [Passive Consumers](../personas/07-passive-consumers.md) · [Seniors](../personas/09-seniors.md)
+
+Invisible left and right tap areas for page navigation — no need to hit small buttons.
+
+## Behavior
+
+- `TapZones` component renders transparent overlays on left/right thirds of the screen
+- `data-testid`: `prev-page` (left), `next-page` (right) zones
+- Large hit targets — ideal for children and seniors
+- Enables one-hand operation for passive listening scenarios
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Tap Middle Toggle](tap-middle-toggle.md) — child feature
+- [E-Ink Flash](eink-flash.md) — visual feedback on tap

--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -1,0 +1,39 @@
+---
+id: "text-to-speech"
+name: "Text-to-Speech"
+type: "app"
+flag_key: "text-to-speech"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "advanced-reading"
+personas:
+  - "09-seniors"
+  - "07-passive-consumers"
+related_features:
+  - "audio-player"
+  - "audio-narration"
+  - "read-along"
+parent: null
+children: []
+---
+
+# Text-to-Speech
+
+**Flag:** `text-to-speech` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Personas:** [Seniors](../personas/09-seniors.md) · [Passive Consumers](../personas/07-passive-consumers.md)
+
+Reads the story text aloud using a synthetic voice — independent of pre-recorded audio files.
+
+## Behavior
+
+- Uses Web Speech API (`SpeechSynthesis`) or a cloud TTS provider
+- Works on any story without pre-recorded audio, unlike [Audio Player](audio-player.md)
+- Rate and voice configurable in settings
+- Complement to [Read-Along](read-along.md): TTS drives the audio, read-along adds highlighting
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Audio Player](audio-player.md) — recorded audio sibling
+- [Audio Narration](audio-narration.md) — strategic roadmap
+- [Read-Along](read-along.md) — word highlight complement

--- a/docs/features/theme.md
+++ b/docs/features/theme.md
@@ -1,0 +1,47 @@
+---
+id: "theme"
+name: "Theme"
+type: "app"
+flag_key: "theme"
+lifecycle: "STABLE"
+flag_default: "light"
+category: "appearance"
+personas:
+  - "05-therapeutic"
+  - "09-seniors"
+  - "07-passive-consumers"
+related_features:
+  - "high-contrast-theme"
+parent: null
+children:
+  - "high-contrast-theme"
+---
+
+# Theme
+
+**Flag:** `theme` · **Lifecycle:** STABLE · **Default:** light
+**Variants:** `light` · `dark` · `system` · `light-hc` · `dark-hc`
+**Personas:** [Therapeutic](../personas/05-therapeutic.md) · [Seniors](../personas/09-seniors.md) · [Passive Consumers](../personas/07-passive-consumers.md)
+
+Global theme selection controlling background, text, and border colors across the entire app.
+
+## Variants
+
+| Variant | Description |
+|---|---|
+| `light` | Warm amber/cream tones |
+| `dark` | Dark slate with amber accents |
+| `system` | Follows OS preference |
+| `light-hc` | Light high-contrast (requires `high-contrast-theme` flag) |
+| `dark-hc` | Dark high-contrast (requires `high-contrast-theme` flag) |
+
+## Implementation Notes
+
+- Theme value flows through `ThemeContext` and is consumed via `useTheme()`
+- All components use `dark`, `hc`, `tc` helpers from `useTheme` for conditional class strings
+- No Tailwind `dark:` variant — all conditional class strings are explicit
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [High Contrast Theme](high-contrast-theme.md) — child feature

--- a/docs/features/typography-panel.md
+++ b/docs/features/typography-panel.md
@@ -1,0 +1,48 @@
+---
+id: "typography-panel"
+name: "Typography Panel"
+type: "app"
+flag_key: "typography-panel"
+lifecycle: "STABLE"
+flag_default: "on"
+category: "typography"
+personas:
+  - "05-therapeutic"
+  - "06-creatives"
+  - "09-seniors"
+related_features:
+  - "subscriber-fonts"
+  - "font-size-controls"
+  - "big-fonts"
+parent: null
+children:
+  - "subscriber-fonts"
+---
+
+# Typography Panel
+
+**Flag:** `typography-panel` · **Lifecycle:** STABLE · **Default:** on
+**Personas:** [Therapeutic](../personas/05-therapeutic.md) · [Creatives](../personas/06-creatives.md) · [Seniors](../personas/09-seniors.md)
+
+A panel for fine-tuning the reading experience: line height, text width, word spacing, and font family.
+
+## Controls
+
+| Control | Options |
+|---|---|
+| Line height | Compact · Normal · Relaxed · Spacious |
+| Text width | Narrow · Medium · Wide · Full |
+| Word spacing | Normal · Wide · Wider |
+| Font family | Serif · Sans · Cursive (+ Mono with `subscriber-fonts`) |
+
+## Implementation Notes
+
+- State managed by `useTypography` hook, persisted to `localStorage`
+- Changes trigger `ResizeObserver` → `buildPages` re-run
+- Panel accessible via a typography icon in the nav bar
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Subscriber Fonts](subscriber-fonts.md) — child feature
+- [Font Size Controls](font-size-controls.md) — companion control

--- a/docs/features/word-blacklist.md
+++ b/docs/features/word-blacklist.md
@@ -1,0 +1,37 @@
+---
+id: "word-blacklist"
+name: "Word Blacklist"
+type: "app"
+flag_key: "word-blacklist"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "text-processing"
+personas: []
+related_features:
+  - "deep-search"
+  - "child-profile"
+parent: null
+children: []
+---
+
+# Word Blacklist
+
+**Flag:** `word-blacklist` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Enter words you don't want to encounter — stories containing those words are hidden in the sidebar.
+
+## Behavior
+
+- Input and list management in `ProfilePanel`
+- Blacklist stored in `localStorage` via `usePersistence`
+- Stories are filtered at display time: any story whose content includes a blacklisted word is excluded
+- Useful for content sensitivity, classroom filtering, or personal preferences
+
+## Notes
+
+Not mapped to a primary persona — this is a power-user / content-control feature that spans multiple contexts (parental control, classroom management, personal preferences).
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Child Profile](child-profile.md) — parental control companion

--- a/docs/features/word-count.md
+++ b/docs/features/word-count.md
@@ -1,0 +1,34 @@
+---
+id: "word-count"
+name: "Word Count"
+type: "app"
+flag_key: "word-count"
+lifecycle: "STABLE"
+flag_default: "off"
+category: "reader-stats"
+personas:
+  - "03-teachers"
+  - "10-gamified-explorers"
+related_features:
+  - "reading-duration"
+parent: null
+children: []
+---
+
+# Word Count
+
+**Flag:** `word-count` · **Lifecycle:** STABLE · **Default:** off
+**Personas:** [Teachers](../personas/03-teachers.md) · [Gamified Explorers](../personas/10-gamified-explorers.md)
+
+Displays the number of words in a story in the sidebar metadata.
+
+## Behavior
+
+- Word count shown alongside the story title in the sidebar list
+- Computed at load time from the story's token array
+- Serves as a quick signal for lesson planning (Teachers) and completionism (Gamified)
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Reading Duration](reading-duration.md) — sibling stat feature

--- a/docs/features/word-highlighting.md
+++ b/docs/features/word-highlighting.md
@@ -1,0 +1,21 @@
+# Word Highlighting
+
+**Status:** Vision  
+**Personas:** [Pre-Readers](../personas/01-pre-readers.md)
+
+Synchronized word-by-word text highlighting driven by audio playback position.
+
+## How It Works
+
+As audio plays, each word is highlighted in the rendered page in real time. The reader scrolls or pages automatically to keep the current word visible.
+
+## Implementation Notes
+
+- Requires per-word timing data — either WebVTT cues or a custom timestamp array alongside the audio file
+- The `buildPages` algorithm already tokenizes content into `{ word, isPara }` entries — each token maps cleanly to a highlightable `<span>`
+- Highlight state is a single `currentWordIndex` integer; no re-pagination needed
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Audio Narration](audio-narration.md) — prerequisite feature

--- a/docs/features/word-highlighting.md
+++ b/docs/features/word-highlighting.md
@@ -1,6 +1,21 @@
+---
+id: "word-highlighting"
+name: "Word Highlighting"
+type: "strategic"
+status: "vision"
+category: "reading-experience"
+personas:
+  - "01-pre-readers"
+related_features:
+  - "audio-narration"
+  - "read-along"
+parent: null
+children: []
+---
+
 # Word Highlighting
 
-**Status:** Vision  
+**Status:** Vision
 **Personas:** [Pre-Readers](../personas/01-pre-readers.md)
 
 Synchronized word-by-word text highlighting driven by audio playback position.
@@ -19,3 +34,4 @@ As audio plays, each word is highlighted in the rendered page in real time. The 
 
 - [Back to Feature Matrix](../personas.md)
 - [Audio Narration](audio-narration.md) — prerequisite feature
+- [Read-Along](read-along.md) — app flag implementing this concept

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,0 +1,170 @@
+# Extended User Personas — Fairy-Tale Webreader
+
+> Beyond classic roles: behavior patterns, context, and jobs-to-be-done.
+
+---
+
+## 1. Pre-Readers / Young Children
+
+**Job-to-be-done:** "I want to experience stories before I can read."
+
+| Use Case | Description |
+|---|---|
+| Audio + Word Highlighting | Synchronized text highlighting while audio plays |
+| Interactive Tales | Tap elements → trigger reactions, animations |
+| AI Character Voices | Distinct AI-generated voices per story character |
+| Language Development | Vocabulary aids, slow narration mode |
+
+**Opportunity:** Family onboarding entry point → long-term user retention across life stages.
+
+---
+
+## 2. Parents / Family Orchestrators
+
+**Job-to-be-done:** "I want high-quality shared time — without effort."
+
+| Use Case | Description |
+|---|---|
+| Curated Bedtime Rituals | 5 / 10 / 15 min story sessions |
+| Age-Appropriate Filters | Content filtering by child age range |
+| "Tell Me Something" Button | One-tap random story discovery |
+| Family Library | Shared reading lists and progress across devices |
+
+**Opportunity:** Subscription model + emotional lock-in via shared family memories.
+
+---
+
+## 3. Teachers / Educators
+
+**Job-to-be-done:** "I want to use fairy tales didactically."
+
+| Use Case | Description |
+|---|---|
+| Interpretation Guides | Structured literary analysis per story |
+| Cross-Cultural Variants | Compare Grimm vs. Andersen vs. regional variants |
+| Worksheet Generation | AI-generated printable exercises |
+| Discussion Questions | AI-generated Socratic prompts per story |
+
+**Opportunity:** B2B channel — schools, libraries, literacy programs.
+
+---
+
+## 4. Culture Explorers / Language Learners
+
+**Job-to-be-done:** "I want to understand culture through stories."
+
+| Use Case | Description |
+|---|---|
+| Parallel Texts | Side-by-side DE / EN / FR / etc. |
+| Local Story Discovery | Browse stories by region/canton/country |
+| Original-Language Audio | Native pronunciation narration |
+| Cultural Annotations | Inline notes on idioms, customs, history |
+
+**Opportunity:** Global differentiation vs. Kindle — stories as cultural artifacts, not just text.
+
+---
+
+## 5. Therapeutic Users / Self-Reflection
+
+**Job-to-be-done:** "I want to understand myself better."
+
+| Use Case | Description |
+|---|---|
+| Symbol Analysis | Jungian archetype mapping per story |
+| Journaling Prompts | Post-reading reflection questions |
+| Mood-Based Recommendations | Story suggestions based on current emotional state |
+| Personal Meaning Layer | "What does this story mean for me?" AI dialogue |
+
+**Opportunity:** High-value AI feature — differentiated from any existing reader product.
+
+---
+
+## 6. Creatives / Storytellers / Writers
+
+**Job-to-be-done:** "I want to create new stories."
+
+| Use Case | Description |
+|---|---|
+| Story Remixing | AI-assisted retellings and mashups |
+| Style Transfer | Grimm → Sci-Fi, Modern, Horror, etc. |
+| Plot Generator | Motif-based story scaffolding |
+| Worldbuilding | Extract and extend fairy-tale world logic |
+
+**Opportunity:** Creator economy — users as contributors, not just consumers.
+
+---
+
+## 7. Passive Consumers / Second-Screen Users
+
+**Job-to-be-done:** "I want to consume stories alongside other activities."
+
+| Use Case | Description |
+|---|---|
+| Audio-First UI | Minimal tap-to-play interface |
+| Background Mode | Continues playing when screen is off |
+| Sleep Timer | Auto-stop after N minutes |
+| Episodic Series | Multi-part stories with cliffhangers |
+
+**Opportunity:** Competes with podcasts and Audible on content depth and cultural richness.
+
+---
+
+## 8. Developers / API Users
+
+**Job-to-be-done:** "I want to use fairy tales programmatically."
+
+| Use Case | Description |
+|---|---|
+| Story API | REST/GraphQL access to story content and metadata |
+| Embeddable Reader | Drop-in `<story-reader>` web component |
+| Story Knowledge Graph | Semantic relationships between motifs, characters, tales |
+| Prompt-Ready Datasets | Structured story content for LLM fine-tuning |
+
+**Opportunity:** Platform play — the project's existing `graphify-out/` knowledge graph is a direct head start here.
+
+---
+
+## 9. Seniors / Nostalgia Users
+
+**Job-to-be-done:** "I want to relive memories."
+
+| Use Case | Description |
+|---|---|
+| Large Typography | Accessible font sizes, high contrast |
+| Classic Versions | Original unedited Grimm/Andersen texts |
+| Slow-Paced Audio | Deliberate narration with natural pauses |
+| Memory Mode | Revisit previously read stories with notes |
+
+**Opportunity:** Underserved segment in digital reading — high loyalty once onboarded.
+
+---
+
+## 10. Gamified Explorers
+
+**Job-to-be-done:** "I want to discover stories like a game."
+
+| Use Case | Description |
+|---|---|
+| Story Map | Visual geographic/thematic discovery map |
+| Achievements | Badges for reading streaks, genres, regions |
+| Choice-Based Tales | Branching narratives with decisions |
+| Variant Unlocks | Complete one story → unlock related variants |
+
+**Opportunity:** Massive engagement driver — turns passive reading into active exploration.
+
+---
+
+## Persona × Feature Matrix
+
+|  | Read | Listen | Analyze | Create | Social |
+|---|---|---|---|---|---|
+| Pre-Readers | ✓ | ✓ | | | |
+| Parents | ✓ | ✓ | | | ✓ |
+| Teachers | ✓ | | ✓ | | ✓ |
+| Culture Explorers | ✓ | ✓ | ✓ | | |
+| Therapeutic | ✓ | ✓ | ✓ | | |
+| Creatives | ✓ | | ✓ | ✓ | |
+| Passive Consumers | | ✓ | | | |
+| Developers | | | ✓ | ✓ | |
+| Seniors | ✓ | ✓ | | | |
+| Gamified | ✓ | | | | ✓ |

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,46 +1,98 @@
-# Extended User Personas — Fairy-Tale Webreader
+---
+title: "Feature Matrix"
+description: "10 personas × 16 strategic features × 30 app features"
+---
 
-> Beyond classic roles: behavior patterns, context, and jobs-to-be-done.
+# Extended User Personas — Feature Matrix
+
+> 10 personas · 16 strategic roadmap features · 30 existing app features
 
 ## Personas
 
-| # | Persona | Job-to-be-done |
-|---|---|---|
-| 👶 | [Pre-Readers](personas/01-pre-readers.md) | "I want to experience stories before I can read." |
-| 👨‍👩‍👧 | [Parents](personas/02-parents.md) | "I want high-quality shared time — without effort." |
-| 🧑‍🏫 | [Teachers](personas/03-teachers.md) | "I want to use fairy tales didactically." |
-| 🌍 | [Culture Explorers](personas/04-culture-explorers.md) | "I want to understand culture through stories." |
-| 🧘 | [Therapeutic](personas/05-therapeutic.md) | "I want to understand myself better." |
-| 🎭 | [Creatives](personas/06-creatives.md) | "I want to create new stories." |
-| 🎧 | [Passive Consumers](personas/07-passive-consumers.md) | "I want to consume stories alongside other activities." |
-| 🧑‍💻 | [Developers](personas/08-developers.md) | "I want to use fairy tales programmatically." |
-| 🧓 | [Seniors](personas/09-seniors.md) | "I want to relive memories." |
-| 🧩 | [Gamified Explorers](personas/10-gamified-explorers.md) | "I want to discover stories like a game." |
+| # | Persona | Category | Job-to-be-done |
+|---|---|---|---|
+| 👶 | [Pre-Readers](personas/01-pre-readers.md) | family | "I want to experience stories before I can read." |
+| 👨‍👩‍👧 | [Parents](personas/02-parents.md) | family | "I want high-quality shared time — without effort." |
+| 🧑‍🏫 | [Teachers](personas/03-teachers.md) | education | "I want to use fairy tales didactically." |
+| 🌍 | [Culture Explorers](personas/04-culture-explorers.md) | culture | "I want to understand culture through stories." |
+| 🧘 | [Therapeutic](personas/05-therapeutic.md) | wellness | "I want to understand myself better." |
+| 🎭 | [Creatives](personas/06-creatives.md) | creative | "I want to create new stories." |
+| 🎧 | [Passive Consumers](personas/07-passive-consumers.md) | media | "I want to consume stories alongside other activities." |
+| 🧑‍💻 | [Developers](personas/08-developers.md) | tech | "I want to use fairy tales programmatically." |
+| 🧓 | [Seniors](personas/09-seniors.md) | accessibility | "I want to relive memories." |
+| 🧩 | [Gamified Explorers](personas/10-gamified-explorers.md) | gamification | "I want to discover stories like a game." |
 
 ---
 
-## Feature Matrix
+## Strategic Features — Roadmap
 
-Each cell links to the feature file. Column headers link to the persona file.
+Column headers link to persona files. Feature names link to feature files.
 
-| Feature | [👶](personas/01-pre-readers.md) | [👨‍👩‍👧](personas/02-parents.md) | [🧑‍🏫](personas/03-teachers.md) | [🌍](personas/04-culture-explorers.md) | [🧘](personas/05-therapeutic.md) | [🎭](personas/06-creatives.md) | [🎧](personas/07-passive-consumers.md) | [🧑‍💻](personas/08-developers.md) | [🧓](personas/09-seniors.md) | [🧩](personas/10-gamified-explorers.md) |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| [Word Highlighting](features/word-highlighting.md) | ✓ | | | | | | | | | |
-| [Audio Narration](features/audio-narration.md) | ✓ | ✓ | | ✓ | | | ✓ | | ✓ | |
-| [Bedtime Mode](features/bedtime-mode.md) | | ✓ | | | | | ✓ | | | |
-| [Age Filter](features/age-filter.md) | ✓ | ✓ | | | | | | | | |
-| [Discussion Questions](features/discussion-questions.md) | | | ✓ | | ✓ | | | | | |
-| [Parallel Texts](features/parallel-texts.md) | | | ✓ | ✓ | | | | | | |
-| [Cultural Annotations](features/cultural-annotations.md) | | | ✓ | ✓ | | | | | | |
-| [Symbol Analysis](features/symbol-analysis.md) | | | ✓ | | ✓ | ✓ | | | | |
-| [Journaling Prompts](features/journaling-prompts.md) | | | | | ✓ | | | | | |
-| [Mood Recommendations](features/mood-recommendations.md) | | | | | ✓ | | | | | |
-| [Story Remix](features/story-remix.md) | | | | | | ✓ | | ✓ | | |
-| [Sleep Timer](features/sleep-timer.md) | | ✓ | | | | | ✓ | | ✓ | |
-| [Story API](features/story-api.md) | | | | | | | | ✓ | | |
-| [Story Map](features/story-map.md) | | | | ✓ | | | | | | ✓ |
-| [Achievements](features/achievements.md) | | | | | | | | | | ✓ |
-| [Choice Narratives](features/choice-narratives.md) | ✓ | | | | | ✓ | | | | ✓ |
+| Feature | Status | [👶](personas/01-pre-readers.md) | [👨‍👩‍👧](personas/02-parents.md) | [🧑‍🏫](personas/03-teachers.md) | [🌍](personas/04-culture-explorers.md) | [🧘](personas/05-therapeutic.md) | [🎭](personas/06-creatives.md) | [🎧](personas/07-passive-consumers.md) | [🧑‍💻](personas/08-developers.md) | [🧓](personas/09-seniors.md) | [🧩](personas/10-gamified-explorers.md) |
+|---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [Word Highlighting](features/word-highlighting.md) | vision | ✓ | | | | | | | | | |
+| [Audio Narration](features/audio-narration.md) | near-term | ✓ | ✓ | | ✓ | | | ✓ | | ✓ | |
+| [Bedtime Mode](features/bedtime-mode.md) | mvp | | ✓ | | | | | ✓ | | | |
+| [Age Filter](features/age-filter.md) | mvp | ✓ | ✓ | | | | | | | | |
+| [Discussion Questions](features/discussion-questions.md) | near-term | | | ✓ | | ✓ | | | | | |
+| [Parallel Texts](features/parallel-texts.md) | near-term | | | ✓ | ✓ | | | | | | |
+| [Cultural Annotations](features/cultural-annotations.md) | near-term | | | ✓ | ✓ | | | | | | |
+| [Symbol Analysis](features/symbol-analysis.md) | vision | | | ✓ | | ✓ | ✓ | | | | |
+| [Journaling Prompts](features/journaling-prompts.md) | near-term | | | | | ✓ | | | | | |
+| [Mood Recommendations](features/mood-recommendations.md) | vision | | | | | ✓ | | | | | |
+| [Story Remix](features/story-remix.md) | vision | | | | | | ✓ | | ✓ | | |
+| [Sleep Timer](features/sleep-timer.md) | mvp | | ✓ | | | | | ✓ | | ✓ | |
+| [Story API](features/story-api.md) | vision | | | | | | | | ✓ | | |
+| [Story Map](features/story-map.md) | vision | | | | ✓ | | | | | | ✓ |
+| [Achievements](features/achievements.md) | near-term | | | | | | | | | | ✓ |
+| [Choice Narratives](features/choice-narratives.md) | vision | ✓ | | | | | ✓ | | | | ✓ |
+
+---
+
+## App Features — Existing Flags
+
+| Feature | Lifecycle | [👶](personas/01-pre-readers.md) | [👨‍👩‍👧](personas/02-parents.md) | [🧑‍🏫](personas/03-teachers.md) | [🌍](personas/04-culture-explorers.md) | [🧘](personas/05-therapeutic.md) | [🎭](personas/06-creatives.md) | [🎧](personas/07-passive-consumers.md) | [🧑‍💻](personas/08-developers.md) | [🧓](personas/09-seniors.md) | [🧩](personas/10-gamified-explorers.md) |
+|---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Reader Core** | | | | | | | | | | | |
+| [Favorites](features/favorites.md) | STABLE | | | | | ✓ | | ✓ | | ✓ | ✓ |
+| [Favorites-Only Toggle](features/favorites-only-toggle.md) | STABLE | | | | | | | ✓ | | ✓ | ✓ |
+| **Reader Stats** | | | | | | | | | | | |
+| [Word Count](features/word-count.md) | STABLE | | | ✓ | | | | | | | ✓ |
+| [Reading Duration](features/reading-duration.md) | STABLE | | ✓ | ✓ | | | | | | ✓ | ✓ |
+| **Reader UI** | | | | | | | | | | | |
+| [Font Size Controls](features/font-size-controls.md) | STABLE | | | | | | | | | ✓ | |
+| [Pinch Font Size](features/pinch-font-size.md) | EXPERIMENT | ✓ | | | | | | | | ✓ | |
+| [E-Ink Flash](features/eink-flash.md) | STABLE | | | | | | | | | ✓ | |
+| [Tap Zones](features/tap-zones.md) | STABLE | ✓ | | | | | | ✓ | | ✓ | |
+| [Tap Middle Toggle](features/tap-middle-toggle.md) | STABLE | | | | | | | ✓ | | | |
+| **Appearance** | | | | | | | | | | | |
+| [Theme](features/theme.md) | STABLE | | | | | ✓ | | ✓ | | ✓ | |
+| [High Contrast](features/high-contrast-theme.md) | STABLE | | | | | | | | | ✓ | |
+| [Big Fonts](features/big-fonts.md) | EXPERIMENT | ✓ | ✓ | | | | | | | ✓ | |
+| [Simplified UI](features/simplified-ui.md) | EXPERIMENT | | ✓ | | | | | | | ✓ | |
+| **Typography** | | | | | | | | | | | |
+| [Adaption Switcher](features/adaption-switcher.md) | STABLE | | | ✓ | ✓ | | ✓ | | | | ✓ |
+| [Typography Panel](features/typography-panel.md) | STABLE | | | | | ✓ | ✓ | | | ✓ | |
+| [Subscriber Fonts](features/subscriber-fonts.md) | EXPERIMENT | | | | | ✓ | ✓ | | | | |
+| **Navigation** | | | | | | | | | | | |
+| [Story Directories](features/story-directories.md) | EXPERIMENT | | | | ✓ | | | | ✓ | | ✓ |
+| [Deep Search](features/deep-search.md) | EXPERIMENT | | | ✓ | ✓ | | ✓ | | ✓ | | |
+| **Advanced Reading** | | | | | | | | | | | |
+| [Speed Reader](features/speed-reader.md) | EXPERIMENT | | | | | | ✓ | ✓ | | | |
+| [ORP Enhancement](features/speedreader-orp.md) | EXPERIMENT | | | | | | ✓ | ✓ | | | |
+| [Audio Player](features/audio-player.md) | EXPERIMENT | ✓ | ✓ | | | | | ✓ | | ✓ | |
+| [Text-to-Speech](features/text-to-speech.md) | EXPERIMENT | | | | | | | ✓ | | ✓ | |
+| **Gen Alpha** | | | | | | | | | | | |
+| [Read-Along](features/read-along.md) | EXPERIMENT | ✓ | ✓ | | | | | | | | |
+| [Illustrations](features/illustrations.md) | EXPERIMENT | ✓ | ✓ | | | | | | | | |
+| [Child Profile](features/child-profile.md) | EXPERIMENT | ✓ | ✓ | | | | | | | | |
+| [Story Quiz](features/story-quiz.md) | EXPERIMENT | ✓ | | ✓ | | | | | | | |
+| **Tools** | | | | | | | | | | | |
+| [Word Blacklist](features/word-blacklist.md) | EXPERIMENT | | | | | | | | | | |
+| [Attribution](features/attribution.md) | STABLE | | | ✓ | ✓ | | | | ✓ | | |
+| **Debug** | | | | | | | | | | | |
+| [Debug Badges](features/debug-badges.md) | EXPERIMENT | | | | | | | | ✓ | | |
+| [Error Page Simulator](features/error-page-simulator.md) | EXPERIMENT | | | | | | | | ✓ | | |
 
 ---
 

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -2,169 +2,48 @@
 
 > Beyond classic roles: behavior patterns, context, and jobs-to-be-done.
 
----
+## Personas
 
-## 1. Pre-Readers / Young Children
-
-**Job-to-be-done:** "I want to experience stories before I can read."
-
-| Use Case | Description |
-|---|---|
-| Audio + Word Highlighting | Synchronized text highlighting while audio plays |
-| Interactive Tales | Tap elements → trigger reactions, animations |
-| AI Character Voices | Distinct AI-generated voices per story character |
-| Language Development | Vocabulary aids, slow narration mode |
-
-**Opportunity:** Family onboarding entry point → long-term user retention across life stages.
-
----
-
-## 2. Parents / Family Orchestrators
-
-**Job-to-be-done:** "I want high-quality shared time — without effort."
-
-| Use Case | Description |
-|---|---|
-| Curated Bedtime Rituals | 5 / 10 / 15 min story sessions |
-| Age-Appropriate Filters | Content filtering by child age range |
-| "Tell Me Something" Button | One-tap random story discovery |
-| Family Library | Shared reading lists and progress across devices |
-
-**Opportunity:** Subscription model + emotional lock-in via shared family memories.
+| # | Persona | Job-to-be-done |
+|---|---|---|
+| 👶 | [Pre-Readers](personas/01-pre-readers.md) | "I want to experience stories before I can read." |
+| 👨‍👩‍👧 | [Parents](personas/02-parents.md) | "I want high-quality shared time — without effort." |
+| 🧑‍🏫 | [Teachers](personas/03-teachers.md) | "I want to use fairy tales didactically." |
+| 🌍 | [Culture Explorers](personas/04-culture-explorers.md) | "I want to understand culture through stories." |
+| 🧘 | [Therapeutic](personas/05-therapeutic.md) | "I want to understand myself better." |
+| 🎭 | [Creatives](personas/06-creatives.md) | "I want to create new stories." |
+| 🎧 | [Passive Consumers](personas/07-passive-consumers.md) | "I want to consume stories alongside other activities." |
+| 🧑‍💻 | [Developers](personas/08-developers.md) | "I want to use fairy tales programmatically." |
+| 🧓 | [Seniors](personas/09-seniors.md) | "I want to relive memories." |
+| 🧩 | [Gamified Explorers](personas/10-gamified-explorers.md) | "I want to discover stories like a game." |
 
 ---
 
-## 3. Teachers / Educators
+## Feature Matrix
 
-**Job-to-be-done:** "I want to use fairy tales didactically."
+Each cell links to the feature file. Column headers link to the persona file.
 
-| Use Case | Description |
-|---|---|
-| Interpretation Guides | Structured literary analysis per story |
-| Cross-Cultural Variants | Compare Grimm vs. Andersen vs. regional variants |
-| Worksheet Generation | AI-generated printable exercises |
-| Discussion Questions | AI-generated Socratic prompts per story |
-
-**Opportunity:** B2B channel — schools, libraries, literacy programs.
-
----
-
-## 4. Culture Explorers / Language Learners
-
-**Job-to-be-done:** "I want to understand culture through stories."
-
-| Use Case | Description |
-|---|---|
-| Parallel Texts | Side-by-side DE / EN / FR / etc. |
-| Local Story Discovery | Browse stories by region/canton/country |
-| Original-Language Audio | Native pronunciation narration |
-| Cultural Annotations | Inline notes on idioms, customs, history |
-
-**Opportunity:** Global differentiation vs. Kindle — stories as cultural artifacts, not just text.
+| Feature | [👶](personas/01-pre-readers.md) | [👨‍👩‍👧](personas/02-parents.md) | [🧑‍🏫](personas/03-teachers.md) | [🌍](personas/04-culture-explorers.md) | [🧘](personas/05-therapeutic.md) | [🎭](personas/06-creatives.md) | [🎧](personas/07-passive-consumers.md) | [🧑‍💻](personas/08-developers.md) | [🧓](personas/09-seniors.md) | [🧩](personas/10-gamified-explorers.md) |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [Word Highlighting](features/word-highlighting.md) | ✓ | | | | | | | | | |
+| [Audio Narration](features/audio-narration.md) | ✓ | ✓ | | ✓ | | | ✓ | | ✓ | |
+| [Bedtime Mode](features/bedtime-mode.md) | | ✓ | | | | | ✓ | | | |
+| [Age Filter](features/age-filter.md) | ✓ | ✓ | | | | | | | | |
+| [Discussion Questions](features/discussion-questions.md) | | | ✓ | | ✓ | | | | | |
+| [Parallel Texts](features/parallel-texts.md) | | | ✓ | ✓ | | | | | | |
+| [Cultural Annotations](features/cultural-annotations.md) | | | ✓ | ✓ | | | | | | |
+| [Symbol Analysis](features/symbol-analysis.md) | | | ✓ | | ✓ | ✓ | | | | |
+| [Journaling Prompts](features/journaling-prompts.md) | | | | | ✓ | | | | | |
+| [Mood Recommendations](features/mood-recommendations.md) | | | | | ✓ | | | | | |
+| [Story Remix](features/story-remix.md) | | | | | | ✓ | | ✓ | | |
+| [Sleep Timer](features/sleep-timer.md) | | ✓ | | | | | ✓ | | ✓ | |
+| [Story API](features/story-api.md) | | | | | | | | ✓ | | |
+| [Story Map](features/story-map.md) | | | | ✓ | | | | | | ✓ |
+| [Achievements](features/achievements.md) | | | | | | | | | | ✓ |
+| [Choice Narratives](features/choice-narratives.md) | ✓ | | | | | ✓ | | | | ✓ |
 
 ---
 
-## 5. Therapeutic Users / Self-Reflection
+## Related
 
-**Job-to-be-done:** "I want to understand myself better."
-
-| Use Case | Description |
-|---|---|
-| Symbol Analysis | Jungian archetype mapping per story |
-| Journaling Prompts | Post-reading reflection questions |
-| Mood-Based Recommendations | Story suggestions based on current emotional state |
-| Personal Meaning Layer | "What does this story mean for me?" AI dialogue |
-
-**Opportunity:** High-value AI feature — differentiated from any existing reader product.
-
----
-
-## 6. Creatives / Storytellers / Writers
-
-**Job-to-be-done:** "I want to create new stories."
-
-| Use Case | Description |
-|---|---|
-| Story Remixing | AI-assisted retellings and mashups |
-| Style Transfer | Grimm → Sci-Fi, Modern, Horror, etc. |
-| Plot Generator | Motif-based story scaffolding |
-| Worldbuilding | Extract and extend fairy-tale world logic |
-
-**Opportunity:** Creator economy — users as contributors, not just consumers.
-
----
-
-## 7. Passive Consumers / Second-Screen Users
-
-**Job-to-be-done:** "I want to consume stories alongside other activities."
-
-| Use Case | Description |
-|---|---|
-| Audio-First UI | Minimal tap-to-play interface |
-| Background Mode | Continues playing when screen is off |
-| Sleep Timer | Auto-stop after N minutes |
-| Episodic Series | Multi-part stories with cliffhangers |
-
-**Opportunity:** Competes with podcasts and Audible on content depth and cultural richness.
-
----
-
-## 8. Developers / API Users
-
-**Job-to-be-done:** "I want to use fairy tales programmatically."
-
-| Use Case | Description |
-|---|---|
-| Story API | REST/GraphQL access to story content and metadata |
-| Embeddable Reader | Drop-in `<story-reader>` web component |
-| Story Knowledge Graph | Semantic relationships between motifs, characters, tales |
-| Prompt-Ready Datasets | Structured story content for LLM fine-tuning |
-
-**Opportunity:** Platform play — the project's existing `graphify-out/` knowledge graph is a direct head start here.
-
----
-
-## 9. Seniors / Nostalgia Users
-
-**Job-to-be-done:** "I want to relive memories."
-
-| Use Case | Description |
-|---|---|
-| Large Typography | Accessible font sizes, high contrast |
-| Classic Versions | Original unedited Grimm/Andersen texts |
-| Slow-Paced Audio | Deliberate narration with natural pauses |
-| Memory Mode | Revisit previously read stories with notes |
-
-**Opportunity:** Underserved segment in digital reading — high loyalty once onboarded.
-
----
-
-## 10. Gamified Explorers
-
-**Job-to-be-done:** "I want to discover stories like a game."
-
-| Use Case | Description |
-|---|---|
-| Story Map | Visual geographic/thematic discovery map |
-| Achievements | Badges for reading streaks, genres, regions |
-| Choice-Based Tales | Branching narratives with decisions |
-| Variant Unlocks | Complete one story → unlock related variants |
-
-**Opportunity:** Massive engagement driver — turns passive reading into active exploration.
-
----
-
-## Persona × Feature Matrix
-
-|  | Read | Listen | Analyze | Create | Social |
-|---|---|---|---|---|---|
-| Pre-Readers | ✓ | ✓ | | | |
-| Parents | ✓ | ✓ | | | ✓ |
-| Teachers | ✓ | | ✓ | | ✓ |
-| Culture Explorers | ✓ | ✓ | ✓ | | |
-| Therapeutic | ✓ | ✓ | ✓ | | |
-| Creatives | ✓ | | ✓ | ✓ | |
-| Passive Consumers | | ✓ | | | |
-| Developers | | | ✓ | ✓ | |
-| Seniors | ✓ | ✓ | | | |
-| Gamified | ✓ | | | | ✓ |
+- [Product Strategy](product-strategy.md) — four-axis framework, MVP vs. vision slicing

--- a/docs/personas/01-pre-readers.md
+++ b/docs/personas/01-pre-readers.md
@@ -1,0 +1,21 @@
+# 👶 Pre-Readers / Young Children
+
+**Job-to-be-done:** "I want to experience stories before I can read."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Word Highlighting](../features/word-highlighting.md) | Synchronized word-by-word text highlight during audio playback |
+| [Audio Narration](../features/audio-narration.md) | Distinct AI-generated voices per story character |
+| [Choice Narratives](../features/choice-narratives.md) | Tap elements to trigger reactions, branch the story |
+| [Age Filter](../features/age-filter.md) | Surface only age-appropriate content |
+
+## Strategic Opportunity
+
+Entry point for families — children grow into other personas (Gamified, Cultural, Creative) over time, creating long-term retention across life stages.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/01-pre-readers.md
+++ b/docs/personas/01-pre-readers.md
@@ -1,3 +1,28 @@
+---
+id: "01-pre-readers"
+name: "Pre-Readers"
+emoji: "👶"
+category: "family"
+job: "I want to experience stories before I can read."
+strategic_features:
+  - word-highlighting
+  - audio-narration
+  - choice-narratives
+  - age-filter
+app_features:
+  - read-along
+  - illustrations
+  - child-profile
+  - story-quiz
+  - tap-zones
+  - big-fonts
+  - audio-player
+related_personas:
+  - "02-parents"
+  - "10-gamified-explorers"
+opportunity: "Entry point for families — long-term retention across life stages as children grow into other personas."
+---
+
 # 👶 Pre-Readers / Young Children
 
 **Job-to-be-done:** "I want to experience stories before I can read."
@@ -11,11 +36,24 @@
 | [Choice Narratives](../features/choice-narratives.md) | Tap elements to trigger reactions, branch the story |
 | [Age Filter](../features/age-filter.md) | Surface only age-appropriate content |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Read-Along](../features/read-along.md) | Simultaneous narration + word highlight (current flag: `read-along`) |
+| [Illustrations](../features/illustrations.md) | Story images displayed alongside text |
+| [Child Profile](../features/child-profile.md) | Simplified UI with age-appropriate defaults |
+| [Story Quiz](../features/story-quiz.md) | Comprehension questions after each story |
+| [Tap Zones](../features/tap-zones.md) | Large touch areas for intuitive page-turning |
+| [Big Fonts](../features/big-fonts.md) | Larger base font sizes for early readers |
+
 ## Strategic Opportunity
 
-Entry point for families — children grow into other personas (Gamified, Cultural, Creative) over time, creating long-term retention across life stages.
+Entry point for families — long-term retention across life stages as children grow into other personas.
 
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Parents →](02-parents.md)
+- [Gamified Explorers →](10-gamified-explorers.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/02-parents.md
+++ b/docs/personas/02-parents.md
@@ -1,3 +1,29 @@
+---
+id: "02-parents"
+name: "Parents"
+emoji: "👨‍👩‍👧"
+category: "family"
+job: "I want high-quality shared time — without effort."
+strategic_features:
+  - bedtime-mode
+  - age-filter
+  - audio-narration
+  - sleep-timer
+app_features:
+  - reading-duration
+  - favorites
+  - audio-player
+  - adaption-switcher
+  - child-profile
+  - read-along
+  - illustrations
+  - simplified-ui
+related_personas:
+  - "01-pre-readers"
+  - "09-seniors"
+opportunity: "Subscription model + emotional lock-in via shared family memories. Parents are the primary purchase decision-makers."
+---
+
 # 👨‍👩‍👧 Parents / Family Orchestrators
 
 **Job-to-be-done:** "I want high-quality shared time — without effort."
@@ -11,6 +37,17 @@
 | [Audio Narration](../features/audio-narration.md) | Hands-free listening experience for the whole family |
 | [Sleep Timer](../features/sleep-timer.md) | Auto-stop playback after a set duration |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Reading Duration](../features/reading-duration.md) | See how long a story takes before starting |
+| [Favorites](../features/favorites.md) | Save stories the family loved |
+| [Audio Player](../features/audio-player.md) | Play recorded or TTS narration |
+| [Adaption Switcher](../features/adaption-switcher.md) | Choose age-appropriate story variants |
+| [Child Profile](../features/child-profile.md) | Hand the device to a child with safe defaults |
+| [Simplified UI](../features/simplified-ui.md) | Clutter-free interface for shared use |
+
 ## Strategic Opportunity
 
 Subscription model + emotional lock-in via shared family memories. Parents are the primary purchase decision-makers in the family segment.
@@ -18,4 +55,6 @@ Subscription model + emotional lock-in via shared family memories. Parents are t
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Pre-Readers →](01-pre-readers.md)
+- [Seniors →](09-seniors.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/02-parents.md
+++ b/docs/personas/02-parents.md
@@ -1,0 +1,21 @@
+# 👨‍👩‍👧 Parents / Family Orchestrators
+
+**Job-to-be-done:** "I want high-quality shared time — without effort."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Bedtime Mode](../features/bedtime-mode.md) | One-tap ritual with curated duration (5 / 10 / 15 min) |
+| [Age Filter](../features/age-filter.md) | Automatic content filtering by child age range |
+| [Audio Narration](../features/audio-narration.md) | Hands-free listening experience for the whole family |
+| [Sleep Timer](../features/sleep-timer.md) | Auto-stop playback after a set duration |
+
+## Strategic Opportunity
+
+Subscription model + emotional lock-in via shared family memories. Parents are the primary purchase decision-makers in the family segment.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/03-teachers.md
+++ b/docs/personas/03-teachers.md
@@ -1,3 +1,27 @@
+---
+id: "03-teachers"
+name: "Teachers"
+emoji: "🧑‍🏫"
+category: "education"
+job: "I want to use fairy tales didactically."
+strategic_features:
+  - discussion-questions
+  - parallel-texts
+  - cultural-annotations
+  - symbol-analysis
+app_features:
+  - adaption-switcher
+  - word-count
+  - reading-duration
+  - deep-search
+  - attribution
+  - story-quiz
+related_personas:
+  - "04-culture-explorers"
+  - "05-therapeutic"
+opportunity: "B2B channel — schools, libraries, and literacy programs. Low churn, high lifetime value, institutional procurement budgets."
+---
+
 # 🧑‍🏫 Teachers / Educators
 
 **Job-to-be-done:** "I want to use fairy tales didactically."
@@ -7,9 +31,20 @@
 | Feature | Description |
 |---|---|
 | [Discussion Questions](../features/discussion-questions.md) | AI-generated Socratic prompts per story |
-| [Parallel Texts](../features/parallel-texts.md) | Cross-cultural variant comparison (Grimm vs. Andersen vs. regional) |
+| [Parallel Texts](../features/parallel-texts.md) | Cross-cultural variant comparison |
 | [Cultural Annotations](../features/cultural-annotations.md) | Inline notes on idioms, customs, historical context |
 | [Symbol Analysis](../features/symbol-analysis.md) | Structured literary and archetypal analysis |
+
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Adaption Switcher](../features/adaption-switcher.md) | Compare Grimm vs. Andersen vs. regional variants |
+| [Word Count](../features/word-count.md) | Estimate lesson reading time |
+| [Reading Duration](../features/reading-duration.md) | Plan lesson pacing |
+| [Deep Search](../features/deep-search.md) | Find stories by content, theme, or motif |
+| [Attribution](../features/attribution.md) | Proper source citation for classroom use |
+| [Story Quiz](../features/story-quiz.md) | Ready-made comprehension questions |
 
 ## Strategic Opportunity
 
@@ -18,4 +53,6 @@ B2B channel — schools, libraries, and literacy programs. Low churn, high lifet
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Culture Explorers →](04-culture-explorers.md)
+- [Therapeutic →](05-therapeutic.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/03-teachers.md
+++ b/docs/personas/03-teachers.md
@@ -1,0 +1,21 @@
+# 🧑‍🏫 Teachers / Educators
+
+**Job-to-be-done:** "I want to use fairy tales didactically."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Discussion Questions](../features/discussion-questions.md) | AI-generated Socratic prompts per story |
+| [Parallel Texts](../features/parallel-texts.md) | Cross-cultural variant comparison (Grimm vs. Andersen vs. regional) |
+| [Cultural Annotations](../features/cultural-annotations.md) | Inline notes on idioms, customs, historical context |
+| [Symbol Analysis](../features/symbol-analysis.md) | Structured literary and archetypal analysis |
+
+## Strategic Opportunity
+
+B2B channel — schools, libraries, and literacy programs. Low churn, high lifetime value, and institutional procurement budgets.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/04-culture-explorers.md
+++ b/docs/personas/04-culture-explorers.md
@@ -1,3 +1,27 @@
+---
+id: "04-culture-explorers"
+name: "Culture Explorers"
+emoji: "🌍"
+category: "culture"
+job: "I want to understand culture through stories."
+strategic_features:
+  - parallel-texts
+  - cultural-annotations
+  - audio-narration
+  - story-map
+app_features:
+  - adaption-switcher
+  - deep-search
+  - story-directories
+  - attribution
+  - audio-player
+related_personas:
+  - "03-teachers"
+  - "06-creatives"
+  - "10-gamified-explorers"
+opportunity: "Global differentiation vs. Kindle — treat stories as living cultural artifacts. The Swiss canton structure is a direct foundation."
+---
+
 # 🌍 Culture Explorers / Language Learners
 
 **Job-to-be-done:** "I want to understand culture through stories."
@@ -11,11 +35,24 @@
 | [Audio Narration](../features/audio-narration.md) | Native-language narration for authentic pronunciation |
 | [Story Map](../features/story-map.md) | Browse stories geographically by region or canton |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Adaption Switcher](../features/adaption-switcher.md) | Browse cultural variants of the same story |
+| [Deep Search](../features/deep-search.md) | Find stories by regional or cultural keywords |
+| [Story Directories](../features/story-directories.md) | Browse by canton, country, or region |
+| [Attribution](../features/attribution.md) | Know the cultural provenance of each text |
+| [Audio Player](../features/audio-player.md) | Listen to original-language narration |
+
 ## Strategic Opportunity
 
-Global differentiation vs. Kindle — treat stories as living cultural artifacts. The Swiss canton structure already in the codebase is a direct foundation.
+Global differentiation vs. Kindle — stories as living cultural artifacts. The Swiss canton structure already in the codebase is a direct foundation.
 
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Teachers →](03-teachers.md)
+- [Creatives →](06-creatives.md)
+- [Gamified Explorers →](10-gamified-explorers.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/04-culture-explorers.md
+++ b/docs/personas/04-culture-explorers.md
@@ -1,0 +1,21 @@
+# 🌍 Culture Explorers / Language Learners
+
+**Job-to-be-done:** "I want to understand culture through stories."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Parallel Texts](../features/parallel-texts.md) | Side-by-side reading in DE / EN / FR and more |
+| [Cultural Annotations](../features/cultural-annotations.md) | Inline notes on idioms, customs, regional history |
+| [Audio Narration](../features/audio-narration.md) | Native-language narration for authentic pronunciation |
+| [Story Map](../features/story-map.md) | Browse stories geographically by region or canton |
+
+## Strategic Opportunity
+
+Global differentiation vs. Kindle — treat stories as living cultural artifacts. The Swiss canton structure already in the codebase is a direct foundation.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/05-therapeutic.md
+++ b/docs/personas/05-therapeutic.md
@@ -1,3 +1,25 @@
+---
+id: "05-therapeutic"
+name: "Therapeutic"
+emoji: "🧘"
+category: "wellness"
+job: "I want to understand myself better."
+strategic_features:
+  - symbol-analysis
+  - journaling-prompts
+  - mood-recommendations
+  - discussion-questions
+app_features:
+  - favorites
+  - typography-panel
+  - theme
+  - subscriber-fonts
+related_personas:
+  - "03-teachers"
+  - "06-creatives"
+opportunity: "High-value AI feature — no existing reader product offers this. Positions the product at the intersection of literary experience and personal growth."
+---
+
 # 🧘 Therapeutic Users / Self-Reflection
 
 **Job-to-be-done:** "I want to understand myself better."
@@ -11,6 +33,15 @@
 | [Mood Recommendations](../features/mood-recommendations.md) | Story suggestions based on current emotional state |
 | [Discussion Questions](../features/discussion-questions.md) | Guided inquiry into personal meaning |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Favorites](../features/favorites.md) | Save stories that resonate personally |
+| [Typography Panel](../features/typography-panel.md) | Create a comfortable, distraction-free reading space |
+| [Theme](../features/theme.md) | Set a calming light or dark environment |
+| [Subscriber Fonts](../features/subscriber-fonts.md) | Choose a font that feels right |
+
 ## Strategic Opportunity
 
 High-value AI feature — no existing reader product offers this. Positions the product at the intersection of literary experience and personal growth.
@@ -18,4 +49,6 @@ High-value AI feature — no existing reader product offers this. Positions the 
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Teachers →](03-teachers.md)
+- [Creatives →](06-creatives.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/05-therapeutic.md
+++ b/docs/personas/05-therapeutic.md
@@ -1,0 +1,21 @@
+# 🧘 Therapeutic Users / Self-Reflection
+
+**Job-to-be-done:** "I want to understand myself better."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Symbol Analysis](../features/symbol-analysis.md) | Jungian archetype mapping and motif identification |
+| [Journaling Prompts](../features/journaling-prompts.md) | Post-reading reflection questions |
+| [Mood Recommendations](../features/mood-recommendations.md) | Story suggestions based on current emotional state |
+| [Discussion Questions](../features/discussion-questions.md) | Guided inquiry into personal meaning |
+
+## Strategic Opportunity
+
+High-value AI feature — no existing reader product offers this. Positions the product at the intersection of literary experience and personal growth.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/06-creatives.md
+++ b/docs/personas/06-creatives.md
@@ -1,3 +1,26 @@
+---
+id: "06-creatives"
+name: "Creatives"
+emoji: "🎭"
+category: "creative"
+job: "I want to create new stories."
+strategic_features:
+  - story-remix
+  - symbol-analysis
+  - choice-narratives
+app_features:
+  - adaption-switcher
+  - deep-search
+  - typography-panel
+  - speed-reader
+  - subscriber-fonts
+related_personas:
+  - "04-culture-explorers"
+  - "05-therapeutic"
+  - "08-developers"
+opportunity: "Creator economy — turn passive readers into active contributors. User-generated content drives organic growth and community."
+---
+
 # 🎭 Creatives / Storytellers / Writers
 
 **Job-to-be-done:** "I want to create new stories."
@@ -10,6 +33,16 @@
 | [Symbol Analysis](../features/symbol-analysis.md) | Extract archetypal structure for worldbuilding |
 | [Choice Narratives](../features/choice-narratives.md) | Author branching story paths |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Adaption Switcher](../features/adaption-switcher.md) | Study how the same story is told differently |
+| [Deep Search](../features/deep-search.md) | Research specific motifs across the corpus |
+| [Typography Panel](../features/typography-panel.md) | Comfortable reading environment for research |
+| [Speed Reader](../features/speed-reader.md) | Rapidly scan stories for source material |
+| [Subscriber Fonts](../features/subscriber-fonts.md) | Match reading aesthetic to creative workflow |
+
 ## Strategic Opportunity
 
 Creator economy — turn passive readers into active contributors. User-generated content drives organic growth and community.
@@ -17,4 +50,7 @@ Creator economy — turn passive readers into active contributors. User-generate
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Culture Explorers →](04-culture-explorers.md)
+- [Therapeutic →](05-therapeutic.md)
+- [Developers →](08-developers.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/06-creatives.md
+++ b/docs/personas/06-creatives.md
@@ -1,0 +1,20 @@
+# 🎭 Creatives / Storytellers / Writers
+
+**Job-to-be-done:** "I want to create new stories."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Story Remix](../features/story-remix.md) | AI-assisted retellings, mashups, and transformations |
+| [Symbol Analysis](../features/symbol-analysis.md) | Extract archetypal structure for worldbuilding |
+| [Choice Narratives](../features/choice-narratives.md) | Author branching story paths |
+
+## Strategic Opportunity
+
+Creator economy — turn passive readers into active contributors. User-generated content drives organic growth and community.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/07-passive-consumers.md
+++ b/docs/personas/07-passive-consumers.md
@@ -1,3 +1,25 @@
+---
+id: "07-passive-consumers"
+name: "Passive Consumers"
+emoji: "🎧"
+category: "media"
+job: "I want to consume stories alongside other activities."
+strategic_features:
+  - audio-narration
+  - sleep-timer
+  - bedtime-mode
+app_features:
+  - audio-player
+  - speed-reader
+  - tap-zones
+  - tap-middle-toggle
+  - text-to-speech
+related_personas:
+  - "09-seniors"
+  - "02-parents"
+opportunity: "Competes with podcasts and Audible on content depth and cultural richness."
+---
+
 # 🎧 Passive Consumers / Second-Screen Users
 
 **Job-to-be-done:** "I want to consume stories alongside other activities."
@@ -10,6 +32,16 @@
 | [Sleep Timer](../features/sleep-timer.md) | Auto-stop after N minutes |
 | [Bedtime Mode](../features/bedtime-mode.md) | Curated session length, screen-off friendly |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Audio Player](../features/audio-player.md) | Core playback with track controls |
+| [Speed Reader](../features/speed-reader.md) | RSVP mode for rapid visual consumption |
+| [Tap Zones](../features/tap-zones.md) | One-tap page turn without precision |
+| [Tap Middle Toggle](../features/tap-middle-toggle.md) | Hide all UI chrome for immersive reading |
+| [Text-to-Speech](../features/text-to-speech.md) | Synthesized narration for any story |
+
 ## Strategic Opportunity
 
 Competes with podcasts and Audible on content depth and cultural richness. The existing speed-reader feature is a foundation for audio-first UX.
@@ -17,4 +49,5 @@ Competes with podcasts and Audible on content depth and cultural richness. The e
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Seniors →](09-seniors.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/07-passive-consumers.md
+++ b/docs/personas/07-passive-consumers.md
@@ -1,0 +1,20 @@
+# 🎧 Passive Consumers / Second-Screen Users
+
+**Job-to-be-done:** "I want to consume stories alongside other activities."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Audio Narration](../features/audio-narration.md) | Full hands-free listening experience |
+| [Sleep Timer](../features/sleep-timer.md) | Auto-stop after N minutes |
+| [Bedtime Mode](../features/bedtime-mode.md) | Curated session length, screen-off friendly |
+
+## Strategic Opportunity
+
+Competes with podcasts and Audible on content depth and cultural richness. The existing speed-reader feature is a foundation for audio-first UX.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/08-developers.md
+++ b/docs/personas/08-developers.md
@@ -1,0 +1,23 @@
+# 🧑‍💻 Developers / API Users
+
+**Job-to-be-done:** "I want to use fairy tales programmatically."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Story API](../features/story-api.md) | REST/GraphQL access to story content and metadata |
+| [Story Remix](../features/story-remix.md) | Programmatic story generation and transformation |
+
+## Strategic Opportunity
+
+Platform play — the project's existing `graphify-out/` knowledge graph is a direct head start. Transitioning from product to platform unlocks a developer ecosystem.
+
+## Implementation Note
+
+The crawler architecture (`SourceAdapter` interface, `crawlers/sources/`) already provides a clean abstraction that maps naturally to a public API surface.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/08-developers.md
+++ b/docs/personas/08-developers.md
@@ -1,3 +1,22 @@
+---
+id: "08-developers"
+name: "Developers"
+emoji: "🧑‍💻"
+category: "tech"
+job: "I want to use fairy tales programmatically."
+strategic_features:
+  - story-api
+  - story-remix
+app_features:
+  - story-directories
+  - debug-badges
+  - deep-search
+  - attribution
+related_personas:
+  - "06-creatives"
+opportunity: "Platform play — graphify-out/ knowledge graph is a direct head start. Transitioning from product to platform unlocks a developer ecosystem."
+---
+
 # 🧑‍💻 Developers / API Users
 
 **Job-to-be-done:** "I want to use fairy tales programmatically."
@@ -8,6 +27,15 @@
 |---|---|
 | [Story API](../features/story-api.md) | REST/GraphQL access to story content and metadata |
 | [Story Remix](../features/story-remix.md) | Programmatic story generation and transformation |
+
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Story Directories](../features/story-directories.md) | Structured multi-level content hierarchy |
+| [Deep Search](../features/deep-search.md) | Full-text search across all story content |
+| [Attribution](../features/attribution.md) | Source metadata for downstream use |
+| [Debug Badges](../features/debug-badges.md) | `data-testid` labels on all UI elements |
 
 ## Strategic Opportunity
 
@@ -20,4 +48,5 @@ The crawler architecture (`SourceAdapter` interface, `crawlers/sources/`) alread
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Creatives →](06-creatives.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/09-seniors.md
+++ b/docs/personas/09-seniors.md
@@ -1,3 +1,29 @@
+---
+id: "09-seniors"
+name: "Seniors"
+emoji: "🧓"
+category: "accessibility"
+job: "I want to relive memories."
+strategic_features:
+  - audio-narration
+  - sleep-timer
+app_features:
+  - font-size-controls
+  - big-fonts
+  - high-contrast-theme
+  - simplified-ui
+  - text-to-speech
+  - audio-player
+  - tap-zones
+  - reading-duration
+  - eink-flash
+  - typography-panel
+related_personas:
+  - "02-parents"
+  - "07-passive-consumers"
+opportunity: "Underserved segment in digital reading — high loyalty once onboarded, strong word-of-mouth in family contexts."
+---
+
 # 🧓 Seniors / Nostalgia Users
 
 **Job-to-be-done:** "I want to relive memories."
@@ -9,10 +35,23 @@
 | [Audio Narration](../features/audio-narration.md) | Slow-paced, warm narration with natural pauses |
 | [Sleep Timer](../features/sleep-timer.md) | Auto-stop for bedtime listening |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Font Size Controls](../features/font-size-controls.md) | + / − buttons to adjust text size |
+| [Big Fonts](../features/big-fonts.md) | Larger base font sizes (big / bigger / biggest) |
+| [High Contrast Theme](../features/high-contrast-theme.md) | Black background, white text for maximum legibility |
+| [Simplified UI](../features/simplified-ui.md) | Fewer options, larger buttons |
+| [Text-to-Speech](../features/text-to-speech.md) | Synthesized narration for any story |
+| [Audio Player](../features/audio-player.md) | Recorded narration playback |
+| [Tap Zones](../features/tap-zones.md) | Large touch areas, no precision needed |
+| [Typography Panel](../features/typography-panel.md) | Wider line spacing, comfortable reading |
+| [E-Ink Flash](../features/eink-flash.md) | Familiar page-turn effect from physical readers |
+
 ## Notes
 
-- Large typography and high contrast are already supported via the `big-fonts` and `high-contrast-theme` feature flags
-- Classic unedited Grimm/Andersen texts are already available in the stories corpus
+Classic unedited Grimm/Andersen texts are already available in the stories corpus — no feature flag required.
 
 ## Strategic Opportunity
 
@@ -21,4 +60,6 @@ Underserved segment in digital reading — high loyalty once onboarded, strong w
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Parents →](02-parents.md)
+- [Passive Consumers →](07-passive-consumers.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/09-seniors.md
+++ b/docs/personas/09-seniors.md
@@ -1,0 +1,24 @@
+# 🧓 Seniors / Nostalgia Users
+
+**Job-to-be-done:** "I want to relive memories."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Audio Narration](../features/audio-narration.md) | Slow-paced, warm narration with natural pauses |
+| [Sleep Timer](../features/sleep-timer.md) | Auto-stop for bedtime listening |
+
+## Notes
+
+- Large typography and high contrast are already supported via the `big-fonts` and `high-contrast-theme` feature flags
+- Classic unedited Grimm/Andersen texts are already available in the stories corpus
+
+## Strategic Opportunity
+
+Underserved segment in digital reading — high loyalty once onboarded, strong word-of-mouth in family contexts.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/personas/10-gamified-explorers.md
+++ b/docs/personas/10-gamified-explorers.md
@@ -1,3 +1,26 @@
+---
+id: "10-gamified-explorers"
+name: "Gamified Explorers"
+emoji: "🧩"
+category: "gamification"
+job: "I want to discover stories like a game."
+strategic_features:
+  - story-map
+  - achievements
+  - choice-narratives
+app_features:
+  - favorites
+  - story-directories
+  - word-count
+  - reading-duration
+  - deep-search
+  - adaption-switcher
+related_personas:
+  - "04-culture-explorers"
+  - "01-pre-readers"
+opportunity: "Massive engagement driver — transforms passive reading into active exploration. Drives breadth of corpus coverage."
+---
+
 # 🧩 Gamified Explorers
 
 **Job-to-be-done:** "I want to discover stories like a game."
@@ -10,6 +33,17 @@
 | [Achievements](../features/achievements.md) | Badges for reading streaks, genres, regions |
 | [Choice Narratives](../features/choice-narratives.md) | Branching narratives with player decisions |
 
+## App Features
+
+| Feature Flag | What it enables |
+|---|---|
+| [Favorites](../features/favorites.md) | Collect and curate personal story libraries |
+| [Story Directories](../features/story-directories.md) | Browse structured regions to discover new territories |
+| [Word Count](../features/word-count.md) | See story length as a completionism signal |
+| [Reading Duration](../features/reading-duration.md) | Track reading investment |
+| [Deep Search](../features/deep-search.md) | Hunt for stories by motif or keyword |
+| [Adaption Switcher](../features/adaption-switcher.md) | Unlock and compare story variants |
+
 ## Strategic Opportunity
 
 Massive engagement driver — transforms passive reading into active exploration. Particularly effective for driving breadth of corpus coverage (users read more stories to unlock variants).
@@ -17,4 +51,6 @@ Massive engagement driver — transforms passive reading into active exploration
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
+- [Culture Explorers →](04-culture-explorers.md)
+- [Pre-Readers →](01-pre-readers.md)
 - [Product Strategy](../product-strategy.md)

--- a/docs/personas/10-gamified-explorers.md
+++ b/docs/personas/10-gamified-explorers.md
@@ -1,0 +1,20 @@
+# 🧩 Gamified Explorers
+
+**Job-to-be-done:** "I want to discover stories like a game."
+
+## Use Cases
+
+| Feature | Description |
+|---|---|
+| [Story Map](../features/story-map.md) | Visual geographic/thematic discovery map |
+| [Achievements](../features/achievements.md) | Badges for reading streaks, genres, regions |
+| [Choice Narratives](../features/choice-narratives.md) | Branching narratives with player decisions |
+
+## Strategic Opportunity
+
+Massive engagement driver — transforms passive reading into active exploration. Particularly effective for driving breadth of corpus coverage (users read more stories to unlock variants).
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/docs/product-strategy.md
+++ b/docs/product-strategy.md
@@ -1,0 +1,103 @@
+# Product Strategy — "Operating System for Stories"
+
+> Stop thinking "web reader". Think "OS for stories".
+
+---
+
+## The Four Axes
+
+Every feature can be placed on four independent axes. The most valuable features live at interesting intersections.
+
+| Axis | Dimension |
+|---|---|
+| **Consumption** | Reading ↔ Listening |
+| **Depth** | Entertainment ↔ Analysis |
+| **Role** | Consumer ↔ Creator |
+| **Context** | Solo ↔ Social |
+
+---
+
+## High-Value Feature Intersections
+
+| Personas | Axes | Feature Concept |
+|---|---|---|
+| Parents + Audio + Context | Consumption × Social | **Bedtime Mode** — one-tap ritual, curated duration, shared family progress |
+| Educators + Analysis | Depth × Consumer | **Symbol Graph** — visual archetype map across stories |
+| Developers + Creatives | Creator × API | **Story API** — embeddable reader + structured story graph |
+| Therapeutic + Analysis | Depth × Solo | **Reflection Layer** — post-reading journaling prompts + mood tracking |
+| Gamified + Social | Consumer × Social | **Story Map** — geographic discovery with unlocks and achievements |
+| Culture Explorers + Listening | Consumption × Depth | **Parallel Audio** — synchronized narration in multiple languages |
+
+---
+
+## Strategic Pillars
+
+### 1. Story Graph (already started)
+
+The project's `graphify-out/` knowledge graph is a foundation for:
+- Semantic story recommendations
+- Motif and archetype linking across sources
+- Developer API surface
+- Visual exploration UI (Story Map)
+
+### 2. AI Interpretation Layer
+
+Transform static texts into dynamic, persona-aware experiences:
+- Symbol analysis (Jungian archetypes)
+- Cross-cultural variant comparison
+- Mood-based recommendations
+- Journaling prompt generation
+
+### 3. Multimodality
+
+| Mode | Current State | Target |
+|---|---|---|
+| Text | ✓ Paginated reader | Speed reader, parallel texts |
+| Audio | Planned (speed-reader flag) | Full audio-first mode, sleep timer |
+| Interaction | None | Choice-based, tap reactions |
+
+### 4. API-First Architecture
+
+Expose story content as a platform, not just a product:
+- REST/GraphQL story API
+- Embeddable `<story-reader>` web component
+- Prompt-ready structured datasets
+- Webhook/event hooks for integrations
+
+---
+
+## MVP vs. Vision Slicing
+
+### MVP (now — low effort, high signal)
+
+- [ ] Bedtime Mode (timer + curated playlist) → targets Parents
+- [ ] Font/contrast accessibility settings → targets Seniors
+- [ ] Story tagging by mood/theme → enables Therapeutic + Gamified
+- [ ] Basic Story API (read-only, existing content) → targets Developers
+
+### Near-term (next quarter)
+
+- [ ] Audio narration (TTS, character voices) → targets Pre-Readers, Passive Consumers
+- [ ] Parallel text view (2 languages) → targets Culture Explorers
+- [ ] Discussion questions per story (AI) → targets Teachers
+
+### Vision (6–18 months)
+
+- [ ] Story Map (geographic/thematic visual explorer)
+- [ ] Choice-based narrative engine
+- [ ] Full Symbol Graph with archetype UI
+- [ ] Creator tools (remix, style transfer)
+- [ ] B2B educator dashboard
+
+---
+
+## Competitive Positioning
+
+| Product | Strength | Our Gap |
+|---|---|---|
+| Kindle | Vast catalog, ecosystem | Cultural depth, interactivity |
+| Audible | Audio quality, production | Text+audio sync, annotation |
+| Podcasts | Passive consumption | Story structure, discovery |
+| Duolingo | Gamification, language | Story-native, cultural context |
+
+**Differentiation:** No existing product treats fairy tales as a living, interconnected knowledge system. The Story Graph + AI Interpretation Layer is the moat.

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -11,6 +11,7 @@ import { ThemeContext } from './ui/ThemeContext';
 import Toggle from './ui/Toggle';
 import IconButton from './ui/IconButton';
 import ProfilePanel from './components/ProfilePanel';
+import PersonasDocsView from './components/PersonasDocsView';
 import HomeView from './components/HomeView';
 import ReaderView from './components/ReaderView';
 import Sidebar from './components/Sidebar';
@@ -58,6 +59,7 @@ const GrimmMarchenApp = () => {
   const [profileOpen, setProfileOpen] = useState(false);
   const [docsOpen, setDocsOpen] = useState(false);
   const [docsAnchor, setDocsAnchor] = useState(null);
+  const [personasDocsOpen, setPersonasDocsOpen] = useState(false);
   const [activeSource, setActiveSource] = useState(() => localStorage.getItem('wr-last-source') || null);
   const [activeDirectory, setActiveDirectory] = useState(null);
   const [stories, setStories] = useState([]);
@@ -569,7 +571,11 @@ const GrimmMarchenApp = () => {
 
         {/* Reader Area */}
         <main className="flex-1 flex flex-col overflow-hidden w-full">
-          {docsOpen ? (
+          {personasDocsOpen ? (
+            <PersonasDocsView
+              onBack={() => { setPersonasDocsOpen(false); setProfileOpen(true); }}
+            />
+          ) : docsOpen ? (
             <FeatureDocs
               darkMode={darkMode}
               initialAnchor={docsAnchor}
@@ -581,6 +587,7 @@ const GrimmMarchenApp = () => {
             <ProfilePanel
               onBack={() => setProfileOpen(false)}
               onOpenDocs={(anchor) => { setDocsOpen(true); setDocsAnchor(anchor); setProfileOpen(false); }}
+              onOpenPersonasDocs={() => { setPersonasDocsOpen(true); setProfileOpen(false); }}
               favorites={favorites}
               completedStories={completedStories}
               totalStories={stories.length}


### PR DESCRIPTION
Adds docs/personas.md with 10 behavior-pattern-driven personas
(jobs-to-be-done, use cases, opportunities) and docs/product-strategy.md
with the four-axis framework, feature intersections, MVP vs vision
slicing, and competitive positioning.

https://claude.ai/code/session_0147FiQbTWFLNEfbphCVPNGA