### PR TITLE
feat(seniors): add text-to-speech and simplified-ui features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Release populated from the matching section below.
 
 ## [Unreleased]
 
+### Added
+- **Senior-targeted features**: two new feature flags, both default `off`.
+  - `text-to-speech`: Web Speech API narration for any story. Adds
+    play/pause/stop buttons to the NavBar, auto-advances pages when a page
+    finishes speaking, and exposes rate (0.7×–1.5×) and voice pickers in the
+    typography panel. New `useTextToSpeech` hook persists voice + rate to
+    `localStorage` (`wr-tts-voice`, `wr-tts-rate`).
+  - `simplified-ui`: enlarges tap targets in the NavBar, sidebar, story list,
+    source list, directory list, and the profile shortcut button; hides
+    experimental/debug toggles in the profile panel so seniors see only
+    relevant features.
+- `data-testid` hooks for the new controls: `tts-toggle`, `tts-stop`,
+  `tts-rate-*`, `tts-voice-select`.
+- Unit tests: `useTextToSpeech.test.jsx` and new cases in
+  `useFeatureFlags.test.jsx` covering the two senior flags.
+
 ## [0.1.1] - 2026-04-18
 ### Fixed
 - `useFeatureFlags`: restore `maxFontSize` mapping to `{off:28, big:28,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,9 @@ Speed reader (visible when `speed-reader` flag is on):
 ORP speed reader (visible when `speedreader-orp` flag is on and speed reader mode is active):
 `orp-panel-toggle` (gear button in RSVP controls row), `orp-preview` (live preview in panel), `orp-method-second-letter`, `orp-method-center`, `orp-method-fixed-index` (ORP method buttons), `orp-letter-index-input` (fixed index number input), `orp-highlight-toggle`, `orp-color-input` (letter highlight controls), `orp-bars-toggle`, `orp-bar-length` (guide bars controls), `orp-marker-toggle`, `orp-fixation-x`, `orp-fixation-y` (fixation point sliders)
 
+Text-to-speech (visible when `text-to-speech` flag is on):
+`tts-toggle` (nav-bar play/pause), `tts-stop` (shown only while playing), `tts-rate-*` (rate buttons in typography panel, 0-based index), `tts-voice-select` (voice dropdown in typography panel)
+
 ### Tailwind
 
 Using Tailwind v4 with `@tailwindcss/postcss`. The CSS entry point uses `@import "tailwindcss"` and `@config "./tailwind.config.js"` (required in v4 to load a config file). Dark mode is implemented via conditional class strings — not the `dark:` variant.

--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, ClockFading } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ClockFading, Play, Pause, Square } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
 
 /**
@@ -18,11 +18,22 @@ export default function NavBar({
   typoPanelOpen,
   onToggleTypoPanel,
   srWordCount,
+  showTextToSpeech,
+  ttsSupported,
+  ttsPlaying,
+  ttsPaused,
+  onToggleTts,
+  onStopTts,
+  simplifiedUi,
 }) {
   const { dark: darkMode, hc: highContrast } = useTheme();
 
+  const navHeight = simplifiedUi ? 'h-16' : 'h-12';
+  const btnIconSize = simplifiedUi ? 24 : 18;
+  const ttsBtnBase = simplifiedUi ? 'w-12 h-12' : 'w-9 h-9';
+
   return (
-    <div data-testid="nav-bar" className={`flex-shrink-0 h-12 flex items-center justify-between px-6 backdrop-blur-sm border-t transition-colors ${
+    <div data-testid="nav-bar" className={`flex-shrink-0 ${navHeight} flex items-center justify-between px-6 backdrop-blur-sm border-t transition-colors ${
       highContrast
         ? (darkMode ? 'bg-black border-white/40 text-white' : 'bg-white border-black/30 text-gray-900')
         : darkMode
@@ -33,11 +44,11 @@ export default function NavBar({
         data-testid="prev-page"
         onClick={onPrev}
         disabled={currentPage === 0 || speedReaderMode}
-        className={`p-1 rounded transition-colors disabled:opacity-30 ${
+        className={`${simplifiedUi ? 'p-2.5' : 'p-1'} rounded transition-colors disabled:opacity-30 ${
           darkMode ? 'hover:bg-slate-700' : 'hover:bg-amber-100'
         }`}
       >
-        <ChevronLeft size={20} />
+        <ChevronLeft size={simplifiedUi ? 28 : 20} />
       </button>
 
       <button
@@ -66,12 +77,47 @@ export default function NavBar({
       </button>
 
       <div className="flex items-center gap-1">
+        {showTextToSpeech && ttsSupported && (
+          <>
+            <button
+              data-testid="tts-toggle"
+              onClick={onToggleTts}
+              disabled={speedReaderMode}
+              title={ttsPlaying && !ttsPaused ? 'Pause' : 'Vorlesen'}
+              className={`flex items-center justify-center ${ttsBtnBase} rounded-xl transition-colors disabled:opacity-30 ${
+                ttsPlaying && !ttsPaused
+                  ? highContrast
+                    ? (darkMode ? 'bg-white text-black' : 'bg-black text-white')
+                    : darkMode ? 'bg-amber-500/30 text-amber-300' : 'bg-amber-100 text-amber-700'
+                  : highContrast
+                    ? (darkMode ? 'text-white/60' : 'text-gray-500')
+                    : darkMode ? 'bg-slate-700/60 text-amber-700' : 'bg-amber-50/80 text-amber-400'
+              }`}
+            >
+              {ttsPlaying && !ttsPaused ? <Pause size={btnIconSize} /> : <Play size={btnIconSize} />}
+            </button>
+            {ttsPlaying && (
+              <button
+                data-testid="tts-stop"
+                onClick={onStopTts}
+                title="Vorlesen stoppen"
+                className={`flex items-center justify-center ${ttsBtnBase} rounded-xl transition-colors ${
+                  highContrast
+                    ? (darkMode ? 'text-white/60' : 'text-gray-500')
+                    : darkMode ? 'bg-slate-700/60 text-amber-700' : 'bg-amber-50/80 text-amber-400'
+                }`}
+              >
+                <Square size={btnIconSize - 4} />
+              </button>
+            )}
+          </>
+        )}
         {showSpeedReader && (
           <button
             data-testid="speed-reader-toggle"
             onClick={onToggleSpeedReader}
             title={speedReaderMode ? 'Normaler Lesebereich' : 'Schnellleser'}
-            className={`flex items-center justify-center w-9 h-9 rounded-xl transition-colors ${
+            className={`flex items-center justify-center ${ttsBtnBase} rounded-xl transition-colors ${
               speedReaderMode
                 ? highContrast
                   ? (darkMode ? 'bg-white text-black' : 'bg-black text-white')
@@ -81,18 +127,18 @@ export default function NavBar({
                   : darkMode ? 'bg-slate-700/60 text-amber-700' : 'bg-amber-50/80 text-amber-400'
             }`}
           >
-            <ClockFading size={18} />
+            <ClockFading size={btnIconSize} />
           </button>
         )}
         <button
           data-testid="next-page"
           onClick={onNext}
           disabled={currentPage >= totalPages - 1 || speedReaderMode}
-          className={`p-1 rounded transition-colors disabled:opacity-30 ${
+          className={`${simplifiedUi ? 'p-2.5' : 'p-1'} rounded transition-colors disabled:opacity-30 ${
             darkMode ? 'hover:bg-slate-700' : 'hover:bg-amber-100'
           }`}
         >
-          <ChevronRight size={20} />
+          <ChevronRight size={simplifiedUi ? 28 : 20} />
         </button>
       </div>
     </div>

--- a/components/ProfilePanel.jsx
+++ b/components/ProfilePanel.jsx
@@ -39,15 +39,28 @@ export default function ProfilePanel({
   showAbTesting,
   showAbTestingAdmin,
   ab,
+  simplifiedUi = false,
 }) {
+  // In simplified-ui mode, hide experimental/debug features from the toggle list
+  // to keep the profile uncluttered for seniors. `simplified-ui` itself always
+  // remains visible so it can be turned back off.
+  const SIMPLIFIED_HIDDEN = new Set([
+    'debug-badges', 'error-page-simulator', 'ab-testing', 'ab-testing-admin',
+    'app-animation', 'word-blacklist', 'speed-reader', 'speedreader-orp',
+    'subscriber-fonts', 'story-directories', 'deep-search', 'pinch-font-size',
+    'read-along', 'illustrations', 'child-profile', 'story-quiz',
+  ]);
   const { dark, hc, tc } = useTheme();
 
   const _o = (key, raw) => Object.hasOwn(userFeatureOverrides, key) ? userFeatureOverrides[key] : raw;
 
   // Admin sees all features; others see only role-assigned features
-  const visibleFeatures = isAdmin
+  let visibleFeatures = isAdmin
     ? features
     : features.filter((f) => visibleFeatureKeys.has(f.key));
+  if (simplifiedUi && !isAdmin) {
+    visibleFeatures = visibleFeatures.filter((f) => !SIMPLIFIED_HIDDEN.has(f.key));
+  }
 
   const nonAdminRoles = ROLES.filter((r) => r !== 'admin');
 

--- a/components/ReaderView.jsx
+++ b/components/ReaderView.jsx
@@ -67,6 +67,18 @@ export default function ReaderView({
   srFontSizeMax,
   srFontSizeStep,
   srFontSizeDefault,
+  showTextToSpeech,
+  ttsSupported,
+  ttsPlaying,
+  ttsPaused,
+  ttsVoiceURI,
+  onTtsVoiceChange,
+  ttsVoices,
+  ttsRateIdx,
+  onTtsRateChange,
+  onToggleTts,
+  onStopTts,
+  simplifiedUi,
 }) {
   const isLastPage = currentPage === totalPages - 1;
 
@@ -169,6 +181,13 @@ export default function ReaderView({
           fontFamilyIdx={fontFamilyIdx}
           onFontFamilyChange={onFontFamilyChange}
           subscriberFonts={subscriberFonts}
+          showTextToSpeech={showTextToSpeech}
+          ttsSupported={ttsSupported}
+          ttsVoices={ttsVoices}
+          ttsVoiceURI={ttsVoiceURI}
+          onTtsVoiceChange={onTtsVoiceChange}
+          ttsRateIdx={ttsRateIdx}
+          onTtsRateChange={onTtsRateChange}
         />
       )}
 
@@ -195,6 +214,13 @@ export default function ReaderView({
           typoPanelOpen={typoPanelOpen}
           onToggleTypoPanel={onToggleTypoPanel}
           srWordCount={srWords.length}
+          showTextToSpeech={showTextToSpeech}
+          ttsSupported={ttsSupported}
+          ttsPlaying={ttsPlaying}
+          ttsPaused={ttsPaused}
+          onToggleTts={onToggleTts}
+          onStopTts={onStopTts}
+          simplifiedUi={simplifiedUi}
         />
       )}
     </>

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -41,6 +41,7 @@ export default function Sidebar({
   profileOpen,
   onCloseProfile,
   onCloseApp,
+  simplifiedUi = false,
 }) {
   const { dark: darkMode } = useTheme();
 
@@ -132,6 +133,7 @@ export default function Sidebar({
                 testId="story-button"
                 onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
                 onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
+                simplifiedUi={simplifiedUi}
               />
             ))}
           </div>
@@ -156,6 +158,7 @@ export default function Sidebar({
                 inlineBadges
                 onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
                 onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
+                simplifiedUi={simplifiedUi}
               />
             ))}
           </div>
@@ -197,6 +200,7 @@ export default function Sidebar({
                     testId="story-button"
                     onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
                     onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
+                    simplifiedUi={simplifiedUi}
                   />
                 ))}
             </div>
@@ -230,13 +234,13 @@ export default function Sidebar({
                   key={dir.id}
                   data-testid="directory-button"
                   onClick={() => onSelectDirectory(dir.id)}
-                  className={`w-full flex items-center justify-between px-3 py-2.5 rounded-lg transition-all ${
+                  className={`w-full flex items-center justify-between ${simplifiedUi ? 'px-4 py-4' : 'px-3 py-2.5'} rounded-lg transition-all ${
                     darkMode
                       ? 'text-amber-100 hover:bg-slate-800'
                       : 'text-amber-900 hover:bg-amber-100'
                   }`}
                 >
-                  <span className="font-serif text-base">{dir.label}</span>
+                  <span className={`font-serif ${simplifiedUi ? 'text-lg' : 'text-base'}`}>{dir.label}</span>
                   <span className={`text-xs tabular-nums mr-1 ${
                     darkMode ? 'text-amber-400' : 'text-amber-700'
                   }`}>
@@ -283,6 +287,7 @@ export default function Sidebar({
                   testId="story-button"
                   onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
                   onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
+                  simplifiedUi={simplifiedUi}
                 />
               ))}
             </div>
@@ -291,7 +296,7 @@ export default function Sidebar({
           /* Source list */
           <div className="px-3 pb-4 space-y-2">
             {sources.map(src => (
-              <SourceButton key={src.id} src={src} onClick={() => onSelectSource(src.id)} />
+              <SourceButton key={src.id} src={src} onClick={() => onSelectSource(src.id)} simplifiedUi={simplifiedUi} />
             ))}
           </div>
         )}
@@ -303,21 +308,21 @@ export default function Sidebar({
       }`}>
         <button
           onClick={() => { onOpenProfile(); onMenuToggle(); }}
-          className={`w-full flex items-center gap-3 px-4 py-3.5 transition-colors ${
+          className={`w-full flex items-center gap-3 ${simplifiedUi ? 'px-5 py-5' : 'px-4 py-3.5'} transition-colors ${
             profileOpen
               ? darkMode ? 'bg-amber-700/20 text-amber-200' : 'bg-amber-100 text-amber-900'
               : darkMode ? 'text-amber-400 hover:bg-slate-800 hover:text-amber-200' : 'text-amber-700 hover:bg-amber-50 hover:text-amber-900'
           }`}
         >
-          <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+          <div className={`flex-shrink-0 ${simplifiedUi ? 'w-10 h-10' : 'w-8 h-8'} rounded-full flex items-center justify-center ${
             darkMode ? 'bg-slate-700' : 'bg-amber-100'
           }`}>
-            <User size={16} />
+            <User size={simplifiedUi ? 20 : 16} />
           </div>
           <div className="flex-1 min-w-0 text-left">
-            <p className="text-sm font-medium truncate">Mein Profil</p>
+            <p className={`font-medium truncate ${simplifiedUi ? 'text-base' : 'text-sm'}`}>Mein Profil</p>
           </div>
-          <ChevronRight size={14} className="flex-shrink-0 opacity-50" />
+          <ChevronRight size={simplifiedUi ? 18 : 14} className="flex-shrink-0 opacity-50" />
         </button>
         <button
           data-testid="close-app-button"

--- a/flags.json
+++ b/flags.json
@@ -18,6 +18,8 @@
   "audio-player":      { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "big-fonts":         { "defaultVariant": "off", "variants": { "off": "off", "big": "big", "bigger": "bigger", "biggest": "biggest" } },
   "high-contrast-theme": { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "simplified-ui":       { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "text-to-speech":      { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "word-blacklist":      { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "deep-search":         { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "story-directories":   { "defaultVariant": "off", "variants": { "on": true, "off": false } },

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -8,6 +8,7 @@ import { useReader } from './hooks/useReader';
 import FeatureDocs from './FeatureDocs';
 import { useRole } from './hooks/useRole';
 import { useABTesting } from './hooks/useABTesting';
+import { useTextToSpeech } from './hooks/useTextToSpeech';
 import { ThemeContext } from './ui/ThemeContext';
 import Toggle from './ui/Toggle';
 import IconButton from './ui/IconButton';
@@ -41,6 +42,7 @@ const GrimmMarchenApp = () => {
     showWordCount, showReadingDuration, showFontSizeControls, showPinchFontSize, showEinkFlash,
     showTapZones, showTapMiddleToggle, showAdaptionSwitcher, showTypographyPanel, showAttribution,
     showFavorites, showFavoritesOnlyToggle, showAudioPlayer, showHighContrastTheme,
+    showSimplifiedUi, showTextToSpeech,
     showSpeedReader, showSpeedreaderOrp, showWordBlacklist, showDeepSearch, showStoryDirectories, showDebugBadges, showSubscriberFonts, showErrorPageSimulator, showAppAnimation,
     showAbTesting, showAbTestingAdmin,
     _rawFlagValues,
@@ -312,6 +314,71 @@ const GrimmMarchenApp = () => {
     pendingResumePageRef,
   });
 
+  // Text-to-speech - reads the current page aloud and auto-advances.
+  const tts = useTextToSpeech({ enabled: showTextToSpeech });
+  const {
+    supported: ttsSupported, voices: ttsVoices, voiceURI: ttsVoiceURI, setVoiceURI: setTtsVoiceURI,
+    rateIdx: ttsRateIdx, setRateIdx: setTtsRateIdx,
+    playing: ttsPlaying, paused: ttsPaused,
+    speak: ttsSpeak, pause: ttsPause, resume: ttsResume, stop: ttsStop,
+  } = tts;
+
+  const pageText = React.useMemo(() => {
+    const page = pages[currentPage];
+    if (!page) return '';
+    const text = page.tokens.map(t => t.word).join(' ');
+    if (page.hasTitle && selectedStory) {
+      const title = selectedVariant?.title ?? selectedStory.title;
+      return `${title}. ${text}`;
+    }
+    return text;
+  }, [pages, currentPage, selectedStory, selectedVariant]);
+
+  // Continuous read-session flag: true while the user wants TTS to keep
+  // auto-advancing page by page. Cleared on pause, stop, or last-page finish.
+  const ttsSessionRef = useRef(false);
+
+  const speakCurrentPage = useCallback(() => {
+    if (!pageText) return;
+    const isLast = currentPage >= totalPages - 1;
+    ttsSpeak(pageText, {
+      onFinish: () => {
+        if (!ttsSessionRef.current) return;
+        if (isLast) { ttsSessionRef.current = false; return; }
+        goToPage(currentPage + 1);
+      },
+    });
+  }, [pageText, currentPage, totalPages, ttsSpeak, goToPage]);
+
+  const handleToggleTts = useCallback(() => {
+    if (!ttsSupported) return;
+    if (ttsPlaying && !ttsPaused) { ttsSessionRef.current = false; ttsPause(); return; }
+    if (ttsPlaying && ttsPaused) { ttsSessionRef.current = true; ttsResume(); return; }
+    ttsSessionRef.current = true;
+    speakCurrentPage();
+  }, [ttsSupported, ttsPlaying, ttsPaused, ttsPause, ttsResume, speakCurrentPage]);
+
+  const handleStopTts = useCallback(() => {
+    ttsSessionRef.current = false;
+    ttsStop();
+  }, [ttsStop]);
+
+  // When the page changes during an active read-session (auto-advance), speak the new page.
+  const prevPageRef = useRef(currentPage);
+  useEffect(() => {
+    if (prevPageRef.current === currentPage) return;
+    prevPageRef.current = currentPage;
+    if (ttsSessionRef.current) speakCurrentPage();
+  }, [currentPage, speakCurrentPage]);
+
+  // Stop TTS when leaving the story or entering speed-reader mode.
+  useEffect(() => {
+    if (!selectedStory || speedReaderMode) {
+      ttsSessionRef.current = false;
+      ttsStop();
+    }
+  }, [selectedStory, speedReaderMode, ttsStop]);
+
   // Effects extracted from usePersistence that depend on reader state
   // (currentPage/totalPages come from useReader above, so they must live here).
   useEffect(() => {
@@ -568,6 +635,7 @@ const GrimmMarchenApp = () => {
           profileOpen={profileOpen}
           onCloseProfile={() => setProfileOpen(false)}
           onCloseApp={handleCloseApp}
+          simplifiedUi={showSimplifiedUi}
         />
           );
         })()}
@@ -627,6 +695,7 @@ const GrimmMarchenApp = () => {
               showAbTesting={showAbTesting}
               showAbTestingAdmin={showAbTestingAdmin}
               ab={ab}
+              simplifiedUi={showSimplifiedUi}
               onSimulateError={(type) => {
                 if (type === 'not-found') {
                   window.location.assign('/does-not-exist');
@@ -690,6 +759,18 @@ const GrimmMarchenApp = () => {
               srFontSizeMax={SPEED_READER_FONT_SIZE.max}
               srFontSizeStep={SPEED_READER_FONT_SIZE.step}
               srFontSizeDefault={SPEED_READER_FONT_SIZE.defaultValue}
+              showTextToSpeech={showTextToSpeech}
+              ttsSupported={ttsSupported}
+              ttsPlaying={ttsPlaying}
+              ttsPaused={ttsPaused}
+              ttsVoices={ttsVoices}
+              ttsVoiceURI={ttsVoiceURI}
+              onTtsVoiceChange={setTtsVoiceURI}
+              ttsRateIdx={ttsRateIdx}
+              onTtsRateChange={setTtsRateIdx}
+              onToggleTts={handleToggleTts}
+              onStopTts={handleStopTts}
+              simplifiedUi={showSimplifiedUi}
             />
           ) : isStoryLoading ? (
             <div className={`h-full w-full grid place-items-center ${darkMode ? 'text-amber-200' : 'text-amber-900'}`}>

--- a/hooks/useFeatureFlags.js
+++ b/hooks/useFeatureFlags.js
@@ -21,6 +21,8 @@ export function useFeatureFlags() {
   const _rawFavoritesOnlyToggle = useBooleanFlagValue('favorites-only-toggle', false);
   const _rawAudioPlayer = useBooleanFlagValue('audio-player', false);
   const _rawHighContrastTheme = useBooleanFlagValue('high-contrast-theme', false);
+  const _rawSimplifiedUi = useBooleanFlagValue('simplified-ui', false);
+  const _rawTextToSpeech = useBooleanFlagValue('text-to-speech', false);
   const _rawSpeedReader = useBooleanFlagValue('speed-reader', false);
   const _rawSpeedreaderOrp = useBooleanFlagValue('speedreader-orp', false);
   const _rawWordBlacklist = useBooleanFlagValue('word-blacklist', false);
@@ -60,6 +62,8 @@ export function useFeatureFlags() {
   const showFavoritesOnlyToggle = _o('favorites-only-toggle', _rawFavoritesOnlyToggle);
   const showAudioPlayer = _o('audio-player', _rawAudioPlayer);
   const showHighContrastTheme = _o('high-contrast-theme', _rawHighContrastTheme);
+  const showSimplifiedUi = _o('simplified-ui', _rawSimplifiedUi);
+  const showTextToSpeech = _o('text-to-speech', _rawTextToSpeech);
   const showSpeedReader = _o('speed-reader', _rawSpeedReader);
   const showSpeedreaderOrp = _o('speedreader-orp', _rawSpeedreaderOrp);
   const showWordBlacklist = _o('word-blacklist', _rawWordBlacklist);
@@ -88,6 +92,8 @@ export function useFeatureFlags() {
     'favorites-only-toggle': _rawFavoritesOnlyToggle,
     'audio-player': _rawAudioPlayer,
     'high-contrast-theme': _rawHighContrastTheme,
+    'simplified-ui': _rawSimplifiedUi,
+    'text-to-speech': _rawTextToSpeech,
     'speed-reader': _rawSpeedReader,
     'speedreader-orp': _rawSpeedreaderOrp,
     'word-blacklist': _rawWordBlacklist,
@@ -121,6 +127,8 @@ export function useFeatureFlags() {
     showFavoritesOnlyToggle,
     showAudioPlayer,
     showHighContrastTheme,
+    showSimplifiedUi,
+    showTextToSpeech,
     showSpeedReader,
     showSpeedreaderOrp,
     showWordBlacklist,

--- a/hooks/useTextToSpeech.js
+++ b/hooks/useTextToSpeech.js
@@ -1,0 +1,129 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export const TTS_RATES = [0.7, 0.85, 1.0, 1.2, 1.5];
+const DEFAULT_RATE_IDX = 2;
+
+function getSynthesis() {
+  return typeof window !== 'undefined' ? window.speechSynthesis : null;
+}
+
+function loadVoicesOnce(synth) {
+  return new Promise((resolve) => {
+    const existing = synth.getVoices();
+    if (existing && existing.length) return resolve(existing);
+    const handle = () => {
+      synth.removeEventListener('voiceschanged', handle);
+      resolve(synth.getVoices());
+    };
+    synth.addEventListener('voiceschanged', handle);
+  });
+}
+
+/**
+ * Text-to-speech hook built on the Web Speech API.
+ * Exposes play/pause/stop, rate + voice selection, and an `onFinish` callback
+ * that fires when the current utterance ends naturally (used for page auto-advance).
+ */
+export function useTextToSpeech({ enabled = false, lang = 'de-DE' } = {}) {
+  const synth = getSynthesis();
+  const supported = !!synth;
+
+  const [voices, setVoices] = useState([]);
+  const [voiceURI, setVoiceURI] = useState(() => localStorage.getItem('wr-tts-voice') ?? '');
+  const [rateIdx, setRateIdx] = useState(() => {
+    const v = parseInt(localStorage.getItem('wr-tts-rate') ?? '');
+    return Number.isFinite(v) ? v : DEFAULT_RATE_IDX;
+  });
+  const [playing, setPlaying] = useState(false);
+  const [paused, setPaused] = useState(false);
+
+  const finishHandlerRef = useRef(null);
+  const utteranceRef = useRef(null);
+
+  useEffect(() => { localStorage.setItem('wr-tts-voice', voiceURI); }, [voiceURI]);
+  useEffect(() => { localStorage.setItem('wr-tts-rate', String(rateIdx)); }, [rateIdx]);
+
+  useEffect(() => {
+    if (!supported) return;
+    let active = true;
+    loadVoicesOnce(synth).then((vs) => {
+      if (!active) return;
+      const localized = vs.filter(v => v.lang.startsWith(lang.slice(0, 2)));
+      setVoices(localized.length ? localized : vs);
+    });
+    return () => { active = false; };
+  }, [supported, synth, lang]);
+
+  const stop = useCallback(() => {
+    if (!supported) return;
+    finishHandlerRef.current = null;
+    synth.cancel();
+    setPlaying(false);
+    setPaused(false);
+  }, [supported, synth]);
+
+  const speak = useCallback((text, { onFinish } = {}) => {
+    if (!supported || !text) return;
+    synth.cancel();
+
+    const utter = new SpeechSynthesisUtterance(text);
+    utter.lang = lang;
+    utter.rate = TTS_RATES[rateIdx] ?? 1.0;
+    const chosen = voices.find(v => v.voiceURI === voiceURI);
+    if (chosen) utter.voice = chosen;
+
+    finishHandlerRef.current = onFinish ?? null;
+    utteranceRef.current = utter;
+
+    utter.onend = () => {
+      setPlaying(false);
+      setPaused(false);
+      const cb = finishHandlerRef.current;
+      finishHandlerRef.current = null;
+      if (cb) cb();
+    };
+    utter.onerror = () => {
+      setPlaying(false);
+      setPaused(false);
+      finishHandlerRef.current = null;
+    };
+
+    setPlaying(true);
+    setPaused(false);
+    synth.speak(utter);
+  }, [supported, synth, lang, rateIdx, voices, voiceURI]);
+
+  const pause = useCallback(() => {
+    if (!supported || !playing) return;
+    synth.pause();
+    setPaused(true);
+  }, [supported, synth, playing]);
+
+  const resume = useCallback(() => {
+    if (!supported || !paused) return;
+    synth.resume();
+    setPaused(false);
+  }, [supported, synth, paused]);
+
+  // Stop on disable or unmount
+  useEffect(() => {
+    if (!enabled) stop();
+    return () => stop();
+  }, [enabled, stop]);
+
+  return {
+    supported,
+    voices,
+    voiceURI,
+    setVoiceURI,
+    rateIdx,
+    setRateIdx,
+    rate: TTS_RATES[rateIdx] ?? 1.0,
+    playing,
+    paused,
+    speak,
+    pause,
+    resume,
+    stop,
+  };
+}

--- a/tests/unit/useFeatureFlags.test.jsx
+++ b/tests/unit/useFeatureFlags.test.jsx
@@ -30,6 +30,8 @@ const boolDefaults = {
   'deep-search': false,
   'story-directories': false,
   'debug-badges': false,
+  'simplified-ui': false,
+  'text-to-speech': false,
 };
 
 describe('useFeatureFlags', () => {
@@ -46,6 +48,22 @@ describe('useFeatureFlags', () => {
     const { result } = renderHook(() => useFeatureFlags());
     expect(result.current.showFontSizeControls).toBe(true);
     expect(result.current.showFavorites).toBe(false);
+  });
+
+  it('exposes senior-targeted flags (simplified-ui, text-to-speech)', () => {
+    const { result } = renderHook(() => useFeatureFlags());
+    expect(result.current.showSimplifiedUi).toBe(false);
+    expect(result.current.showTextToSpeech).toBe(false);
+  });
+
+  it('honours overrides for senior-targeted flags', () => {
+    localStorage.setItem('wr-feature-overrides', JSON.stringify({
+      'simplified-ui': true,
+      'text-to-speech': true,
+    }));
+    const { result } = renderHook(() => useFeatureFlags());
+    expect(result.current.showSimplifiedUi).toBe(true);
+    expect(result.current.showTextToSpeech).toBe(true);
   });
 
   it('applies user overrides over raw flag values', () => {

--- a/tests/unit/useTextToSpeech.test.jsx
+++ b/tests/unit/useTextToSpeech.test.jsx
@@ -1,0 +1,78 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTextToSpeech, TTS_RATES } from '../../hooks/useTextToSpeech';
+
+function mockSpeechSynthesis() {
+  const listeners = {};
+  const queue = [];
+  const synth = {
+    speak: vi.fn((utter) => {
+      queue.push(utter);
+      synth._lastUtter = utter;
+    }),
+    cancel: vi.fn(() => { queue.length = 0; }),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    getVoices: vi.fn(() => [
+      { voiceURI: 'de-DE-Anna', name: 'Anna', lang: 'de-DE' },
+      { voiceURI: 'en-US-Mike', name: 'Mike', lang: 'en-US' },
+    ]),
+    addEventListener: vi.fn((evt, fn) => { listeners[evt] = fn; }),
+    removeEventListener: vi.fn(() => {}),
+  };
+  window.speechSynthesis = synth;
+  window.SpeechSynthesisUtterance = class {
+    constructor(text) { this.text = text; this.onend = null; this.onerror = null; }
+  };
+  return synth;
+}
+
+describe('useTextToSpeech', () => {
+  let synth;
+  beforeEach(() => {
+    synth = mockSpeechSynthesis();
+  });
+
+  it('reports supported=true when speechSynthesis exists', () => {
+    const { result } = renderHook(() => useTextToSpeech({ enabled: true }));
+    expect(result.current.supported).toBe(true);
+  });
+
+  it('filters voices by locale (de)', async () => {
+    const { result, rerender } = renderHook(() => useTextToSpeech({ enabled: true, lang: 'de-DE' }));
+    // voices load via async promise
+    await act(async () => { await Promise.resolve(); });
+    rerender();
+    expect(result.current.voices.map(v => v.voiceURI)).toEqual(['de-DE-Anna']);
+  });
+
+  it('persists rate and voice to localStorage', () => {
+    const { result } = renderHook(() => useTextToSpeech({ enabled: true }));
+    act(() => { result.current.setRateIdx(4); });
+    act(() => { result.current.setVoiceURI('de-DE-Anna'); });
+    expect(localStorage.getItem('wr-tts-rate')).toBe('4');
+    expect(localStorage.getItem('wr-tts-voice')).toBe('de-DE-Anna');
+    expect(TTS_RATES[4]).toBe(1.5);
+  });
+
+  it('invokes onFinish when utterance ends naturally', () => {
+    const { result } = renderHook(() => useTextToSpeech({ enabled: true }));
+    const finish = vi.fn();
+    act(() => { result.current.speak('Hallo Welt', { onFinish: finish }); });
+    const utter = synth._lastUtter;
+    act(() => { utter.onend(); });
+    expect(finish).toHaveBeenCalledTimes(1);
+    expect(result.current.playing).toBe(false);
+  });
+
+  it('stop() cancels synthesis and clears onFinish', () => {
+    const { result } = renderHook(() => useTextToSpeech({ enabled: true }));
+    const finish = vi.fn();
+    act(() => { result.current.speak('text', { onFinish: finish }); });
+    act(() => { result.current.stop(); });
+    expect(synth.cancel).toHaveBeenCalled();
+    // onend fired after stop (cancel triggers it) should NOT call finish
+    const utter = synth._lastUtter;
+    act(() => { utter.onend?.(); });
+    expect(finish).not.toHaveBeenCalled();
+  });
+});

--- a/ui/SourceButton.jsx
+++ b/ui/SourceButton.jsx
@@ -9,7 +9,7 @@ import { useTheme } from './ThemeContext';
  * src  - { id, label, count }
  * onClick - called when clicked
  */
-export default function SourceButton({ src, onClick }) {
+export default function SourceButton({ src, onClick, simplifiedUi = false }) {
   const { tc } = useTheme();
 
   return (
@@ -17,7 +17,8 @@ export default function SourceButton({ src, onClick }) {
       data-testid="source-button"
       onClick={onClick}
       className={cn(
-        'w-full flex items-center justify-between px-3 py-2.5 rounded-lg transition-all',
+        'w-full flex items-center justify-between rounded-lg transition-all',
+        simplifiedUi ? 'px-4 py-4' : 'px-3 py-2.5',
         tc({
           light: 'text-amber-900 hover:bg-amber-100',
           dark: 'text-amber-100 hover:bg-slate-800',
@@ -26,10 +27,11 @@ export default function SourceButton({ src, onClick }) {
         })
       )}
     >
-      <span className="font-serif text-base truncate min-w-0 flex-1 text-left pr-3">{src.label}</span>
+      <span className={`font-serif ${simplifiedUi ? 'text-lg' : 'text-base'} truncate min-w-0 flex-1 text-left pr-3`}>{src.label}</span>
       <span className="flex-shrink-0 flex items-center gap-2">
         <span className={cn(
-          'text-xs tabular-nums',
+          'tabular-nums',
+          simplifiedUi ? 'text-sm' : 'text-xs',
           tc({
             light: 'text-amber-700',
             dark: 'text-amber-400',
@@ -39,7 +41,7 @@ export default function SourceButton({ src, onClick }) {
         )}>
           {src.count}
         </span>
-        <ChevronRight size={16} />
+        <ChevronRight size={simplifiedUi ? 20 : 16} />
       </span>
     </button>
   );

--- a/ui/StoryButton.jsx
+++ b/ui/StoryButton.jsx
@@ -34,6 +34,7 @@ export default function StoryButton({
   onFavoriteClick,
   testId,
   className = '',
+  simplifiedUi = false,
 }) {
   const { tc } = useTheme();
 
@@ -82,7 +83,8 @@ export default function StoryButton({
         data-testid={testId}
         onClick={onClick}
         className={cn(
-          'flex-1 min-w-0 text-left px-3 py-2.5 rounded-lg transition-all',
+          'flex-1 min-w-0 text-left rounded-lg transition-all',
+          simplifiedUi ? 'px-4 py-4' : 'px-3 py-2.5',
           isActive
             ? tc({
                 light:   'bg-amber-200 text-amber-900',
@@ -98,7 +100,7 @@ export default function StoryButton({
               })
         )}
       >
-        <span className={`font-serif text-base${inlineBadges ? ' leading-snug' : ' line-clamp-2 block'}`}>
+        <span className={`font-serif ${simplifiedUi ? 'text-lg' : 'text-base'}${inlineBadges ? ' leading-snug' : ' line-clamp-2 block'}`}>
           {story.title}
         </span>
         {inlineBadges ? badges : hasBadgeRow && (
@@ -110,7 +112,8 @@ export default function StoryButton({
         <button
           onClick={onFavoriteClick}
           className={cn(
-            'flex-shrink-0 p-1.5 rounded-lg transition-colors',
+            'flex-shrink-0 rounded-lg transition-colors',
+            simplifiedUi ? 'p-3' : 'p-1.5',
             heartFilled
               ? tc({
                   light:   'text-amber-600 hover:bg-amber-100',
@@ -126,7 +129,7 @@ export default function StoryButton({
                 })
           )}
         >
-          <Heart size={14} fill={heartFilled ? 'currentColor' : 'none'} />
+          <Heart size={simplifiedUi ? 20 : 14} fill={heartFilled ? 'currentColor' : 'none'} />
         </button>
       )}
     </div>

--- a/ui/TypographyPanel.jsx
+++ b/ui/TypographyPanel.jsx
@@ -1,5 +1,6 @@
 import { cn } from './cn';
 import { useTheme } from './ThemeContext';
+import { TTS_RATES } from '../hooks/useTextToSpeech';
 
 export const LINE_HEIGHTS  = [1.5, 1.8, 2.2];
 export const WORD_SPACINGS = ['normal', '0.06em', '0.15em'];
@@ -50,6 +51,13 @@ export default function TypographyPanel({
   wordSpacingIdx,   onWordSpacingChange,
   fontFamilyIdx,    onFontFamilyChange,
   subscriberFonts = false,
+  showTextToSpeech = false,
+  ttsSupported = false,
+  ttsVoices = [],
+  ttsVoiceURI = '',
+  onTtsVoiceChange,
+  ttsRateIdx = 2,
+  onTtsRateChange,
   className = '',
 }) {
   const { tc } = useTheme();
@@ -174,6 +182,50 @@ export default function TypographyPanel({
             ))}
           </div>
         </div>
+      )}
+
+      {showTextToSpeech && ttsSupported && (
+        <>
+          <div className="flex items-center gap-3 py-1">
+            <span className={labelCls}>Lesetempo</span>
+            <div className="flex gap-1.5">
+              {TTS_RATES.map((r, i) => (
+                <button
+                  key={i}
+                  data-testid={`tts-rate-${i}`}
+                  onClick={() => onTtsRateChange?.(i)}
+                  className={cn('w-10 h-8 flex items-center justify-center rounded-lg transition-colors text-xs tabular-nums', ttsRateIdx === i ? activeBtnCls : inactiveBtnCls)}
+                >
+                  {r.toFixed(r === 1 ? 0 : 2).replace(/\.?0+$/, '')}×
+                </button>
+              ))}
+            </div>
+          </div>
+          {ttsVoices.length > 0 && (
+            <div className="flex items-center gap-3 py-1">
+              <span className={labelCls}>Stimme</span>
+              <select
+                data-testid="tts-voice-select"
+                value={ttsVoiceURI}
+                onChange={(e) => onTtsVoiceChange?.(e.target.value)}
+                className={cn(
+                  'flex-1 min-w-0 text-sm rounded-lg px-2 py-1 border transition-colors',
+                  tc({
+                    light:   'bg-white border-amber-200 text-amber-900',
+                    dark:    'bg-slate-800 border-amber-700/40 text-amber-100',
+                    hcLight: 'bg-white border-black/40 text-gray-900',
+                    hcDark:  'bg-black border-white/40 text-white',
+                  })
+                )}
+              >
+                <option value="">Standard</option>
+                {ttsVoices.map(v => (
+                  <option key={v.voiceURI} value={v.voiceURI}>{v.name} ({v.lang})</option>
+                ))}
+              </select>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
Two new feature flags that make the reader genuinely usable for seniors:

text-to-speech - narrates stories via the Web Speech API, auto-advances
page by page, and exposes rate (0.7x to 1.5x) + voice pickers in the
typography panel. New useTextToSpeech hook persists voice and rate.
NavBar adds play/pause/stop controls gated behind the flag.

simplified-ui - enlarges tap targets across the NavBar, sidebar, story
list, source list, directory list, and profile shortcut, and filters
experimental/debug toggles out of the profile so only senior-relevant
features remain visible.

Adds data-testid hooks (tts-toggle, tts-stop, tts-rate-*,
tts-voice-select) and unit tests for the new hook and flag wiring.