### PR TITLE
feat(sales): add subscription tiers, sales role, and commerce feature set

### DIFF
--- a/docs/features/billing-portal-stub.md
+++ b/docs/features/billing-portal-stub.md
@@ -1,0 +1,33 @@
+---
+id: "billing-portal-stub"
+name: "Billing Portal (Stub)"
+type: "app"
+flag_key: "billing-portal-stub"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas: []
+related_features:
+  - "pricing-page"
+  - "sales-mode"
+parent: null
+children: []
+---
+
+# Billing Portal (Stub)
+
+**Flag:** `billing-portal-stub` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+A mocked billing portal used for demos and UX prototyping. No real payment provider is wired; the UI covers plan switch, seat management (Family/Edu), pause-subscription, and cancel flows.
+
+## Behavior
+
+- `data-testid`: `billing-portal`, `billing-plan-switch`, `billing-pause`, `billing-cancel`
+- Explicitly labeled as a mock to prevent confusion during demos.
+- Replaced by a real provider integration before first production launch.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Subscription Tiers](../sales/tiers.md)
+- [Sales Mode](sales-mode.md)

--- a/docs/features/conversion-analytics.md
+++ b/docs/features/conversion-analytics.md
@@ -1,0 +1,33 @@
+---
+id: "conversion-analytics"
+name: "Conversion Analytics"
+type: "app"
+flag_key: "conversion-analytics"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas: []
+related_features:
+  - "sales-mode"
+  - "paywall"
+parent: null
+children: []
+---
+
+# Conversion Analytics
+
+**Flag:** `conversion-analytics` · **Lifecycle:** EXPERIMENT · **Default:** off · **Role-gated:** Sales, Admin
+
+An on-screen overlay that labels every commerce surface with its current funnel step, paywall variant, upgrade-cta copy variant, and any active A/B experiment assignment. Intended for live demos and for debugging conversion drop-off.
+
+## Behavior
+
+- `data-testid`: `conversion-analytics-overlay`, `conversion-funnel-step`
+- Sits in a corner of the viewport; non-interactive for the underlying UI.
+- Funnel steps: `visitor` → `engaged` → `teaser-seen` → `paywall-hit` → `pricing-viewed` → `checkout-opened` → `converted`.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Sales Mode](sales-mode.md)
+- [Paywall](paywall.md)

--- a/docs/features/paywall.md
+++ b/docs/features/paywall.md
@@ -1,0 +1,40 @@
+---
+id: "paywall"
+name: "Paywall"
+type: "app"
+flag_key: "paywall"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas:
+  - "02-parents"
+  - "04-culture-explorers"
+  - "06-creatives"
+related_features:
+  - "upgrade-cta"
+  - "pricing-page"
+  - "trial-banner"
+parent: null
+children: []
+---
+
+# Paywall
+
+**Flag:** `paywall` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Blocks access to tier-gated features and prompts the user to upgrade. Three styles are tested via the `paywall-style` A/B experiment.
+
+## Behavior
+
+- `data-testid`: `paywall`, `paywall-cta`, `paywall-dismiss`
+- Variants:
+  - **hard-gate** — feature is completely blocked until upgrade
+  - **soft-gate** — feature works once or for N seconds, then locks
+  - **teaser** — feature shows partial output (e.g. first 3 deep-search hits) with "Upgrade for more"
+- Never gates accessibility features (font-size-controls, high-contrast-theme, tap-zones) — see [Senior persona story](../sales/user-stories.md).
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Subscription Tiers](../sales/tiers.md)
+- [User Stories](../sales/user-stories.md)

--- a/docs/features/pricing-page.md
+++ b/docs/features/pricing-page.md
@@ -1,0 +1,35 @@
+---
+id: "pricing-page"
+name: "Pricing Page"
+type: "app"
+flag_key: "pricing-page"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas: []
+related_features:
+  - "paywall"
+  - "upgrade-cta"
+  - "tier-badge"
+parent: null
+children: []
+---
+
+# Pricing Page
+
+**Flag:** `pricing-page` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Dedicated route that lists all subscription tiers with feature comparison. Layout is tested via the `pricing-page-layout` A/B experiment.
+
+## Behavior
+
+- `data-testid`: `pricing-page`, `pricing-tier-free`, `pricing-tier-plus`, `pricing-tier-pro`, `pricing-tier-family`, `pricing-tier-edu`
+- Layout variants:
+  - **3-tier** — Free / Pro / Family (hides Plus and Edu)
+  - **4-tier** — Free / Plus / Pro / Family
+  - **slider** — interactive slider that morphs the recommended tier based on selected features
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Subscription Tiers](../sales/tiers.md)

--- a/docs/features/promo-code.md
+++ b/docs/features/promo-code.md
@@ -1,0 +1,33 @@
+---
+id: "promo-code"
+name: "Promo Code"
+type: "app"
+flag_key: "promo-code"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas: []
+related_features:
+  - "referral-program"
+  - "pricing-page"
+parent: null
+children: []
+---
+
+# Promo Code
+
+**Flag:** `promo-code` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Redeem a promo code to unlock a trial, a tier upgrade, or a discount. Sales and Admin roles can also *generate* codes; all other roles can only redeem.
+
+## Behavior
+
+- `data-testid`: `promo-code-input`, `promo-code-submit`, `promo-code-generate` (Sales/Admin only)
+- Code formats: single-use, multi-use with limit, time-bound campaign code.
+- Generation UI lives in the profile panel and is role-gated.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Referral Program](referral-program.md)
+- [Sales Role](../roles/sales.md)

