### PR TITLE
feat: add minimal A/B testing framework with sidebar-v2 experiment

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,57 @@
+# Path → label mapping for actions/labeler.
+# Labels must exist in the repo before the action can apply them.
+
+"area:ui":
+  - changed-files:
+      - any-glob-to-any-file:
+          - components/**
+          - ui/**
+          - "*.jsx"
+          - "*.css"
+
+"area:hooks":
+  - changed-files:
+      - any-glob-to-any-file:
+          - hooks/**
+
+"area:flags":
+  - changed-files:
+      - any-glob-to-any-file:
+          - flags.json
+          - features.jsx
+          - hooks/useFeatureFlags.js
+          - src/lib/initFeatureFlags.js
+
+"area:crawler":
+  - changed-files:
+      - any-glob-to-any-file:
+          - crawlers/**
+
+"area:tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - tests/**
+          - "**/*.spec.js"
+          - playwright.config.*
+
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - "*.md"
+
+"content":
+  - changed-files:
+      - any-glob-to-any-file:
+          - stories/**
+
+"deps":
+  - changed-files:
+      - any-glob-to-any-file:
+          - package.json
+          - package-lock.json

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec  # v4.6.1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
         with:
           name: playwright-report
           path: test-results/

--- a/components/ABTestingPanel.jsx
+++ b/components/ABTestingPanel.jsx
@@ -1,0 +1,189 @@
+import { FlaskConical, Shield, Trash2 } from 'lucide-react';
+import { useTheme } from '../ui/ThemeContext';
+import Toggle from '../ui/Toggle';
+import { ROLES, ROLE_LABELS } from '../hooks/useRole';
+
+/**
+ * A/B testing panel. Embedded in ProfilePanel.
+ *
+ * Renders:
+ *  - User section (when showAbTesting is on): per-experiment variant pickers,
+ *    limited to experiments the user currently has access to.
+ *  - Admin section (when showAbTestingAdmin is on and isAdmin): full experiment
+ *    list with active toggle, role-access chips, revoke button.
+ */
+export default function ABTestingPanel({
+  showAbTesting,
+  showAbTestingAdmin,
+  isAdmin,
+  experiments,
+  accessibleExperiments,
+  getExperimentConfig,
+  getVariant,
+  setExperimentActive,
+  toggleRoleAccess,
+  revokeExperiment,
+  selectVariant,
+}) {
+  const { dark } = useTheme();
+
+  const showAdmin = showAbTestingAdmin && isAdmin;
+  const showUser = showAbTesting && accessibleExperiments.length > 0;
+
+  if (!showAdmin && !showUser) return null;
+
+  const nonAdminRoles = ROLES.filter((r) => r !== 'admin');
+
+  return (
+    <div className="mt-10 space-y-8" data-testid="ab-testing-panel">
+      {/* User section: variant picker for experiments the user has access to */}
+      {showUser && (
+        <div>
+          <h2 className={`text-xs font-semibold uppercase tracking-wider mb-3 px-1 flex items-center gap-1.5 ${
+            dark ? 'text-amber-500' : 'text-amber-600'
+          }`}>
+            <FlaskConical size={12} />
+            UI-Varianten
+          </h2>
+          <div className={`rounded-2xl border divide-y ${
+            dark ? 'border-amber-700/30 divide-amber-700/30' : 'border-amber-200 divide-amber-200'
+          }`}>
+            {accessibleExperiments.map((exp) => {
+              const current = getVariant(exp.id);
+              return (
+                <div
+                  key={exp.id}
+                  data-testid={`ab-user-experiment-${exp.id}`}
+                  className={`px-5 py-4 ${dark ? 'text-amber-200' : 'text-amber-900'}`}
+                >
+                  <p className="text-sm font-medium">{exp.label}</p>
+                  <p className={`text-xs mt-0.5 leading-relaxed ${dark ? 'text-amber-600' : 'text-amber-500'}`}>
+                    {exp.description}
+                  </p>
+                  <div className={`mt-3 flex rounded-xl border overflow-hidden ${
+                    dark ? 'border-amber-700/40' : 'border-amber-200'
+                  }`}>
+                    {exp.variants.map((v) => {
+                      const active = current === v.id;
+                      return (
+                        <button
+                          key={v.id}
+                          data-testid={`ab-user-variant-${exp.id}-${v.id}`}
+                          onClick={() => selectVariant(exp.id, v.id)}
+                          className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                            active
+                              ? dark ? 'bg-amber-700/50 text-amber-100' : 'bg-amber-100 text-amber-900'
+                              : dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-800'
+                          }`}
+                        >
+                          {v.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <p className={`mt-2 px-1 text-xs ${dark ? 'text-amber-700' : 'text-amber-500'}`}>
+            Du kannst jederzeit zwischen den Varianten wechseln. Dein Feedback hilft uns weiter.
+          </p>
+        </div>
+      )}
+
+      {/* Admin section: full experiment management */}
+      {showAdmin && (
+        <div>
+          <h2 className={`text-xs font-semibold uppercase tracking-wider mb-3 px-1 flex items-center gap-1.5 ${
+            dark ? 'text-violet-400' : 'text-violet-600'
+          }`}>
+            <Shield size={12} />
+            A/B-Verwaltung (Admin)
+          </h2>
+          <div className={`rounded-2xl border divide-y ${
+            dark ? 'border-violet-800/40 divide-violet-800/40' : 'border-violet-200 divide-violet-200'
+          }`}>
+            {experiments.map((exp) => {
+              const cfg = getExperimentConfig(exp.id);
+              return (
+                <div
+                  key={exp.id}
+                  data-testid={`ab-admin-experiment-${exp.id}`}
+                  className={`px-5 py-4 ${dark ? 'text-amber-200' : 'text-amber-900'}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium">{exp.label}</p>
+                      <p className={`text-xs mt-0.5 leading-relaxed ${dark ? 'text-amber-600' : 'text-amber-500'}`}>
+                        {exp.description}
+                      </p>
+                      <p className={`text-[11px] mt-1 ${dark ? 'text-amber-700' : 'text-amber-400'}`}>
+                        Varianten: {exp.variants.map((v) => v.label).join(' · ')}
+                      </p>
+                    </div>
+                    <div data-testid={`ab-admin-active-${exp.id}`}>
+                      <Toggle
+                        checked={!!cfg.active}
+                        onChange={() => setExperimentActive(exp.id, !cfg.active)}
+                        label={`Aktiv: ${exp.label}`}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-2 mt-3 flex-wrap">
+                    <span className={`text-[10px] uppercase tracking-wider ${
+                      dark ? 'text-amber-700' : 'text-amber-400'
+                    }`}>
+                      Zugriff:
+                    </span>
+                    {nonAdminRoles.map((r) => {
+                      const assigned = cfg.allowedRoles?.includes(r);
+                      return (
+                        <button
+                          key={r}
+                          data-testid={`ab-admin-role-${exp.id}-${r}`}
+                          onClick={() => toggleRoleAccess(exp.id, r)}
+                          disabled={!cfg.active}
+                          className={`text-[10px] font-medium px-2 py-0.5 rounded-full border transition-colors disabled:opacity-30 ${
+                            assigned
+                              ? dark
+                                ? 'bg-violet-700/60 border-violet-500 text-violet-200'
+                                : 'bg-violet-100 border-violet-400 text-violet-800'
+                              : dark
+                                ? 'border-amber-800/50 text-amber-800 hover:text-amber-600'
+                                : 'border-amber-300 text-amber-400 hover:text-amber-600'
+                          }`}
+                        >
+                          {ROLE_LABELS[r]}
+                        </button>
+                      );
+                    })}
+                    <span className={`ml-auto text-[10px] ${dark ? 'text-amber-700' : 'text-amber-400'}`}>
+                      (Admin hat immer Zugriff)
+                    </span>
+                    <button
+                      data-testid={`ab-admin-revoke-${exp.id}`}
+                      onClick={() => revokeExperiment(exp.id)}
+                      title="Experiment deaktivieren und alle Rollen-Freigaben zurücknehmen"
+                      className={`inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full border transition-colors ${
+                        dark
+                          ? 'border-red-800/60 text-red-400 hover:bg-red-900/30'
+                          : 'border-red-200 text-red-600 hover:bg-red-50'
+                      }`}
+                    >
+                      <Trash2 size={10} />
+                      Widerrufen
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <p className={`mt-2 px-1 text-xs ${dark ? 'text-amber-700' : 'text-amber-500'}`}>
+            „Aktiv" schaltet das Experiment ein. Zuweisungen bestimmen, welche Rollen die Variante wählen dürfen.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ProfilePanel.jsx
+++ b/components/ProfilePanel.jsx
@@ -2,6 +2,7 @@ import { ChevronLeft, X, User, Shield, FlameKindling, Users } from 'lucide-react
 import { useTheme } from '../ui/ThemeContext';
 import Toggle from '../ui/Toggle';
 import { ROLES, ROLE_LABELS } from '../hooks/useRole';
+import ABTestingPanel from './ABTestingPanel';
 
 /**
  * Profile panel - user stats, word blacklist, feature toggles, and admin tools.
@@ -34,6 +35,10 @@ export default function ProfilePanel({
   // Error page simulator
   showErrorPageSimulator,
   onSimulateError,
+  // A/B testing
+  showAbTesting,
+  showAbTestingAdmin,
+  ab,
 }) {
   const { dark, hc, tc } = useTheme();
 
@@ -358,6 +363,23 @@ export default function ProfilePanel({
             })}
           </div>
         </div>
+
+        {/* A/B testing panel */}
+        {ab && (
+          <ABTestingPanel
+            showAbTesting={showAbTesting}
+            showAbTestingAdmin={showAbTestingAdmin}
+            isAdmin={isAdmin}
+            experiments={ab.experiments}
+            accessibleExperiments={ab.accessibleExperiments}
+            getExperimentConfig={ab.getExperimentConfig}
+            getVariant={ab.getVariant}
+            setExperimentActive={ab.setExperimentActive}
+            toggleRoleAccess={ab.toggleRoleAccess}
+            revokeExperiment={ab.revokeExperiment}
+            selectVariant={ab.selectVariant}
+          />
+        )}
       </div>
     </div>
   );

--- a/components/SidebarV2.jsx
+++ b/components/SidebarV2.jsx
@@ -1,0 +1,371 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { ChevronDown, ChevronRight, Heart, User, LogOut, Sparkles } from 'lucide-react';
+import { useTheme } from '../ui/ThemeContext';
+import SearchInput from '../ui/SearchInput';
+import StoryButton from '../ui/StoryButton';
+
+/**
+ * SidebarV2 — experimental A/B variant of the sidebar.
+ *
+ * Improvements over the original:
+ *  - Tree view: all sources (and directories) on one page, expand/collapse in place.
+ *    No back-buttons, no drill-down navigation; users can see multiple sources at once.
+ *  - Keyboard navigation: j/k or arrow keys to move between visible stories, Enter to open.
+ *  - Persistent expansion state (remembers which sources are open).
+ *  - Compact "variant" badge so users know they are in the A/B test.
+ *  - Same favourites / search / deep-search behaviour.
+ */
+export default function SidebarV2({
+  menuOpen,
+  onMenuToggle,
+  searchTerm,
+  onSearchChange,
+  showDeepSearch,
+  favoritesOnly,
+  onToggleFavoritesOnly,
+  showFavoritesOnlyToggle,
+  showFavorites,
+  selectedStory,
+  activeSource,
+  onSelectSource,
+  showStoryDirectories,
+  directoriesBySource,
+  onSelectStory,
+  completedStories,
+  favorites,
+  onToggleFavorite,
+  showWordCount,
+  showReadingDuration,
+  storyWordCount,
+  readingMinutes,
+  favoriteStories,
+  filteredStories,
+  sources,
+  storiesBySource,
+  onOpenProfile,
+  profileOpen,
+  onCloseProfile,
+  onCloseApp,
+}) {
+  const { dark: darkMode } = useTheme();
+
+  const EXPANDED_KEY = 'wr-sidebar-v2-expanded';
+  const [expandedSources, setExpandedSources] = useState(() => {
+    const stored = localStorage.getItem(EXPANDED_KEY);
+    if (stored) {
+      try { return new Set(JSON.parse(stored)); } catch { /* fall through */ }
+    }
+    return new Set(activeSource ? [activeSource] : []);
+  });
+  const [expandedDirs, setExpandedDirs] = useState(new Set());
+
+  useEffect(() => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify([...expandedSources]));
+  }, [expandedSources]);
+
+  useEffect(() => {
+    if (activeSource && !expandedSources.has(activeSource)) {
+      setExpandedSources((prev) => new Set([...prev, activeSource]));
+    }
+  }, [activeSource]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const toggleSource = (id) => {
+    setExpandedSources((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+    onSelectSource(id);
+  };
+
+  const toggleDir = (key) => {
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  // Build the flat list of visible stories for keyboard navigation.
+  const visibleStoriesFlat = useMemo(() => {
+    if (searchTerm) return filteredStories;
+    if (favoritesOnly && showFavorites) return favoriteStories;
+    const out = [];
+    for (const src of sources) {
+      if (!expandedSources.has(src.id)) continue;
+      const srcStories = storiesBySource[src.id] ?? [];
+      const dirs = showStoryDirectories ? (directoriesBySource[src.id] ?? []) : [];
+      if (dirs.length === 0) {
+        out.push(...srcStories);
+      } else {
+        for (const dir of dirs) {
+          const dirKey = `${src.id}::${dir.id}`;
+          if (!expandedDirs.has(dirKey)) continue;
+          out.push(...srcStories.filter((s) => s.directory === dir.id));
+        }
+      }
+    }
+    return out;
+  }, [sources, storiesBySource, directoriesBySource, expandedSources, expandedDirs, searchTerm, filteredStories, favoritesOnly, showFavorites, favoriteStories, showStoryDirectories]);
+
+  const [focusIdx, setFocusIdx] = useState(-1);
+  const asideRef = useRef(null);
+
+  useEffect(() => {
+    if (!menuOpen && window.matchMedia('(max-width: 1024px)').matches) return undefined;
+
+    const onKey = (e) => {
+      if (!asideRef.current?.contains(document.activeElement) && document.activeElement !== document.body) return;
+      if (visibleStoriesFlat.length === 0) return;
+
+      if (e.key === 'j' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setFocusIdx((i) => Math.min(visibleStoriesFlat.length - 1, i + 1));
+      } else if (e.key === 'k' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setFocusIdx((i) => Math.max(0, i - 1));
+      } else if (e.key === 'Enter' && focusIdx >= 0) {
+        e.preventDefault();
+        const story = visibleStoriesFlat[focusIdx];
+        if (story) {
+          onSelectStory(story);
+          onMenuToggle();
+          if (profileOpen) onCloseProfile();
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visibleStoriesFlat, focusIdx, onSelectStory, onMenuToggle, profileOpen, onCloseProfile, menuOpen]);
+
+  // Reset keyboard focus when the visible set changes substantially.
+  useEffect(() => { setFocusIdx(-1); }, [searchTerm, favoritesOnly, expandedSources]);
+
+  const renderStory = (story, idx) => (
+    <StoryButton
+      key={story.id}
+      story={story}
+      isActive={selectedStory?.id === story.id}
+      isCompleted={completedStories.has(story.id)}
+      isFavorite={favorites.has(story.id)}
+      showWordCount={showWordCount}
+      showFavoriteButton={showFavorites}
+      testId="story-button"
+      className={focusIdx === idx ? (darkMode ? 'ring-2 ring-amber-400 rounded-lg' : 'ring-2 ring-amber-500 rounded-lg') : ''}
+      onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+      onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
+    />
+  );
+
+  const sourceHeader = (src, isOpen) => (
+    <button
+      key={`src-${src.id}`}
+      data-testid="source-button"
+      onClick={() => toggleSource(src.id)}
+      className={`w-full flex items-center gap-2 px-3 py-2.5 rounded-lg transition-all ${
+        darkMode ? 'text-amber-100 hover:bg-slate-800' : 'text-amber-900 hover:bg-amber-100'
+      }`}
+    >
+      {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+      <span className="font-serif text-base truncate flex-1 text-left">{src.label}</span>
+      <span className={`text-xs tabular-nums ${darkMode ? 'text-amber-400' : 'text-amber-700'}`}>
+        {src.count}
+      </span>
+    </button>
+  );
+
+  const dirHeader = (src, dir, isOpen) => {
+    const key = `${src.id}::${dir.id}`;
+    return (
+      <button
+        key={`dir-${key}`}
+        data-testid="directory-button"
+        onClick={() => toggleDir(key)}
+        className={`w-full flex items-center gap-2 pl-6 pr-3 py-2 rounded-lg transition-all text-sm ${
+          darkMode ? 'text-amber-200 hover:bg-slate-800' : 'text-amber-800 hover:bg-amber-50'
+        }`}
+      >
+        {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <span className="font-serif truncate flex-1 text-left">{dir.label}</span>
+        <span className={`text-xs tabular-nums ${darkMode ? 'text-amber-500' : 'text-amber-600'}`}>
+          {dir.count}
+        </span>
+      </button>
+    );
+  };
+
+  return (
+    <aside
+      ref={asideRef}
+      data-testid="sidebar-v2"
+      className={`fixed lg:static top-16 bottom-0 left-0 w-80 lg:w-72 z-30 transform transition-transform duration-300 flex flex-col ${
+        menuOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+      } ${
+        darkMode
+          ? 'bg-slate-950/95 border-amber-700/30'
+          : 'bg-white/95 border-amber-200/50'
+      } border-r backdrop-blur-sm`}
+    >
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {/* Variant badge */}
+        <div className={`flex items-center gap-1.5 px-4 pt-3 text-[11px] font-semibold uppercase tracking-wider ${
+          darkMode ? 'text-violet-400' : 'text-violet-600'
+        }`}>
+          <Sparkles size={12} />
+          <span>Seitenleiste v2 · Beta</span>
+        </div>
+
+        {/* Search */}
+        <div className="px-4 pt-2 pb-3">
+          <div className="flex items-center gap-2">
+            <SearchInput
+              value={searchTerm}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Märchen suchen…"
+            />
+            {showFavoritesOnlyToggle && showFavorites && (
+              <button
+                onClick={() => onToggleFavoritesOnly()}
+                title={favoritesOnly ? 'Alle anzeigen' : 'Nur Favoriten'}
+                className={`flex-shrink-0 p-2 rounded-lg border transition-colors ${
+                  favoritesOnly
+                    ? darkMode ? 'bg-amber-700 border-amber-600 text-white' : 'bg-amber-200 border-amber-300 text-amber-900'
+                    : darkMode ? 'border-amber-700/50 text-amber-600 hover:text-amber-400 hover:bg-slate-800' : 'border-amber-300 text-amber-400 hover:text-amber-700 hover:bg-amber-50'
+                }`}
+              >
+                <Heart size={16} fill={favoritesOnly ? 'currentColor' : 'none'} />
+              </button>
+            )}
+          </div>
+          {showDeepSearch && (
+            <p className={`mt-2 px-1 text-xs ${darkMode ? 'text-amber-600' : 'text-amber-700'}`}>
+              Tiefensuche aktiv: Treffer im Inhalt werden nachgeladen.
+            </p>
+          )}
+          <p className={`mt-2 px-1 text-[11px] ${darkMode ? 'text-amber-700' : 'text-amber-500'}`}>
+            Tastatur: j/k blättern, Enter öffnet.
+          </p>
+        </div>
+
+        {/* Word count / reading duration */}
+        {selectedStory && (showWordCount || showReadingDuration) && (
+          <div className={`mx-4 mb-2 rounded-xl px-4 py-3 space-y-1.5 ${
+            darkMode ? 'bg-slate-800' : 'bg-amber-50'
+          }`}>
+            {showWordCount && (
+              <div className={`flex items-center justify-between text-sm ${darkMode ? 'text-amber-400' : 'text-amber-700'}`}>
+                <span>Wörter</span>
+                <span className="tabular-nums font-medium">{storyWordCount.toLocaleString('de')}</span>
+              </div>
+            )}
+            {showReadingDuration && (
+              <div className={`flex items-center justify-between text-sm ${darkMode ? 'text-amber-400' : 'text-amber-700'}`}>
+                <span>Lesezeit</span>
+                <span className="tabular-nums font-medium">~{readingMinutes} min</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Content area */}
+        <div className="px-3 pb-4 space-y-1">
+          {favoritesOnly && showFavorites ? (
+            favoriteStories.length === 0 ? (
+              <p className={`px-2 py-3 text-sm ${darkMode ? 'text-amber-600' : 'text-amber-700'}`}>Keine Favoriten</p>
+            ) : favoriteStories.map((s, i) => renderStory(s, i))
+          ) : searchTerm ? (
+            filteredStories.length === 0 ? (
+              <p className={`px-2 py-3 text-sm ${darkMode ? 'text-amber-600' : 'text-amber-700'}`}>Keine Ergebnisse</p>
+            ) : filteredStories.map((s, i) => (
+              <StoryButton
+                key={s.id}
+                story={s}
+                isActive={selectedStory?.id === s.id}
+                isCompleted={completedStories.has(s.id)}
+                isFavorite={favorites.has(s.id)}
+                showSourceBadge
+                showWordCount={showWordCount}
+                showFavoriteButton={showFavorites}
+                inlineBadges
+                className={focusIdx === i ? (darkMode ? 'ring-2 ring-amber-400 rounded-lg' : 'ring-2 ring-amber-500 rounded-lg') : ''}
+                onClick={() => { onSelectStory(s); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+                onFavoriteClick={(e) => onToggleFavorite(s.id, e)}
+              />
+            ))
+          ) : (
+            (() => {
+              let idxCursor = 0;
+              return sources.map((src) => {
+                const isOpen = expandedSources.has(src.id);
+                const srcStories = storiesBySource[src.id] ?? [];
+                const dirs = showStoryDirectories ? (directoriesBySource[src.id] ?? []) : [];
+                const rows = [sourceHeader(src, isOpen)];
+                if (isOpen) {
+                  if (dirs.length === 0) {
+                    for (const story of srcStories) {
+                      rows.push(
+                        <div key={`s-${story.id}`} className="pl-4">
+                          {renderStory(story, idxCursor)}
+                        </div>
+                      );
+                      idxCursor++;
+                    }
+                  } else {
+                    for (const dir of dirs) {
+                      const dirKey = `${src.id}::${dir.id}`;
+                      const dirOpen = expandedDirs.has(dirKey);
+                      rows.push(dirHeader(src, dir, dirOpen));
+                      if (dirOpen) {
+                        for (const story of srcStories.filter((s) => s.directory === dir.id)) {
+                          rows.push(
+                            <div key={`s-${story.id}`} className="pl-8">
+                              {renderStory(story, idxCursor)}
+                            </div>
+                          );
+                          idxCursor++;
+                        }
+                      }
+                    }
+                  }
+                }
+                return rows;
+              });
+            })()
+          )}
+        </div>
+      </div>
+
+      {/* Bottom actions */}
+      <div className={`flex-shrink-0 border-t ${darkMode ? 'border-amber-700/30' : 'border-amber-200/50'}`}>
+        <button
+          onClick={() => { onOpenProfile(); onMenuToggle(); }}
+          className={`w-full flex items-center gap-3 px-4 py-3.5 transition-colors ${
+            profileOpen
+              ? darkMode ? 'bg-amber-700/20 text-amber-200' : 'bg-amber-100 text-amber-900'
+              : darkMode ? 'text-amber-400 hover:bg-slate-800 hover:text-amber-200' : 'text-amber-700 hover:bg-amber-50 hover:text-amber-900'
+          }`}
+        >
+          <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${darkMode ? 'bg-slate-700' : 'bg-amber-100'}`}>
+            <User size={16} />
+          </div>
+          <div className="flex-1 min-w-0 text-left">
+            <p className="text-sm font-medium truncate">Mein Profil</p>
+          </div>
+          <ChevronRight size={14} className="flex-shrink-0 opacity-50" />
+        </button>
+        <button
+          data-testid="close-app-button"
+          onClick={onCloseApp}
+          className={`w-full flex items-center justify-center gap-2 px-4 py-3.5 border-t transition-colors ${
+            darkMode
+              ? 'border-amber-700/30 text-amber-500 hover:bg-slate-800 hover:text-amber-300'
+              : 'border-amber-200/50 text-amber-700 hover:bg-amber-50 hover:text-amber-900'
+          }`}
+        >
+          <LogOut size={16} />
+          <span className="text-sm font-medium">App schließen</span>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/features.jsx
+++ b/features.jsx
@@ -26,6 +26,8 @@ import {
   Crosshair,
   FlameKindling,
   Lock,
+  FlaskConical,
+  Beaker,
 } from 'lucide-react';
 
 export const FEATURES = [
@@ -207,5 +209,17 @@ export const FEATURES = [
     label: 'App-Animation',
     description: 'Einführungs- und Abschluss-Animation mit „Swipe to Unlock" und „Swipe to Close".',
     Icon: () => <Lock size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'ab-testing',
+    label: 'UI-Varianten (A/B)',
+    description: 'Ermöglicht das Wechseln zwischen Original- und Testvarianten der Oberfläche im Profil.',
+    Icon: () => <Beaker size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'ab-testing-admin',
+    label: 'A/B-Verwaltung',
+    description: 'Admin-Werkzeug zum Aktivieren, Deaktivieren und Zuteilen von UI-Varianten an Rollen.',
+    Icon: () => <FlaskConical size={20} strokeWidth={1.75} />,
   },
 ];

--- a/flags.json
+++ b/flags.json
@@ -25,5 +25,7 @@
   "hero-tagline":        { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "subscriber-fonts":       { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "error-page-simulator":   { "defaultVariant": "off", "variants": { "on": true, "off": false } },
-  "app-animation":          { "defaultVariant": "off", "variants": { "on": true, "off": false } }
+  "app-animation":          { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "ab-testing":             { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "ab-testing-admin":       { "defaultVariant": "off", "variants": { "on": true, "off": false } }
 }

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -7,6 +7,7 @@ import { usePersistence } from './hooks/usePersistence';
 import { useReader } from './hooks/useReader';
 import FeatureDocs from './FeatureDocs';
 import { useRole } from './hooks/useRole';
+import { useABTesting } from './hooks/useABTesting';
 import { ThemeContext } from './ui/ThemeContext';
 import Toggle from './ui/Toggle';
 import IconButton from './ui/IconButton';
@@ -15,6 +16,7 @@ import PersonasDocsView from './components/PersonasDocsView';
 import HomeView from './components/HomeView';
 import ReaderView from './components/ReaderView';
 import Sidebar from './components/Sidebar';
+import SidebarV2 from './components/SidebarV2';
 import TypographyPanel, { LINE_HEIGHTS, WORD_SPACINGS, FONT_FAMILIES } from './ui/TypographyPanel';
 import AudioPlayer from './ui/AudioPlayer';
 import SpeedReaderView from './ui/SpeedReaderView';
@@ -40,6 +42,7 @@ const GrimmMarchenApp = () => {
     showTapZones, showTapMiddleToggle, showAdaptionSwitcher, showTypographyPanel, showAttribution,
     showFavorites, showFavoritesOnlyToggle, showAudioPlayer, showHighContrastTheme,
     showSpeedReader, showSpeedreaderOrp, showWordBlacklist, showDeepSearch, showStoryDirectories, showDebugBadges, showSubscriberFonts, showErrorPageSimulator, showAppAnimation,
+    showAbTesting, showAbTestingAdmin,
     _rawFlagValues,
     userFeatureOverrides, setUserFeatureOverrides, _o,
     flagTheme, bigFontsVariant,
@@ -49,6 +52,10 @@ const GrimmMarchenApp = () => {
   const {
     role, setRole, isAdmin, visibleFeatureKeys, isFeatureAssignedToRole, toggleFeatureForRole,
   } = useRole();
+
+  // A/B testing
+  const ab = useABTesting({ role, isAdmin });
+  const sidebarVariant = ab.getVariant('sidebar');
 
   // Typography
   const typo = useTypography({ maxFontSize, subscriberFonts: showSubscriberFonts });
@@ -524,8 +531,11 @@ const GrimmMarchenApp = () => {
 
       {/* Main Content Area */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Sidebar */}
-        <Sidebar
+        {/* Sidebar (A/B variant selection via useABTesting) */}
+        {(() => {
+          const SidebarComponent = sidebarVariant === 'v2' ? SidebarV2 : Sidebar;
+          return (
+        <SidebarComponent
           menuOpen={menuOpen}
           onMenuToggle={() => setMenuOpen(false)}
           searchTerm={searchTerm}
@@ -559,6 +569,8 @@ const GrimmMarchenApp = () => {
           onCloseProfile={() => setProfileOpen(false)}
           onCloseApp={handleCloseApp}
         />
+          );
+        })()}
 
         {/* Hidden measurement container - off-screen, used to calculate paragraph heights */}
         <div
@@ -612,6 +624,9 @@ const GrimmMarchenApp = () => {
               isFeatureAssignedToRole={isFeatureAssignedToRole}
               toggleFeatureForRole={toggleFeatureForRole}
               showErrorPageSimulator={showErrorPageSimulator}
+              showAbTesting={showAbTesting}
+              showAbTestingAdmin={showAbTestingAdmin}
+              ab={ab}
               onSimulateError={(type) => {
                 if (type === 'not-found') {
                   window.location.assign('/does-not-exist');

--- a/hooks/useABTesting.js
+++ b/hooks/useABTesting.js
@@ -1,0 +1,116 @@
+import { useState, useEffect, useCallback } from 'react';
+import { AB_EXPERIMENTS, AB_DEFAULT_CONFIG, getExperiment } from '../src/lib/abExperiments';
+
+const CONFIG_KEY = 'wr-ab-experiments';
+const VARIANTS_KEY = 'wr-ab-variants';
+
+/**
+ * A/B testing hook.
+ *
+ * Two persisted stores:
+ *   - wr-ab-experiments: admin-controlled config per experiment
+ *       { [expId]: { active: boolean, allowedRoles: string[] } }
+ *   - wr-ab-variants: user-selected variant per experiment
+ *       { [expId]: variantId }
+ *
+ * Returns resolved variants (user choice when allowed, otherwise defaultVariant)
+ * plus admin and user mutators.
+ */
+export function useABTesting({ role, isAdmin }) {
+  const [config, setConfig] = useState(() => {
+    const stored = localStorage.getItem(CONFIG_KEY);
+    return stored ? JSON.parse(stored) : AB_DEFAULT_CONFIG;
+  });
+
+  const [userVariants, setUserVariants] = useState(() => {
+    const stored = localStorage.getItem(VARIANTS_KEY);
+    return stored ? JSON.parse(stored) : {};
+  });
+
+  useEffect(() => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+  }, [config]);
+
+  useEffect(() => {
+    localStorage.setItem(VARIANTS_KEY, JSON.stringify(userVariants));
+  }, [userVariants]);
+
+  const getExperimentConfig = useCallback(
+    (id) => config[id] ?? { active: false, allowedRoles: [] },
+    [config],
+  );
+
+  const hasAccess = useCallback(
+    (id) => {
+      const cfg = getExperimentConfig(id);
+      if (!cfg.active) return false;
+      if (isAdmin) return true;
+      return cfg.allowedRoles.includes(role);
+    },
+    [getExperimentConfig, role, isAdmin],
+  );
+
+  const getVariant = useCallback(
+    (id) => {
+      const exp = getExperiment(id);
+      if (!exp) return null;
+      if (!hasAccess(id)) return exp.defaultVariant;
+      const picked = userVariants[id];
+      const isValid = picked && exp.variants.some((v) => v.id === picked);
+      return isValid ? picked : exp.defaultVariant;
+    },
+    [userVariants, hasAccess],
+  );
+
+  // Admin mutators
+  const setExperimentActive = useCallback((id, active) => {
+    setConfig((prev) => ({
+      ...prev,
+      [id]: { ...(prev[id] ?? { allowedRoles: [] }), active },
+    }));
+  }, []);
+
+  const toggleRoleAccess = useCallback((id, targetRole) => {
+    setConfig((prev) => {
+      const cur = prev[id] ?? { active: false, allowedRoles: [] };
+      const has = cur.allowedRoles.includes(targetRole);
+      return {
+        ...prev,
+        [id]: {
+          ...cur,
+          allowedRoles: has
+            ? cur.allowedRoles.filter((r) => r !== targetRole)
+            : [...cur.allowedRoles, targetRole],
+        },
+      };
+    });
+  }, []);
+
+  const revokeExperiment = useCallback((id) => {
+    setConfig((prev) => ({
+      ...prev,
+      [id]: { active: false, allowedRoles: [] },
+    }));
+  }, []);
+
+  // User mutator
+  const selectVariant = useCallback((id, variantId) => {
+    setUserVariants((prev) => ({ ...prev, [id]: variantId }));
+  }, []);
+
+  const accessibleExperiments = AB_EXPERIMENTS.filter((e) => hasAccess(e.id));
+
+  return {
+    experiments: AB_EXPERIMENTS,
+    config,
+    userVariants,
+    accessibleExperiments,
+    getExperimentConfig,
+    getVariant,
+    hasAccess,
+    setExperimentActive,
+    toggleRoleAccess,
+    revokeExperiment,
+    selectVariant,
+  };
+}

--- a/hooks/useFeatureFlags.js
+++ b/hooks/useFeatureFlags.js
@@ -30,6 +30,8 @@ export function useFeatureFlags() {
   const _rawSubscriberFonts = useBooleanFlagValue('subscriber-fonts', false);
   const _rawErrorPageSimulator = useBooleanFlagValue('error-page-simulator', false);
   const _rawAppAnimation = useBooleanFlagValue('app-animation', false);
+  const _rawAbTesting = useBooleanFlagValue('ab-testing', false);
+  const _rawAbTestingAdmin = useBooleanFlagValue('ab-testing-admin', false);
 
   // User feature overrides - stored in localStorage, take precedence over flag defaults
   const [userFeatureOverrides, setUserFeatureOverrides] = useState(() =>
@@ -67,6 +69,8 @@ export function useFeatureFlags() {
   const showSubscriberFonts = _o('subscriber-fonts', _rawSubscriberFonts);
   const showErrorPageSimulator = _o('error-page-simulator', _rawErrorPageSimulator);
   const showAppAnimation = _o('app-animation', _rawAppAnimation);
+  const showAbTesting = _o('ab-testing', _rawAbTesting);
+  const showAbTestingAdmin = _o('ab-testing-admin', _rawAbTestingAdmin);
 
   // Raw values keyed by feature key - used in profile feature toggles
   const _rawFlagValues = {
@@ -93,6 +97,8 @@ export function useFeatureFlags() {
     'subscriber-fonts': _rawSubscriberFonts,
     'error-page-simulator': _rawErrorPageSimulator,
     'app-animation': _rawAppAnimation,
+    'ab-testing': _rawAbTesting,
+    'ab-testing-admin': _rawAbTestingAdmin,
   };
 
   // String flags
@@ -124,6 +130,8 @@ export function useFeatureFlags() {
     showSubscriberFonts,
     showErrorPageSimulator,
     showAppAnimation,
+    showAbTesting,
+    showAbTestingAdmin,
     _rawFlagValues,
     userFeatureOverrides,
     setUserFeatureOverrides,

--- a/hooks/useRole.js
+++ b/hooks/useRole.js
@@ -46,6 +46,7 @@ function defaultRoleFeatures() {
       'speed-reader',
       'speedreader-orp',
       'subscriber-fonts',
+      'ab-testing',
     ],
     tester: [
       'favorites',
@@ -76,6 +77,7 @@ function defaultRoleFeatures() {
       'speedreader-orp',
       'subscriber-fonts',
       'error-page-simulator',
+      'ab-testing',
     ],
   };
 }

--- a/src/lib/abExperiments.js
+++ b/src/lib/abExperiments.js
@@ -1,0 +1,42 @@
+/**
+ * A/B experiment registry.
+ *
+ * Each experiment defines a set of UI variants that can be swapped at runtime.
+ * Admins activate/revoke experiments and grant role access via the A/B admin panel.
+ * Users with the `ab-testing` feature flag can pick a variant at runtime.
+ *
+ * Experiment shape:
+ *   id             - stable identifier, used as the key in variant and config storage
+ *   label          - short human label (German, matches the app)
+ *   description    - one-line purpose of the experiment
+ *   defaultVariant - variant id used when no user selection exists
+ *   variants       - array of { id, label, description? }
+ *
+ * Default admin config (active, allowedRoles) lives in abDefaultConfig and
+ * seeds localStorage['wr-ab-experiments'] on first run. Admins mutate the
+ * localStorage copy via the admin panel.
+ */
+
+export const AB_EXPERIMENTS = [
+  {
+    id: 'sidebar',
+    label: 'Seitenleiste',
+    description: 'Neue Seitenleiste mit hierarchischer Baumansicht, ohne Drill-Down.',
+    defaultVariant: 'control',
+    variants: [
+      { id: 'control', label: 'Original', description: 'Die bestehende Drill-Down-Navigation.' },
+      { id: 'v2',      label: 'Baum v2',  description: 'Alles auf einer Ebene, Quellen ein- und ausklappbar, Tastatur-Navigation.' },
+    ],
+  },
+];
+
+export const AB_DEFAULT_CONFIG = {
+  sidebar: {
+    active: true,
+    allowedRoles: ['tester', 'admin'],
+  },
+};
+
+export function getExperiment(id) {
+  return AB_EXPERIMENTS.find((e) => e.id === id) ?? null;
+}


### PR DESCRIPTION
Introduces two feature flags (ab-testing, ab-testing-admin), an experiment
registry, a useABTesting hook, and an ABTestingPanel that slots into the
profile. Admins can activate, deactivate, revoke and grant role access to
UI variants; subscribers and testers pick variants at runtime.

Ships sidebar-v2 as the inaugural experiment: a tree view that expands
sources in place instead of drilling down, plus j/k keyboard navigation.
Default variant is 'control' so users without access keep the existing UI.

https://claude.ai/code/session_01BwotDEkTAAUocqMNc9qSGh