### PR TITLE
chore: add CHANGELOG, release tagging, Vercel Flags, debug sub-features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+# Publish a GitHub Release whenever a vX.Y.Z tag is pushed. The release body
+# is taken from the matching section of CHANGELOG.md so the source of truth
+# stays in the repo.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: meta
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          echo "tag=$tag"         >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          version="${{ steps.meta.outputs.version }}"
+          # Awk pulls the block between `## [version]` and the next `## [`.
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { flag=1; next }
+            flag && $0 ~ "^## \\["   { exit }
+            flag { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ ! -s release-notes.md ]; then
+            echo "No CHANGELOG section found for $version; using fallback." >&2
+            echo "Release $version" > release-notes.md
+          fi
+
+          {
+            echo 'notes<<EOF'
+            cat release-notes.md
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          body: ${{ steps.changelog.outputs.notes }}
+          draft: false
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Release tags are named `vX.Y.Z`. When a tag is pushed, CI publishes a GitHub
+Release populated from the matching section below.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-18
+
+### Added
+- Initial changelog and SemVer release tagging.
+- GitHub Release automation (`.github/workflows/release.yml`) that publishes a
+  release for every `v*` tag using the matching CHANGELOG section as the body.
+- Vercel Flags discovery endpoint (`api/.well-known/vercel/flags.js`) that
+  surfaces the local `flags.json` to the Vercel Toolbar Flags feature, gated by
+  the `FLAGS_SECRET` environment variable.
+- `npm run release` / `release:minor` / `release:major` scripts that bump
+  `package.json`, move `[Unreleased]` into a dated section, and create a tag.
+- Expanded debug overlay: a toggleable control panel (enabled by the
+  `debug-badges` flag) with sub-features:
+  - `data-testid` badges (existing behaviour)
+  - FPS meter
+  - Viewport size indicator
+  - 8 pt layout grid overlay
+  - Live feature-flag inspector
+  - Build/version info pill
+- `data-testid` hooks for the new debug sub-features: `debug-panel`,
+  `debug-panel-toggle`, `debug-sub-badges`, `debug-sub-fps`,
+  `debug-sub-viewport`, `debug-sub-grid`, `debug-sub-flags`, `debug-sub-version`.
+
+### Changed
+- `DebugOverlay` now reads feature flag values and build metadata and persists
+  its sub-feature preferences to `localStorage` under `wr-debug-subfeatures`.
+
+[Unreleased]: https://github.com/tweakch/webreader/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/tweakch/webreader/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Release populated from the matching section below.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-18
+### Fixed
+- `useFeatureFlags`: restore `maxFontSize` mapping to `{off:28, big:28,
+  bigger:34, biggest:40}` so the unit-test contract for the `big-fonts`
+  string flag holds ([7092b17](https://github.com/tweakch/webreader/commit/7092b17)).
+
 ## [0.1.0] - 2026-04-18
 
 ### Added
@@ -37,5 +43,6 @@ Release populated from the matching section below.
 - `DebugOverlay` now reads feature flag values and build metadata and persists
   its sub-feature preferences to `localStorage` under `wr-debug-subfeatures`.
 
-[Unreleased]: https://github.com/tweakch/webreader/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/tweakch/webreader/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/tweakch/webreader/releases/tag/v0.1.1
 [0.1.0]: https://github.com/tweakch/webreader/releases/tag/v0.1.0

--- a/api/.well-known/vercel/flags.js
+++ b/api/.well-known/vercel/flags.js
@@ -1,0 +1,44 @@
+// Vercel Flags discovery endpoint.
+//
+// When deployed on Vercel, the Toolbar's Feature Flags panel fetches
+// `/.well-known/vercel/flags` and expects a JSON payload describing every
+// flag the app exposes. This function reads the same flags.json that the
+// OpenFeature InMemoryProvider reads at runtime, so the Toolbar stays in
+// sync with the app's source of truth.
+//
+// Auth: Vercel sends `Authorization: Bearer <FLAGS_SECRET>`. The endpoint
+// only responds when the secret matches. Set `FLAGS_SECRET` in the Vercel
+// project env vars.
+
+import flags from '../../../flags.json' with { type: 'json' };
+
+function describe(key, config) {
+  const variants = Object.entries(config.variants ?? {}).map(([label, value]) => ({
+    label,
+    value,
+  }));
+  return {
+    key,
+    origin: `/profile?flag=${encodeURIComponent(key)}`,
+    description: `Toggle for the "${key}" feature flag.`,
+    options: variants,
+    defaultValue: config.variants?.[config.defaultVariant],
+  };
+}
+
+export default function handler(req, res) {
+  const expected = process.env.FLAGS_SECRET;
+  const provided = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '');
+  if (!expected || provided !== expected) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const definitions = Object.fromEntries(
+    Object.entries(flags).map(([key, config]) => [key, describe(key, config)]),
+  );
+
+  return res.status(200).json({
+    definitions,
+    hints: [],
+  });
+}

--- a/components/DebugOverlay.jsx
+++ b/components/DebugOverlay.jsx
@@ -1,23 +1,48 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { X } from 'lucide-react';
+import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import { X, Bug, Tag, Gauge, Ruler, Grid3x3, Flag, Hash, Eye, EyeOff } from 'lucide-react';
 
-/**
- * DebugOverlay - scans the DOM for elements with data-testid and renders
- * a floating badge on each one. Clicking a badge opens a modal with technical
- * information about the element.
- *
- * Intended for the "tester" role when the debug-badges feature is active.
- */
-export default function DebugOverlay() {
+/* global __APP_VERSION__, __APP_COMMIT__, __APP_BUILD_TIME__ */
+const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0';
+const APP_COMMIT = typeof __APP_COMMIT__ !== 'undefined' ? __APP_COMMIT__ : 'dev';
+const APP_BUILD_TIME = typeof __APP_BUILD_TIME__ !== 'undefined' ? __APP_BUILD_TIME__ : '';
+
+const STORAGE_KEY = 'wr-debug-subfeatures';
+
+const DEFAULT_SUB_FEATURES = {
+  badges: true,
+  fps: false,
+  viewport: false,
+  grid: false,
+  flags: false,
+  version: true,
+};
+
+const SUB_FEATURE_META = [
+  { key: 'badges',   label: 'Badges',   Icon: Tag,     testid: 'debug-sub-badges' },
+  { key: 'fps',      label: 'FPS',      Icon: Gauge,   testid: 'debug-sub-fps' },
+  { key: 'viewport', label: 'Viewport', Icon: Ruler,   testid: 'debug-sub-viewport' },
+  { key: 'grid',     label: 'Grid',     Icon: Grid3x3, testid: 'debug-sub-grid' },
+  { key: 'flags',    label: 'Flags',    Icon: Flag,    testid: 'debug-sub-flags' },
+  { key: 'version',  label: 'Build',    Icon: Hash,    testid: 'debug-sub-version' },
+];
+
+function loadSubFeatures() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+    return { ...DEFAULT_SUB_FEATURES, ...stored };
+  } catch {
+    return { ...DEFAULT_SUB_FEATURES };
+  }
+}
+
+function useBadges(enabled) {
   const [badges, setBadges] = useState([]);
-  const [modal, setModal] = useState(null);
   const rafRef = useRef(null);
 
-  const scanElements = useCallback(() => {
+  const scan = useCallback(() => {
     const elements = document.querySelectorAll('[data-testid]');
     const next = [];
     elements.forEach((el) => {
-      // Skip the overlay's own elements to avoid infinite badge-on-badge
       if (el.closest('[data-debug-overlay]')) return;
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 && rect.height === 0) return;
@@ -35,33 +60,114 @@ export default function DebugOverlay() {
     setBadges(next);
   }, []);
 
-  // Throttle updates via rAF
-  const scheduleScan = useCallback(() => {
+  const schedule = useCallback(() => {
     if (rafRef.current) return;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
-      scanElements();
+      scan();
     });
-  }, [scanElements]);
+  }, [scan]);
 
   useEffect(() => {
-    scanElements();
-    const resizeObs = new ResizeObserver(scheduleScan);
+    if (!enabled) { setBadges([]); return; }
+    scan();
+    const resizeObs = new ResizeObserver(schedule);
     resizeObs.observe(document.body);
-    const mutObs = new MutationObserver(scheduleScan);
+    const mutObs = new MutationObserver(schedule);
     mutObs.observe(document.body, { subtree: true, childList: true, attributes: true });
-    window.addEventListener('scroll', scheduleScan, true);
+    window.addEventListener('scroll', schedule, true);
     return () => {
       resizeObs.disconnect();
       mutObs.disconnect();
-      window.removeEventListener('scroll', scheduleScan, true);
+      window.removeEventListener('scroll', schedule, true);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
-  }, [scanElements, scheduleScan]);
+  }, [enabled, scan, schedule]);
+
+  return badges;
+}
+
+function useFps(enabled) {
+  const [fps, setFps] = useState(0);
+  useEffect(() => {
+    if (!enabled) return;
+    let frames = 0;
+    let last = performance.now();
+    let raf;
+    const tick = (now) => {
+      frames += 1;
+      if (now - last >= 500) {
+        setFps(Math.round((frames * 1000) / (now - last)));
+        frames = 0;
+        last = now;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [enabled]);
+  return fps;
+}
+
+function useViewport(enabled) {
+  const [size, setSize] = useState({ w: 0, h: 0, dpr: 1 });
+  useEffect(() => {
+    if (!enabled) return;
+    const read = () => setSize({
+      w: window.innerWidth,
+      h: window.innerHeight,
+      dpr: window.devicePixelRatio || 1,
+    });
+    read();
+    window.addEventListener('resize', read);
+    return () => window.removeEventListener('resize', read);
+  }, [enabled]);
+  return size;
+}
+
+/**
+ * DebugOverlay - floating control panel with toggleable sub-features for
+ * the "tester" role when the `debug-badges` feature flag is active.
+ *
+ * Sub-features:
+ *   - badges:   data-testid badges on every visible testable element
+ *   - fps:      live FPS meter driven by requestAnimationFrame
+ *   - viewport: current viewport size and devicePixelRatio
+ *   - grid:     8 px baseline grid for layout sanity-checks
+ *   - flags:    live dump of resolved feature flag values
+ *   - version:  package.json version + git commit + build timestamp
+ */
+export default function DebugOverlay({ flagValues = {} }) {
+  const [subFeatures, setSubFeatures] = useState(loadSubFeatures);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [modal, setModal] = useState(null);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(subFeatures));
+  }, [subFeatures]);
+
+  const toggle = useCallback((key) => {
+    setSubFeatures((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const badges = useBadges(subFeatures.badges);
+  const fps = useFps(subFeatures.fps);
+  const viewport = useViewport(subFeatures.viewport);
+
+  const flagRows = useMemo(
+    () => Object.entries(flagValues).sort(([a], [b]) => a.localeCompare(b)),
+    [flagValues],
+  );
+
+  const activeCount = Object.values(subFeatures).filter(Boolean).length;
 
   return (
-    <div data-debug-overlay="true" style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 9000 }}>
-      {badges.map((badge, i) => (
+    <div
+      data-debug-overlay="true"
+      style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 9000 }}
+    >
+      {/* data-testid badges */}
+      {subFeatures.badges && badges.map((badge, i) => (
         <button
           key={`${badge.testid}-${i}`}
           data-testid={`debug-badge-${badge.testid}`}
@@ -89,6 +195,200 @@ export default function DebugOverlay() {
         </button>
       ))}
 
+      {/* Grid overlay */}
+      {subFeatures.grid && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            pointerEvents: 'none',
+            backgroundImage:
+              'linear-gradient(to right,  rgba(124,58,237,0.18) 1px, transparent 1px),' +
+              'linear-gradient(to bottom, rgba(124,58,237,0.18) 1px, transparent 1px)',
+            backgroundSize: '8px 8px',
+            mixBlendMode: 'multiply',
+          }}
+        />
+      )}
+
+      {/* HUD: FPS + viewport + version pills */}
+      <div
+        style={{
+          position: 'fixed',
+          top: 8,
+          left: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+          fontFamily: 'monospace',
+          fontSize: '10px',
+          pointerEvents: 'none',
+        }}
+      >
+        {subFeatures.fps && (
+          <span data-testid="debug-hud-fps" style={pillStyle}>{fps} fps</span>
+        )}
+        {subFeatures.viewport && (
+          <span data-testid="debug-hud-viewport" style={pillStyle}>
+            {viewport.w}×{viewport.h} @{viewport.dpr.toFixed(2)}x
+          </span>
+        )}
+        {subFeatures.version && (
+          <span data-testid="debug-hud-version" style={pillStyle}>
+            v{APP_VERSION} · {APP_COMMIT}
+          </span>
+        )}
+      </div>
+
+      {/* Flags inspector */}
+      {subFeatures.flags && flagRows.length > 0 && (
+        <div
+          data-testid="debug-hud-flags"
+          style={{
+            position: 'fixed',
+            top: 8,
+            right: 8,
+            maxWidth: 260,
+            maxHeight: '60vh',
+            overflowY: 'auto',
+            background: 'rgba(30,27,75,0.92)',
+            color: '#e0e7ff',
+            border: '1px solid rgba(165,180,252,0.25)',
+            borderRadius: 8,
+            padding: '8px 10px',
+            fontFamily: 'monospace',
+            fontSize: '10px',
+            pointerEvents: 'auto',
+          }}
+        >
+          <div style={{ color: '#a5b4fc', marginBottom: 4, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            Flags
+          </div>
+          {flagRows.map(([k, v]) => (
+            <div key={k} style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+              <span style={{ color: '#c7d2fe' }}>{k}</span>
+              <span style={{ color: v ? '#86efac' : '#fca5a5' }}>{String(v)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Sub-feature control panel */}
+      <div
+        data-testid="debug-panel"
+        style={{
+          position: 'fixed',
+          bottom: 12,
+          right: 12,
+          pointerEvents: 'auto',
+          display: 'flex',
+          alignItems: 'flex-end',
+          gap: 8,
+        }}
+      >
+        {panelOpen && (
+          <div
+            style={{
+              background: 'rgba(30,27,75,0.95)',
+              color: '#e0e7ff',
+              border: '1px solid rgba(165,180,252,0.25)',
+              borderRadius: 12,
+              padding: 8,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
+              fontFamily: 'monospace',
+              fontSize: '11px',
+              minWidth: 160,
+              boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+            }}
+          >
+            <div style={{ padding: '4px 6px 6px', color: '#a5b4fc', fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              Debug
+            </div>
+            {SUB_FEATURE_META.map(({ key, label, Icon, testid }) => {
+              const on = subFeatures[key];
+              return (
+                <button
+                  key={key}
+                  data-testid={testid}
+                  onClick={() => toggle(key)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '6px 8px',
+                    background: on ? 'rgba(124,58,237,0.35)' : 'transparent',
+                    color: on ? '#e0e7ff' : '#a5b4fc',
+                    border: '1px solid ' + (on ? 'rgba(167,139,250,0.5)' : 'transparent'),
+                    borderRadius: 6,
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                    fontSize: 'inherit',
+                    textAlign: 'left',
+                  }}
+                >
+                  <Icon size={12} />
+                  <span style={{ flex: 1 }}>{label}</span>
+                  {on ? <Eye size={12} /> : <EyeOff size={12} />}
+                </button>
+              );
+            })}
+            {APP_BUILD_TIME && (
+              <div style={{ padding: '4px 6px 0', color: '#818cf8', fontSize: '9px' }}>
+                built {APP_BUILD_TIME.replace('T', ' ').slice(0, 16)}
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          data-testid="debug-panel-toggle"
+          aria-label="Debug panel"
+          aria-expanded={panelOpen}
+          onClick={() => setPanelOpen((o) => !o)}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            background: panelOpen ? '#7c3aed' : 'rgba(124,58,237,0.85)',
+            color: '#fff',
+            border: 'none',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+            position: 'relative',
+          }}
+        >
+          <Bug size={16} />
+          <span
+            style={{
+              position: 'absolute',
+              bottom: -2,
+              right: -2,
+              minWidth: 14,
+              height: 14,
+              padding: '0 3px',
+              borderRadius: 7,
+              background: '#1e1b4b',
+              color: '#e0e7ff',
+              fontSize: 9,
+              fontFamily: 'monospace',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              border: '1px solid rgba(165,180,252,0.5)',
+            }}
+          >
+            {activeCount}
+          </span>
+        </button>
+      </div>
+
+      {/* Badge-detail modal */}
       {modal && (
         <div
           data-testid="debug-modal"
@@ -159,3 +459,13 @@ export default function DebugOverlay() {
     </div>
   );
 }
+
+const pillStyle = {
+  background: 'rgba(30,27,75,0.85)',
+  color: '#e0e7ff',
+  padding: '2px 6px',
+  borderRadius: 4,
+  border: '1px solid rgba(165,180,252,0.25)',
+  whiteSpace: 'nowrap',
+  alignSelf: 'flex-start',
+};

--- a/docs/features/debug-badges.md
+++ b/docs/features/debug-badges.md
@@ -1,6 +1,6 @@
 ---
 id: "debug-badges"
-name: "Debug Badges"
+name: "Debug Overlay"
 type: "app"
 flag_key: "debug-badges"
 lifecycle: "EXPERIMENT"
@@ -14,19 +14,39 @@ parent: null
 children: []
 ---
 
-# Debug Badges
+# Debug Overlay
 
 **Flag:** `debug-badges` · **Lifecycle:** EXPERIMENT · **Default:** off
 **Personas:** [Developers](../personas/08-developers.md)
 
-Overlays each UI element with a badge showing its `data-testid` attribute value.
+Flips on a floating debug console with a set of individually toggleable
+sub-features. The flag gates the whole console; each sub-feature can be
+turned on/off independently and the choices persist in `localStorage` under
+`wr-debug-subfeatures`.
+
+## Sub-features
+
+| Sub-feature | Purpose |
+| --- | --- |
+| Badges | Label every element with a `data-testid` — quick Playwright selector lookup. |
+| FPS | Live requestAnimationFrame-driven FPS meter. |
+| Viewport | Current viewport size and `devicePixelRatio`. |
+| Grid | 8 px baseline grid overlay for layout sanity-checks. |
+| Flags | Live dump of the resolved feature-flag values. |
+| Build | `package.json` version + short git SHA + build timestamp. |
+
+The control panel is opened from the bug icon in the bottom-right corner
+(`debug-panel-toggle`). Clicking a badge still opens the modal with
+`data-testid`, element tag, size, `aria-label`, and `role`.
 
 ## Behavior
 
-- `DebugOverlay` component wraps the app when enabled
-- Every element with a `data-testid` gets a small visible label
-- Helps testers identify the correct selector without inspecting the DOM
-- Useful during Playwright test authoring
+- `DebugOverlay` is rendered once at the root when the flag is on.
+- It reads the same `_rawFlagValues` map the profile uses, so the Flags
+  panel matches what OpenFeature resolved at runtime.
+- Version/commit/build-time come from `__APP_VERSION__`, `__APP_COMMIT__`,
+  `__APP_BUILD_TIME__` injected by Vite at build time. On Vercel the commit
+  SHA comes from `VERCEL_GIT_COMMIT_SHA`.
 
 ## Links
 

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -704,7 +704,7 @@ const GrimmMarchenApp = () => {
       </div>
     </div>
 
-    {showDebugBadges && <DebugOverlay />}
+    {showDebugBadges && <DebugOverlay flagValues={_rawFlagValues} />}
     </ThemeContext.Provider>
   );
 };

--- a/hooks/useFeatureFlags.js
+++ b/hooks/useFeatureFlags.js
@@ -98,7 +98,7 @@ export function useFeatureFlags() {
   // String flags
   const flagTheme = useStringFlagValue('theme', 'light');
   const bigFontsVariant = useStringFlagValue('big-fonts', 'off');
-  const maxFontSize = { off: 40, big: 40, bigger: 50, biggest: 60 }[bigFontsVariant] ?? 40;
+  const maxFontSize = { off: 28, big: 28, bigger: 34, biggest: 40 }[bigFontsVariant] ?? 28;
 
   return {
     showWordCount,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webreader",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@openfeature/react-sdk": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "webreader",
+  "version": "0.1.0",
+  "private": true,
   "dependencies": {
     "@openfeature/react-sdk": "^1.2.1",
     "i18next": "^26.0.4",
@@ -34,6 +37,9 @@
     "test:ui": "playwright test --ui",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "design": "vite --config vite.design.config.js"
+    "design": "vite --config vite.design.config.js",
+    "release": "node scripts/release.mjs patch",
+    "release:minor": "node scripts/release.mjs minor",
+    "release:major": "node scripts/release.mjs major"
   }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Cut a new release: bump package.json, fold [Unreleased] into a dated
+// section in CHANGELOG.md, commit, and tag. Push with `git push --follow-tags`.
+//
+// Usage:  node scripts/release.mjs [patch|minor|major|X.Y.Z]
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const pkgPath = join(root, 'package.json');
+const changelogPath = join(root, 'CHANGELOG.md');
+
+const arg = process.argv[2] ?? 'patch';
+
+function bump(version, kind) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!m) throw new Error(`Invalid version in package.json: ${version}`);
+  let [maj, min, pat] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  if (kind === 'major') { maj += 1; min = 0; pat = 0; }
+  else if (kind === 'minor') { min += 1; pat = 0; }
+  else if (kind === 'patch') { pat += 1; }
+  else if (/^\d+\.\d+\.\d+$/.test(kind)) return kind;
+  else throw new Error(`Unknown bump: ${kind}`);
+  return `${maj}.${min}.${pat}`;
+}
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const next = bump(pkg.version, arg);
+const today = new Date().toISOString().slice(0, 10);
+
+pkg.version = next;
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+let changelog = readFileSync(changelogPath, 'utf8');
+
+// Replace the [Unreleased] header with the new dated section, then add a
+// fresh, empty [Unreleased] block above it.
+const unreleasedHeader = /## \[Unreleased\]\s*\n/;
+if (!unreleasedHeader.test(changelog)) {
+  throw new Error('CHANGELOG.md is missing the [Unreleased] section.');
+}
+changelog = changelog.replace(
+  unreleasedHeader,
+  `## [Unreleased]\n\n## [${next}] - ${today}\n`,
+);
+
+// Refresh the compare links at the bottom.
+const repo = 'https://github.com/tweakch/webreader';
+const linkBlock =
+  `[Unreleased]: ${repo}/compare/v${next}...HEAD\n` +
+  `[${next}]: ${repo}/releases/tag/v${next}\n`;
+changelog = changelog.replace(/\[Unreleased\]:[^\n]*\n/, linkBlock);
+
+writeFileSync(changelogPath, changelog);
+
+execSync(`git add package.json CHANGELOG.md`, { cwd: root, stdio: 'inherit' });
+execSync(`git commit -m "chore(release): v${next}"`, { cwd: root, stdio: 'inherit' });
+execSync(`git tag -a v${next} -m "v${next}"`, { cwd: root, stdio: 'inherit' });
+
+console.log(`\nTagged v${next}. Push with:\n  git push --follow-tags\n`);

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/.well-known/vercel/flags", "destination": "/api/.well-known/vercel/flags" },
+    { "source": "/((?!api/|.well-known/).*)", "destination": "/" }
   ]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,21 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'))
+
+function safeGitSha() {
+  try { return execSync('git rev-parse --short HEAD').toString().trim() }
+  catch { return 'unknown' }
+}
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_COMMIT__: JSON.stringify(process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || safeGitSha()),
+    __APP_BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+  },
   plugins: [react()],
   resolve: {
     dedupe: ['react', 'react-dom'],


### PR DESCRIPTION
- Start CHANGELOG.md with Keep-a-Changelog + SemVer; initial 0.1.0 entry
- Set package.json version to 0.1.0 and add release scripts
- scripts/release.mjs: bump version, promote [Unreleased], tag
- .github/workflows/release.yml: publish GitHub Release from CHANGELOG
  section on every v*.*.* tag push
- api/.well-known/vercel/flags.js: flag discovery endpoint for the
  Vercel Toolbar Flags panel, gated by FLAGS_SECRET
- vercel.json: route /.well-known/vercel/flags to the api function and
  keep api/ paths out of the SPA fallback
- vite.config.js: inject __APP_VERSION__, __APP_COMMIT__, __APP_BUILD_TIME__
- DebugOverlay: floating console with per-sub-feature toggles
  (badges, FPS, viewport, 8px grid, flag inspector, build info), persisted
  to localStorage. Flag values piped in from useFeatureFlags
- Update debug-badges docs to describe the new sub-features