--- a/docs/features/referral-program.md
+++ b/docs/features/referral-program.md
@@ -1,0 +1,32 @@
+---
+id: "referral-program"
+name: "Referral Program"
+type: "app"
+flag_key: "referral-program"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas: []
+related_features:
+  - "promo-code"
+parent: null
+children: []
+---
+
+# Referral Program
+
+**Flag:** `referral-program` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Each paid subscriber gets a personal referral link. A successful signup gives the friend 30 days free and the referrer one bonus month.
+
+## Behavior
+
+- `data-testid`: `referral-link`, `referral-copy`, `referral-count`
+- Available to Plus, Pro, and Family tiers (not Edu — institutional billing handles that separately).
+- Tracks invited, signed-up, and converted counts.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Promo Code](promo-code.md)
+- [Subscription Tiers](../sales/tiers.md)

--- a/docs/features/sales-mode.md
+++ b/docs/features/sales-mode.md
@@ -1,0 +1,34 @@
+---
+id: "sales-mode"
+name: "Sales Mode"
+type: "app"
+flag_key: "sales-mode"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas: []
+related_features:
+  - "conversion-analytics"
+  - "tier-badge"
+  - "pricing-page"
+parent: null
+children: []
+---
+
+# Sales Mode
+
+**Flag:** `sales-mode` · **Lifecycle:** EXPERIMENT · **Default:** off · **Role-gated:** Sales, Admin
+
+Demo overlay for the Sales team. Adds a tier picker to the profile panel that overrides the user's effective tier for the current session — without touching billing state or stored subscription data.
+
+## Behavior
+
+- `data-testid`: `sales-mode-toggle`, `sales-mode-tier-picker`
+- When active, the simulated tier drives which features are visible, which paywalls trigger, and which CTAs appear. A clear "DEMO" ribbon is drawn on screen so the prospect sees the simulation explicitly.
+- Deactivating restores the real tier.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Sales Role](../roles/sales.md)
+- [Conversion Analytics](conversion-analytics.md)

--- a/docs/features/tier-badge.md
+++ b/docs/features/tier-badge.md
@@ -1,0 +1,33 @@
+---
+id: "tier-badge"
+name: "Tier Badge"
+type: "app"
+flag_key: "tier-badge"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas: []
+related_features:
+  - "paywall"
+  - "pricing-page"
+parent: null
+children: []
+---
+
+# Tier Badge
+
+**Flag:** `tier-badge` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Shows the current subscription tier (Free, Plus, Pro, Family, Edu) in the profile panel. Serves as a constant reminder of what the user is paying for and what the next upgrade step is.
+
+## Behavior
+
+- `data-testid`: `tier-badge`
+- Reads the simulated tier from `sales-mode` when that feature is active; otherwise reads from the stored subscription tier.
+- Clicking the badge navigates to `pricing-page` (when flag enabled).
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Subscription Tiers](../sales/tiers.md)
+- [Paywall](paywall.md)

--- a/docs/features/trial-banner.md
+++ b/docs/features/trial-banner.md
@@ -1,0 +1,35 @@
+---
+id: "trial-banner"
+name: "Trial Banner"
+type: "app"
+flag_key: "trial-banner"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas:
+  - "02-parents"
+  - "06-creatives"
+related_features:
+  - "paywall"
+  - "pricing-page"
+parent: null
+children: []
+---
+
+# Trial Banner
+
+**Flag:** `trial-banner` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Starts and displays the remaining time on a time-limited trial. Trial length is tested via the `trial-length` A/B experiment (7 / 14 / 30 days, and a 5-minute micro-trial for the speed-reader).
+
+## Behavior
+
+- `data-testid`: `trial-banner`, `trial-banner-start`, `trial-banner-countdown`
+- Counts down in days when > 24h remain, in hours below that.
+- Shows a "Keep features" CTA 48h before expiry.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Subscription Tiers](../sales/tiers.md)
+- [User Stories](../sales/user-stories.md)

--- a/docs/features/upgrade-cta.md
+++ b/docs/features/upgrade-cta.md
@@ -1,0 +1,38 @@
+---
+id: "upgrade-cta"
+name: "Upgrade CTA"
+type: "app"
+flag_key: "upgrade-cta"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
+category: "commerce"
+personas:
+  - "06-creatives"
+  - "07-passive-consumers"
+related_features:
+  - "paywall"
+  - "pricing-page"
+parent: null
+children: []
+---
+
+# Upgrade CTA
+
+**Flag:** `upgrade-cta` · **Lifecycle:** EXPERIMENT · **Default:** off
+
+Contextual call-to-action that surfaces tier upgrades at moments of engagement (not only at paywalls). Copy variants tested via the `upgrade-cta-copy` A/B experiment.
+
+## Behavior
+
+- `data-testid`: `upgrade-cta`, `upgrade-cta-dismiss`
+- Copy variants:
+  - **feature-focused** — "Unlock speed-reader + ORP"
+  - **outcome-focused** — "Read 3× faster"
+  - **price-anchor** — "Less than a coffee per month"
+- Placement: nav bar (after 10 stories), profile panel, story end card.
+
+## Links
+
+- [Back to Feature Matrix](../personas.md)
+- [Paywall](paywall.md)
+- [User Stories](../sales/user-stories.md)

--- a/docs/product-strategy.md
+++ b/docs/product-strategy.md
@@ -91,6 +91,22 @@ Expose story content as a platform, not just a product:
 
 ---
 
+## Monetization
+
+Subscription tiers stack on top of the [role matrix](roles.md). See [Subscription Tiers](sales/tiers.md) for the full feature-by-tier breakdown and [User Stories](sales/user-stories.md) for persona × tier conversion stories.
+
+| Tier | Price Anchor | Wedge |
+|---|---|---|
+| **Free** | €0 | Accessibility + canonical reading — ungated. |
+| **Plus** | €2.99 / mo | Stats, variants, directories — "I enjoy this". |
+| **Pro** | €59 / yr | Speed-reader, ORP, deep-search, TTS — "I live in this". |
+| **Family** | €9.99 / mo | Child-profile + Gen-Alpha bundle (up to 5 seats). |
+| **Edu** | €149 / yr / seat | Discussion-questions, parallel-texts, symbol-analysis — B2B wedge. |
+
+Pricing is placeholder — the `pricing-page-layout`, `trial-length`, `paywall-style`, `upgrade-cta-copy`, and `hero-pitch` A/B experiments allow each lever to vary per cohort. The **Sales** role gates demo tooling (`sales-mode`, `conversion-analytics`, `promo-code` generation) so the growth team can demo tiers live without admin risk.
+
+---
+
 ## Competitive Positioning
 
 | Product | Strength | Our Gap |

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,11 +1,13 @@
 ---
 title: "Role Matrix"
-description: "Guest, Subscriber, Tester, and Admin roles"
+description: "Guest, Subscriber, Tester, Sales, and Admin roles"
 ---
 
 # User Roles — Access Matrix
 
-> 4 roles · Feature-based access control · Configurable via Admin
+> 5 roles · Feature-based access control · Configurable via Admin
+
+Roles describe **access control** (what a user is *allowed* to see). Subscription **tiers** describe *what a user is paying for* — see [Subscription Tiers](sales/tiers.md). A user's effective feature set is the intersection of their role and their tier.
 
 ## Roles
 
@@ -14,6 +16,7 @@ description: "Guest, Subscriber, Tester, and Admin roles"
 | 👤 | [Guest](roles/guest.md) | PUBLIC | Default role for new or anonymous users. |
 | 💎 | [Subscriber](roles/subscriber.md) | PAID | Premium users with access to advanced reading tools. |
 | 🧪 | [Tester](roles/tester.md) | INTERNAL | QA and beta users with access to experimental features. |
+| 💰 | [Sales](roles/sales.md) | INTERNAL | Growth team — demo any tier, generate promo codes, inspect funnel. |
 | ⚡ | [Admin](roles/admin.md) | SYSTEM | Full control over features, roles, and content. |
 
 ---
@@ -22,22 +25,25 @@ description: "Guest, Subscriber, Tester, and Admin roles"
 
 Role-based access is managed in `hooks/useRole.js`. Admins can dynamically toggle features for other roles.
 
-| Feature Category | [👤](roles/guest.md) | [💎](roles/subscriber.md) | [🧪](roles/tester.md) | [⚡](roles/admin.md) |
-|---|:---:|:---:|:---:|:---:|
-| **Reader Core** | ✓ | ✓ | ✓ | ✓ |
-| **Reader Stats** | | ✓ | ✓ | ✓ |
-| **Reader UI** | ✓ | ✓ | ✓ | ✓ |
-| **Appearance** | ✓ | ✓ | ✓ | ✓ |
-| **Typography** | ✓ | ✓ | ✓ | ✓ |
-| **Navigation** | | ✓ | ✓ | ✓ |
-| **Advanced Reading** | | ✓ | ✓ | ✓ |
-| **Gen Alpha** | | | ✓ | ✓ |
-| **Tools** | | ✓ | ✓ | ✓ |
-| **Debug** | | | ✓ | ✓ |
+| Feature Category | [👤](roles/guest.md) | [💎](roles/subscriber.md) | [🧪](roles/tester.md) | [💰](roles/sales.md) | [⚡](roles/admin.md) |
+|---|:---:|:---:|:---:|:---:|:---:|
+| **Reader Core** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Reader Stats** | | ✓ | ✓ | ✓ | ✓ |
+| **Reader UI** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Appearance** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Typography** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Navigation** | | ✓ | ✓ | ✓ | ✓ |
+| **Advanced Reading** | | ✓ | ✓ | partial | ✓ |
+| **Gen Alpha** | | | ✓ | | ✓ |
+| **Tools** | | ✓ | ✓ | ✓ | ✓ |
+| **Commerce** | | | | ✓ | ✓ |
+| **Debug** | | | ✓ | | ✓ |
 
 ---
 
 ## Related
 
 - [Personas](personas.md) — user archetypes that map to these roles.
+- [Subscription Tiers](sales/tiers.md) — monetization overlay on top of roles.
+- [User Stories](sales/user-stories.md) — persona × tier conversion stories.
 - [Product Strategy](product-strategy.md) — monetization and platform goals.

--- a/docs/roles/sales.md
+++ b/docs/roles/sales.md
@@ -1,0 +1,79 @@
+---
+id: "sales"
+name: "Sales"
+emoji: "💰"
+access_level: "INTERNAL"
+description: "Sales and growth team — demo any tier, generate promo codes, and inspect the conversion funnel."
+features:
+  - favorites
+  - favorites-only-toggle
+  - word-count
+  - reading-duration
+  - font-size-controls
+  - pinch-font-size
+  - eink-flash
+  - tap-zones
+  - tap-middle-toggle
+  - adaption-switcher
+  - typography-panel
+  - attribution
+  - audio-player
+  - story-directories
+  - high-contrast-theme
+  - subscriber-fonts
+  - tier-badge
+  - paywall
+  - upgrade-cta
+  - trial-banner
+  - pricing-page
+  - promo-code
+  - referral-program
+  - sales-mode
+  - conversion-analytics
+  - billing-portal-stub
+---
+
+# 💰 Sales Role
+
+**Access Level:** INTERNAL
+**Purpose:** Demo any subscription tier live, generate promo codes, and inspect the conversion funnel without admin risk.
+
+## Access Profile
+
+Sales has read-write access to commerce features (`paywall`, `upgrade-cta`, `pricing-page`, `promo-code`, `sales-mode`, `conversion-analytics`) and read-only access to the reader feature set of every tier — but **no access to role/feature mutation** (that stays Admin-only). This separation lets the growth team run demos and campaigns without touching feature-flag infrastructure.
+
+## Included Features (vs. Subscriber)
+
+| Feature | Category | Notes |
+|---|---|---|
+| [Tier Badge](../features/tier-badge.md) | Commerce | Shows the currently simulated tier |
+| [Paywall](../features/paywall.md) | Commerce | Inspector for the paywall UI variants |
+| [Upgrade CTA](../features/upgrade-cta.md) | Commerce | Inspector for CTA copy variants |
+| [Trial Banner](../features/trial-banner.md) | Commerce | Trigger and preview trial banners |
+| [Pricing Page](../features/pricing-page.md) | Commerce | Preview 3-tier, 4-tier, and slider layouts |
+| [Promo Code](../features/promo-code.md) | Commerce | Generate and redeem codes |
+| [Referral Program](../features/referral-program.md) | Commerce | Test referral flows |
+| [Sales Mode](../features/sales-mode.md) | Commerce | Demo overlay — toggle simulated tier |
+| [Conversion Analytics](../features/conversion-analytics.md) | Commerce | Funnel-step overlay (Sales + Admin only) |
+| [Billing Portal (stub)](../features/billing-portal-stub.md) | Commerce | Mocked billing UI for demos |
+
+Sales does **not** get access to experimental Gen-Alpha features (read-along, illustrations, child-profile, story-quiz) — those remain Tester-gated to avoid leaking unreleased UX into demos.
+
+## Implementation Notes
+
+- Declared in `hooks/useRole.js` (`ROLES`, `ROLE_LABELS`, `defaultRoleFeatures`).
+- Does **not** receive `ALL`-level access like Admin; its feature list is enumerable.
+- `sales-mode` is the key entry point — when active, the profile panel exposes a tier picker that overrides the user's effective tier for the current session without mutating billing state.
+
+## Strategic Purpose
+
+The Sales role is the growth team's equivalent of Tester: internal access to product surfaces that the end user would only see at a commercial decision point. It keeps promotional tooling out of the Admin panel (reducing mis-click risk during live demos) and out of the Subscriber tier (avoiding leakage of unreleased pricing to paying customers).
+
+## Links
+
+- [Back to Role Matrix](../roles.md)
+- [Subscriber ←](subscriber.md)
+- [Tester ←](tester.md)
+- [Admin →](admin.md)
+- [Subscription Tiers](../sales/tiers.md)
+- [User Stories](../sales/user-stories.md)

--- a/docs/sales/tiers.md
+++ b/docs/sales/tiers.md
@@ -1,0 +1,82 @@
+---
+title: "Subscription Tiers"
+description: "Free, Plus, Pro, Family, and Edu tiers — feature scope, price anchors, and target personas."
+---
+
+# Subscription Tiers
+
+> 5 tiers · Feature stacking · Persona-aligned pricing
+
+The tier model stacks on top of the four existing [roles](../roles.md). Roles describe *access control* (who can see what). Tiers describe *monetization* (what a user pays for). A user's effective feature set is the intersection of their role and their tier.
+
+---
+
+## Tier Matrix
+
+| Tier | Price Anchor | Role Mapping | Target Personas |
+|---|---|---|---|
+| **Free** | €0 | Guest | Pre-Readers · Seniors · casual drop-ins |
+| **Plus** | €2.99 / mo | Subscriber (light) | Culture Explorers · Therapeutic · Passive Consumers |
+| **Pro** | €59 / yr (≈ €4.92/mo) | Subscriber (full) | Creatives · Developers · Gamified Explorers |
+| **Family** | €9.99 / mo (up to 5 seats) | Subscriber + child-profile | Parents · Pre-Readers |
+| **Edu** | €149 / yr / seat · bulk | Subscriber + Tester preview | Teachers · institutions |
+
+Prices are placeholders for A/B testing — the `pricing-page-layout` and `trial-length` experiments allow the values and structure to vary per cohort.
+
+---
+
+## Feature Scope by Tier
+
+| Category | Feature | Free | Plus | Pro | Family | Edu |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| **Reader Core** | favorites, favorites-only-toggle | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Reader Stats** | word-count, reading-duration | | ✓ | ✓ | ✓ | ✓ |
+| **Reader UI** | font-size, pinch-font-size, tap-zones, eink-flash | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Appearance** | theme, high-contrast-theme | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Appearance** | big-fonts | | ✓ | ✓ | ✓ | ✓ |
+| **Typography** | typography-panel | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Typography** | adaption-switcher, subscriber-fonts | | ✓ | ✓ | ✓ | ✓ |
+| **Navigation** | story-directories | | ✓ | ✓ | ✓ | ✓ |
+| **Navigation** | deep-search | | | ✓ | ✓ | ✓ |
+| **Advanced Reading** | audio-player | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Advanced Reading** | speed-reader, speedreader-orp | | | ✓ | ✓ | ✓ |
+| **Advanced Reading** | text-to-speech | | | ✓ | ✓ | ✓ |
+| **Tools** | word-blacklist, attribution | | ✓ | ✓ | ✓ | ✓ |
+| **Gen Alpha** | child-profile, read-along, illustrations, story-quiz | | | | ✓ | ✓ |
+| **B2B / Edu** | discussion-questions, parallel-texts, symbol-analysis | | | | | ✓ |
+| **Commerce** | tier-badge | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Commerce** | trial-banner, paywall, upgrade-cta | ✓ | | | | |
+| **Commerce** | referral-program | | ✓ | ✓ | ✓ | |
+| **Commerce** | promo-code (redeem) | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+---
+
+## Upgrade Paths
+
+```
+Free  ─┬─►  Plus   (primary conversion — triggered by paywall on stats + navigation)
+       ├─►  Pro    (power-user path — triggered by speed-reader/deep-search teaser)
+       └─►  Family (if child-profile trial seen)
+
+Plus  ──►  Pro     (upsell when user hits speed-reader paywall)
+Pro   ──►  Family  (lifecycle — first child added)
+```
+
+---
+
+## Strategic Notes
+
+- **Free** stays generous on accessibility (fonts, contrast, tap zones, audio) to avoid gating Seniors and Pre-Readers.
+- **Plus** is the "I enjoy this" tier: stats, variants, directories, blacklist — no speed tooling.
+- **Pro** is the "I live in this" tier: speed-reader, ORP, deep-search, TTS. Target ARPU driver.
+- **Family** pivots on child-profile and Gen-Alpha features — the only tier that unbundles them from Tester.
+- **Edu** is the B2B wedge — priced per seat, includes teacher-only features (parallel-texts, discussion-questions).
+
+---
+
+## Related
+
+- [User Stories](user-stories.md) — stories per persona × tier
+- [Sales Role](../roles/sales.md) — internal role for demoing tiers
+- [Role Matrix](../roles.md) — Guest · Subscriber · Tester · Admin · Sales
+- [Product Strategy](../product-strategy.md) — monetization section

--- a/docs/sales/user-stories.md
+++ b/docs/sales/user-stories.md
@@ -1,0 +1,180 @@
+---
+title: "User Stories — Persona × Tier"
+description: "Conversion, retention, and activation stories per persona and subscription tier."
+---
+
+# User Stories
+
+> Each story is written in the **As a / I want / So that** form, tagged with its intended A/B experiment and success metric.
+
+---
+
+## Conversion Stories (Free → Paid)
+
+### Parents
+
+- **As a** Parent on Free,
+  **I want** a one-tap "Start Bedtime Routine" banner that reveals the Family tier,
+  **so that** I can see curated, duration-controlled evening stories without configuring anything.
+  - *Experiment:* `paywall-style` (soft-gate teaser) · *Metric:* Family trial start rate
+
+- **As a** Parent on Free,
+  **I want** the first child-profile tap to show a 7-day Family trial CTA,
+  **so that** I can evaluate read-along and illustrations with my child before paying.
+  - *Experiment:* `trial-length` · *Metric:* Trial → paid conversion
+
+### Culture Explorers
+
+- **As a** Culture Explorer on Free,
+  **I want** a teaser on `deep-search` that shows the first 3 results and gates the rest,
+  **so that** I can preview the value and upgrade to Pro when I hit a research wall.
+  - *Experiment:* `paywall-style` (teaser vs. hard-gate) · *Metric:* Pro conversion
+
+- **As a** Culture Explorer on Plus,
+  **I want** a side-by-side preview of `parallel-texts` in an Edu-gated sample story,
+  **so that** I consider upgrading to Edu or requesting institutional access.
+  - *Experiment:* `upgrade-cta-copy` · *Metric:* Edu lead-form submissions
+
+### Creatives
+
+- **As a** Creative on Free,
+  **I want** a 5-minute Pro trial of `speed-reader` + `speedreader-orp` on any story,
+  **so that** I can feel the productivity difference before committing.
+  - *Experiment:* `trial-length` (5min vs. 1 day vs. 7 day) · *Metric:* Pro trial → paid
+
+### Passive Consumers
+
+- **As a** Passive Consumer on Free,
+  **I want** the audio-player CTA to show "Upgrade for background playback + sleep timer",
+  **so that** I upgrade to Plus to listen while commuting.
+  - *Experiment:* `upgrade-cta-copy` (feature vs. outcome) · *Metric:* Plus conversion
+
+### Gamified Explorers
+
+- **As a** Gamified Explorer on Free,
+  **I want** an achievement-based unlock of `story-map` previews after 3 stories,
+  **so that** I feel progress and upgrade to Pro for the full map.
+  - *Experiment:* `hero-pitch` (gamified variant) · *Metric:* Pro conversion
+
+### Developers
+
+- **As a** Developer on Free,
+  **I want** a visible `story-api` docs link with a Pro-gated live key,
+  **so that** I can evaluate the API surface before subscribing.
+  - *Experiment:* `pricing-page-layout` (with API tier call-out) · *Metric:* API key issued
+
+### Seniors
+
+- **As a** Senior on Free,
+  **I want** *not* to see aggressive paywalls on accessibility features,
+  **so that** my reading experience stays calm and I trust the product.
+  - *Experiment:* `paywall-style` (no-gate on a11y) · *Metric:* Retention (30-day)
+
+### Therapeutic
+
+- **As a** Therapeutic user on Free,
+  **I want** a gentle "Keep your reading private" upgrade nudge on the 3rd session,
+  **so that** I consider Plus for journaling history sync (once shipped).
+  - *Experiment:* `upgrade-cta-copy` (privacy vs. feature) · *Metric:* Plus conversion
+
+### Teachers
+
+- **As a** Teacher on Free,
+  **I want** a "Request classroom access" form next to `discussion-questions`,
+  **so that** I can trigger an Edu sales conversation for my school.
+  - *Experiment:* `upgrade-cta-copy` (lead-form vs. self-serve) · *Metric:* Edu SQL
+
+### Pre-Readers (via Parent)
+
+- **As a** Parent of a Pre-Reader on Free,
+  **I want** a visible "Try Family free for 7 days" banner on first `read-along` tap,
+  **so that** I can unlock kid-safe features during a trial.
+  - *Experiment:* `trial-length` · *Metric:* Family conversion
+
+---
+
+## Activation Stories (Within-Tier)
+
+### Plus
+
+- **As a** Plus subscriber,
+  **I want** a subtle "Pro unlocks speed-reader" hint in the nav bar after 10 stories,
+  **so that** I consider the upsell at a moment of engagement.
+  - *Experiment:* `upgrade-cta-copy` · *Metric:* Plus → Pro upgrade
+
+- **As a** Plus subscriber,
+  **I want** my `tier-badge` visible in the profile panel,
+  **so that** I feel the value of what I'm paying for.
+  - *Metric:* Retention
+
+### Pro
+
+- **As a** Pro subscriber,
+  **I want** early-access toggles for Gen-Alpha features (read-along, illustrations),
+  **so that** I feel Pro is the "first access" tier.
+  - *Experiment:* none (feature entitlement) · *Metric:* Session depth
+
+### Family
+
+- **As a** Family subscriber,
+  **I want** per-seat `child-profile` switching from the profile panel,
+  **so that** I can share without sharing a password.
+  - *Metric:* Weekly active seats
+
+### Edu
+
+- **As a** Teacher with Edu access,
+  **I want** to export a class-level reading report (word-count, reading-duration aggregates),
+  **so that** I can show administrative impact.
+  - *Metric:* Report exports / week
+
+---
+
+## Retention Stories
+
+- **As any** paid user,
+  **I want** a "Pause subscription for 1 month" option in the billing portal,
+  **so that** I don't churn permanently during low-reading periods.
+  - *Metric:* Cancel → pause deflection rate
+
+- **As a** user whose trial is ending,
+  **I want** a clear countdown and "Keep features" CTA 48h before expiry,
+  **so that** I don't lose access unexpectedly.
+  - *Experiment:* `trial-length` · *Metric:* Trial → paid
+
+---
+
+## Referral Stories
+
+- **As a** Plus or Pro subscriber,
+  **I want** to share a promo code that gives a friend 30 days free + me 1 free month,
+  **so that** I invite friends and extend my subscription.
+  - *Feature:* `referral-program` · *Metric:* Referral K-factor
+
+- **As a** Sales team member,
+  **I want** to generate single-use or batch promo codes from the profile panel,
+  **so that** I can run campaigns without engineering.
+  - *Feature:* `promo-code` (generation is Sales/Admin only) · *Metric:* Code redemption rate
+
+---
+
+## Sales-Role Stories
+
+- **As a** Sales team member,
+  **I want** a `sales-mode` toggle that previews any tier's feature set without billing,
+  **so that** I can demo the product live to a prospect.
+  - *Feature:* `sales-mode` · *Role:* sales · *Metric:* Demos / week
+
+- **As a** Sales team member,
+  **I want** the `conversion-analytics` overlay to show the paywall copy, current experiment variant, and conversion funnel step,
+  **so that** I can explain what the prospect would see at each stage.
+  - *Feature:* `conversion-analytics` · *Role:* sales, admin
+
+---
+
+## Related
+
+- [Subscription Tiers](tiers.md)
+- [Sales Role](../roles/sales.md)
+- [Personas](../personas.md)
+- [Product Strategy](../product-strategy.md)

--- a/features.jsx
+++ b/features.jsx
@@ -28,6 +28,16 @@ import {
   Lock,
   FlaskConical,
   Beaker,
+  BadgeCheck,
+  DoorClosed,
+  Sparkles,
+  BellRing,
+  Tag,
+  Ticket,
+  Gift,
+  Megaphone,
+  LineChart,
+  CreditCard,
 } from 'lucide-react';
 
 export const FEATURES = [
@@ -221,5 +231,66 @@ export const FEATURES = [
     label: 'A/B-Verwaltung',
     description: 'Admin-Werkzeug zum Aktivieren, Deaktivieren und Zuteilen von UI-Varianten an Rollen.',
     Icon: () => <FlaskConical size={20} strokeWidth={1.75} />,
+  },
+  // Commerce / Sales
+  {
+    key: 'tier-badge',
+    label: 'Tarif-Abzeichen',
+    description: 'Zeigt das aktuelle Abo (Free, Plus, Pro, Family, Edu) im Profil-Panel an.',
+    Icon: () => <BadgeCheck size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'paywall',
+    label: 'Zahlschranke',
+    description: 'Zeigt eine Zahlschranke vor kostenpflichtigen Features - Varianten: Hard-Gate, Soft-Gate, Teaser.',
+    Icon: () => <DoorClosed size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'upgrade-cta',
+    label: 'Upgrade-Hinweis',
+    description: 'Kontextabhängiger Hinweis zum Upgrade auf den nächsthöheren Tarif.',
+    Icon: () => <Sparkles size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'trial-banner',
+    label: 'Testzeitraum-Banner',
+    description: 'Banner, der einen 7-, 14- oder 30-tägigen Testzeitraum startet und den verbleibenden Zeitraum anzeigt.',
+    Icon: () => <BellRing size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'pricing-page',
+    label: 'Preisseite',
+    description: 'Dedizierte Preisseite mit Tarif-Vergleich - Layout-Varianten: 3-Tarife, 4-Tarife, interaktiver Slider.',
+    Icon: () => <Tag size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'promo-code',
+    label: 'Promo-Code',
+    description: 'Promo-Code-Eingabe fuer Endnutzer; Sales und Admin koennen Codes erzeugen.',
+    Icon: () => <Ticket size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'referral-program',
+    label: 'Empfehlungsprogramm',
+    description: 'Persoenlicher Empfehlungslink - Freund erhaelt 30 Tage gratis, Empfehler einen Gratismonat.',
+    Icon: () => <Gift size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'sales-mode',
+    label: 'Vertriebs-Modus',
+    description: 'Demo-Overlay fuer die Sales-Rolle - schaltet simulierte Tarife fuer Live-Praesentationen um.',
+    Icon: () => <Megaphone size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'conversion-analytics',
+    label: 'Conversion-Analyse',
+    description: 'Einblendung des aktuellen Funnel-Schritts, der Paywall-Variante und des A/B-Variant-Zustands.',
+    Icon: () => <LineChart size={20} strokeWidth={1.75} />,
+  },
+  {
+    key: 'billing-portal-stub',
+    label: 'Abrechnungs-Portal (Mock)',
+    description: 'Gemocktes Abrechnungs-Portal fuer Demos - keine echte Zahlungsabwicklung.',
+    Icon: () => <CreditCard size={20} strokeWidth={1.75} />,
   },
 ];

--- a/flags.json
+++ b/flags.json
@@ -27,5 +27,15 @@
   "error-page-simulator":   { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "app-animation":          { "defaultVariant": "off", "variants": { "on": true, "off": false } },
   "ab-testing":             { "defaultVariant": "off", "variants": { "on": true, "off": false } },
-  "ab-testing-admin":       { "defaultVariant": "off", "variants": { "on": true, "off": false } }
+  "ab-testing-admin":       { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "tier-badge":             { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "paywall":                { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "upgrade-cta":            { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "trial-banner":           { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "pricing-page":           { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "promo-code":             { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "referral-program":       { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "sales-mode":             { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "conversion-analytics":   { "defaultVariant": "off", "variants": { "on": true, "off": false } },
+  "billing-portal-stub":    { "defaultVariant": "off", "variants": { "on": true, "off": false } }
 }

--- a/hooks/useRole.js
+++ b/hooks/useRole.js
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { FEATURES } from '../features';
 
-export const ROLES = ['guest', 'subscriber', 'tester', 'admin'];
+export const ROLES = ['guest', 'subscriber', 'tester', 'sales', 'admin'];
 
 export const ROLE_LABELS = {
   guest: 'Gast',
   subscriber: 'Abonnent',
   tester: 'Tester',
+  sales: 'Vertrieb',
   admin: 'Admin',
 };
 
@@ -77,6 +78,35 @@ function defaultRoleFeatures() {
       'speedreader-orp',
       'subscriber-fonts',
       'error-page-simulator',
+      'ab-testing',
+    ],
+    sales: [
+      'favorites',
+      'favorites-only-toggle',
+      'word-count',
+      'reading-duration',
+      'font-size-controls',
+      'pinch-font-size',
+      'eink-flash',
+      'tap-zones',
+      'tap-middle-toggle',
+      'adaption-switcher',
+      'typography-panel',
+      'attribution',
+      'audio-player',
+      'story-directories',
+      'high-contrast-theme',
+      'subscriber-fonts',
+      'tier-badge',
+      'paywall',
+      'upgrade-cta',
+      'trial-banner',
+      'pricing-page',
+      'promo-code',
+      'referral-program',
+      'sales-mode',
+      'conversion-analytics',
+      'billing-portal-stub',
       'ab-testing',
     ],
   };

--- a/src/lib/abExperiments.js
+++ b/src/lib/abExperiments.js
@@ -28,12 +28,89 @@ export const AB_EXPERIMENTS = [
       { id: 'v2',      label: 'Baum v2',  description: 'Alles auf einer Ebene, Quellen ein- und ausklappbar, Tastatur-Navigation.' },
     ],
   },
+  {
+    id: 'paywall-style',
+    label: 'Zahlschranken-Stil',
+    description: 'Wie stark blockieren Paywalls den Zugriff auf kostenpflichtige Features?',
+    defaultVariant: 'soft-gate',
+    variants: [
+      { id: 'hard-gate', label: 'Harte Sperre',  description: 'Feature ist bis zum Upgrade komplett gesperrt.' },
+      { id: 'soft-gate', label: 'Sanfte Sperre', description: 'Feature funktioniert einmal oder fuer N Sekunden, dann gesperrt.' },
+      { id: 'teaser',    label: 'Teaser',        description: 'Feature zeigt Teilergebnisse mit Upgrade-Hinweis.' },
+    ],
+  },
+  {
+    id: 'upgrade-cta-copy',
+    label: 'Upgrade-Hinweis-Text',
+    description: 'Welcher Ton ueberzeugt mehr Nutzer zum Upgrade?',
+    defaultVariant: 'feature-focused',
+    variants: [
+      { id: 'feature-focused', label: 'Feature-fokussiert', description: '„Schalte Schnellleser + ORP frei".' },
+      { id: 'outcome-focused', label: 'Ergebnis-fokussiert', description: '„Lies 3x schneller".' },
+      { id: 'price-anchor',    label: 'Preis-Anker',         description: '„Weniger als ein Kaffee pro Monat".' },
+    ],
+  },
+  {
+    id: 'pricing-page-layout',
+    label: 'Preisseiten-Layout',
+    description: 'Wie ist die Preisseite strukturiert?',
+    defaultVariant: '4-tier',
+    variants: [
+      { id: '3-tier', label: '3 Tarife',            description: 'Free / Pro / Family - Plus und Edu versteckt.' },
+      { id: '4-tier', label: '4 Tarife',            description: 'Free / Plus / Pro / Family.' },
+      { id: 'slider', label: 'Interaktiver Slider', description: 'Slider empfiehlt Tarif basierend auf gewaehlten Features.' },
+    ],
+  },
+  {
+    id: 'trial-length',
+    label: 'Testzeitraum-Laenge',
+    description: 'Wie lange laeuft der kostenlose Testzeitraum?',
+    defaultVariant: '14-days',
+    variants: [
+      { id: '5-min',  label: '5 Minuten', description: 'Mikro-Trial fuer speed-reader und ORP.' },
+      { id: '7-days', label: '7 Tage',    description: 'Kurzer Trial - schnelle Entscheidung.' },
+      { id: '14-days', label: '14 Tage',  description: 'Mittel - Industriestandard.' },
+      { id: '30-days', label: '30 Tage',  description: 'Lang - maximale Aktivierungszeit.' },
+    ],
+  },
+  {
+    id: 'hero-pitch',
+    label: 'Hero-Pitch',
+    description: 'Welche Positionierung spricht welche Persona am staerksten an?',
+    defaultVariant: 'story-os',
+    variants: [
+      { id: 'story-os',    label: 'Story OS',       description: 'Das Betriebssystem fuer Maerchen.' },
+      { id: 'speed',       label: 'Schneller lesen', description: '3x schneller lesen mit ORP.' },
+      { id: 'family',      label: 'Familien-Ritual', description: 'Eine Gute-Nacht-Geschichte, nur ein Tipp entfernt.' },
+      { id: 'culture',     label: 'Kulturerbe',      description: 'Maerchen im Original und in jeder Sprache.' },
+    ],
+  },
 ];
 
 export const AB_DEFAULT_CONFIG = {
   sidebar: {
     active: true,
     allowedRoles: ['tester', 'admin'],
+  },
+  'paywall-style': {
+    active: false,
+    allowedRoles: ['sales', 'tester', 'admin'],
+  },
+  'upgrade-cta-copy': {
+    active: false,
+    allowedRoles: ['sales', 'tester', 'admin'],
+  },
+  'pricing-page-layout': {
+    active: false,
+    allowedRoles: ['sales', 'tester', 'admin'],
+  },
+  'trial-length': {
+    active: false,
+    allowedRoles: ['sales', 'tester', 'admin'],
+  },
+  'hero-pitch': {
+    active: false,
+    allowedRoles: ['sales', 'tester', 'admin'],
   },
 };
 


### PR DESCRIPTION
- docs/sales/tiers.md, docs/sales/user-stories.md: 5-tier model (Free, Plus, Pro, Family, Edu) with persona x tier conversion stories
- docs/roles/sales.md: new Sales role for live tier demos and promo-code generation (internal, separated from Admin)
- hooks/useRole.js: Sales role wired with enumerable feature list (no ALL-access)
- features.jsx + flags.json: 10 commerce features (tier-badge, paywall, upgrade-cta, trial-banner, pricing-page, promo-code, referral-program, sales-mode, conversion-analytics, billing-portal-stub)
- src/lib/abExperiments.js: 5 new experiments (paywall-style, upgrade-cta-copy, pricing-page-layout, trial-length, hero-pitch) gated to sales/tester/admin
- docs/roles.md + docs/product-strategy.md: monetization overlay documented

https://claude.ai/code/session_016LnJ6B81eYdaygv279V3R2