### PR TITLE
feat: walk back through nav breadcrumbs on device back

### DIFF
--- a/components/LeaveAppDialog.jsx
+++ b/components/LeaveAppDialog.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import { useTheme } from '../ui/ThemeContext';
+
+export default function LeaveAppDialog({ open, onConfirm, onCancel }) {
+  const { dark: darkMode, hc: highContrast } = useTheme();
+  const confirmRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    confirmRef.current?.focus();
+    const onKey = (e) => {
+      if (e.key === 'Escape') onCancel();
+      if (e.key === 'Enter') onConfirm();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onCancel, onConfirm]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="leave-app-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="leave-app-title"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+      onClick={onCancel}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className={`w-full max-w-sm rounded-2xl shadow-xl p-6 ${
+          highContrast
+            ? (darkMode ? 'bg-black text-white border border-white/60' : 'bg-white text-black border border-black/60')
+            : darkMode
+              ? 'bg-slate-900 text-amber-100 border border-amber-700/40'
+              : 'bg-white text-amber-900 border border-amber-200'
+        }`}
+      >
+        <h2 id="leave-app-title" className="text-lg font-serif font-bold mb-2">
+          App verlassen?
+        </h2>
+        <p className={`text-sm mb-5 ${
+          highContrast ? '' : darkMode ? 'text-amber-300' : 'text-amber-800'
+        }`}>
+          Du bist an der Startseite der App angekommen. Möchtest du die App verlassen und zur Landing Page zurückkehren?
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            data-testid="leave-app-cancel"
+            onClick={onCancel}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              darkMode
+                ? 'text-amber-200 hover:bg-slate-800'
+                : 'text-amber-800 hover:bg-amber-50'
+            }`}
+          >
+            Bleiben
+          </button>
+          <button
+            ref={confirmRef}
+            data-testid="leave-app-confirm"
+            onClick={onConfirm}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              darkMode
+                ? 'bg-amber-700 text-white hover:bg-amber-600'
+                : 'bg-amber-900 text-white hover:bg-amber-800'
+            }`}
+          >
+            Verlassen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -131,7 +131,7 @@ export default function Sidebar({
                 showFavoriteButton
                 alwaysFilled
                 testId="story-button"
-                onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+                onClick={() => { onSelectStory(story); onMenuToggle(); }}
                 onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
                 simplifiedUi={simplifiedUi}
               />
@@ -156,7 +156,7 @@ export default function Sidebar({
                 showWordCount={showWordCount}
                 showFavoriteButton={showFavorites}
                 inlineBadges
-                onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+                onClick={() => { onSelectStory(story); onMenuToggle(); }}
                 onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
                 simplifiedUi={simplifiedUi}
               />
@@ -198,7 +198,7 @@ export default function Sidebar({
                     showWordCount={showWordCount}
                     showFavoriteButton={showFavorites}
                     testId="story-button"
-                    onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+                    onClick={() => { onSelectStory(story); onMenuToggle(); }}
                     onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
                     simplifiedUi={simplifiedUi}
                   />
@@ -285,7 +285,7 @@ export default function Sidebar({
                   showWordCount={showWordCount}
                   showFavoriteButton={showFavorites}
                   testId="story-button"
-                  onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+                  onClick={() => { onSelectStory(story); onMenuToggle(); }}
                   onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
                   simplifiedUi={simplifiedUi}
                 />

--- a/components/SidebarV2.jsx
+++ b/components/SidebarV2.jsx
@@ -209,7 +209,6 @@ export default function SidebarV2({
         if (story) {
           onSelectStory(story);
           onMenuToggle();
-          if (profileOpen) onCloseProfile();
         }
       } else if (e.key === '[') {
         e.preventDefault();
@@ -221,7 +220,7 @@ export default function SidebarV2({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [visibleStoriesFlat, focusIdx, onSelectStory, onMenuToggle, profileOpen, onCloseProfile, searchTerm, onSearchChange, collapseAll, expandAll]);
+  }, [visibleStoriesFlat, focusIdx, onSelectStory, onMenuToggle, searchTerm, onSearchChange, collapseAll, expandAll]);
 
   // Reset keyboard focus when the visible set changes substantially.
   useEffect(() => { setFocusIdx(-1); }, [searchTerm, favoritesOnly, expandedSources]);
@@ -241,7 +240,7 @@ export default function SidebarV2({
         inlineBadges={opts.inlineBadges}
         testId="story-button"
         className={focusIdx === idx ? (darkMode ? 'ring-2 ring-amber-400 rounded-lg' : 'ring-2 ring-amber-500 rounded-lg') : ''}
-        onClick={() => { onSelectStory(story); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+        onClick={() => { onSelectStory(story); onMenuToggle(); }}
         onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
       />
     </div>
@@ -460,7 +459,7 @@ export default function SidebarV2({
                       inlineBadges
                       showFavoriteButton={showFavorites}
                       testId="story-button"
-                      onClick={() => { onSelectStory(s); onMenuToggle(); if (profileOpen) onCloseProfile(); }}
+                      onClick={() => { onSelectStory(s); onMenuToggle(); }}
                       onFavoriteClick={(e) => onToggleFavorite(s.id, e)}
                     />
                   </div>

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -9,6 +9,7 @@ import FeatureDocs from './FeatureDocs';
 import { useRole } from './hooks/useRole';
 import { useABTesting } from './hooks/useABTesting';
 import { useTextToSpeech } from './hooks/useTextToSpeech';
+import { useBreadcrumbNavigation } from './hooks/useBreadcrumbNavigation';
 import { ThemeContext } from './ui/ThemeContext';
 import Toggle from './ui/Toggle';
 import IconButton from './ui/IconButton';
@@ -18,6 +19,7 @@ import HomeView from './components/HomeView';
 import ReaderView from './components/ReaderView';
 import Sidebar from './components/Sidebar';
 import SidebarV2 from './components/SidebarV2';
+import LeaveAppDialog from './components/LeaveAppDialog';
 import TypographyPanel, { LINE_HEIGHTS, WORD_SPACINGS, FONT_FAMILIES } from './ui/TypographyPanel';
 import AudioPlayer from './ui/AudioPlayer';
 import SpeedReaderView from './ui/SpeedReaderView';
@@ -88,10 +90,40 @@ const GrimmMarchenApp = () => {
     setProfileOpen(false);
   }, []);
 
+  // Device-back support: each forward nav registers an undo via
+  // pushBreadcrumb; popstate walks back through them. When the stack is empty
+  // the hook opens a "leave app?" dialog instead of exiting /app.
+  const { pushBreadcrumb, goBack, leavePromptOpen, confirmLeave, cancelLeave } =
+    useBreadcrumbNavigation({
+      onLeaveApp: () => {
+        if (showAppAnimation) {
+          window.dispatchEvent(new CustomEvent('app:request-close'));
+        } else {
+          window.location.assign('/');
+        }
+      },
+    });
+
   const handleSelectSource = React.useCallback((sourceId) => {
+    if (sourceId !== activeSource || activeDirectory !== null) {
+      const prevSource = activeSource;
+      const prevDirectory = activeDirectory;
+      pushBreadcrumb(() => {
+        setActiveSource(prevSource);
+        setActiveDirectory(prevDirectory);
+      });
+    }
     setActiveSource(sourceId);
     setActiveDirectory(null);
-  }, []);
+  }, [activeSource, activeDirectory, pushBreadcrumb]);
+
+  const handleSelectDirectory = React.useCallback((dirId) => {
+    if (dirId !== activeDirectory) {
+      const prevDirectory = activeDirectory;
+      pushBreadcrumb(() => setActiveDirectory(prevDirectory));
+    }
+    setActiveDirectory(dirId);
+  }, [activeDirectory, pushBreadcrumb]);
 
 
   const readerAreaRef = useRef(null);
@@ -132,8 +164,25 @@ const GrimmMarchenApp = () => {
 
   const handleSelectStory = useCallback(async (story) => {
     if (!story) return;
+    const prevStory = selectedStory;
+    const wasProfileOpen = profileOpen;
+    const wasDocsOpen = docsOpen;
+    const prevDocsAnchor = docsAnchor;
+    const wasPersonasOpen = personasDocsOpen;
+    const isSameStory = prevStory && prevStory.id === story.id;
+    if (!isSameStory) {
+      pushBreadcrumb(() => {
+        setSelectedStory(prevStory);
+        if (wasProfileOpen) setProfileOpen(true);
+        if (wasDocsOpen) { setDocsOpen(true); setDocsAnchor(prevDocsAnchor); }
+        if (wasPersonasOpen) setPersonasDocsOpen(true);
+      });
+    }
     setSelectedStory(null);
     setMenuOpen(false);
+    if (wasProfileOpen) setProfileOpen(false);
+    if (wasDocsOpen) { setDocsOpen(false); setDocsAnchor(null); }
+    if (wasPersonasOpen) setPersonasDocsOpen(false);
     setIsStoryLoading(true);
     try {
       const loadedStory = await loadStoryById(story.id);
@@ -150,7 +199,7 @@ const GrimmMarchenApp = () => {
     } finally {
       setIsStoryLoading(false);
     }
-  }, []);
+  }, [selectedStory, profileOpen, docsOpen, docsAnchor, personasDocsOpen, pushBreadcrumb]);
 
   useEffect(() => {
     if (!activeSource || stories.length === 0) return;
@@ -502,6 +551,34 @@ const GrimmMarchenApp = () => {
     }
   }, [showAppAnimation]);
 
+  // Forward nav helpers: register an undo before opening an overlay so device
+  // back reverts to the prior view instead of leaving /app.
+  const handleOpenProfile = useCallback(() => {
+    if (profileOpen) return;
+    pushBreadcrumb(() => setProfileOpen(false));
+    setProfileOpen(true);
+  }, [profileOpen, pushBreadcrumb]);
+
+  const handleOpenDocs = useCallback((anchor) => {
+    pushBreadcrumb(() => {
+      setDocsOpen(false);
+      setDocsAnchor(null);
+      setProfileOpen(true);
+    });
+    setDocsOpen(true);
+    setDocsAnchor(anchor);
+    setProfileOpen(false);
+  }, [pushBreadcrumb]);
+
+  const handleOpenPersonasDocs = useCallback(() => {
+    pushBreadcrumb(() => {
+      setPersonasDocsOpen(false);
+      setProfileOpen(true);
+    });
+    setPersonasDocsOpen(true);
+    setProfileOpen(false);
+  }, [pushBreadcrumb]);
+
   // Throwing inside the render body is caught by the nearest ErrorBoundary.
   // The error-page-simulator uses this to preview the 500 page.
   if (simulatedErrorType === 'unexpected') {
@@ -616,7 +693,7 @@ const GrimmMarchenApp = () => {
           activeSource={activeSource}
           onSelectSource={handleSelectSource}
           activeDirectory={activeDirectory}
-          onSelectDirectory={setActiveDirectory}
+          onSelectDirectory={handleSelectDirectory}
           showStoryDirectories={showStoryDirectories}
           directoriesBySource={directoriesBySource}
           onSelectStory={handleSelectStory}
@@ -631,9 +708,9 @@ const GrimmMarchenApp = () => {
           filteredStories={filteredStories}
           sources={sources}
           storiesBySource={storiesBySource}
-          onOpenProfile={() => setProfileOpen(true)}
+          onOpenProfile={handleOpenProfile}
           profileOpen={profileOpen}
-          onCloseProfile={() => setProfileOpen(false)}
+          onCloseProfile={goBack}
           onCloseApp={handleCloseApp}
           simplifiedUi={showSimplifiedUi}
         />
@@ -657,21 +734,21 @@ const GrimmMarchenApp = () => {
         <main className="flex-1 flex flex-col overflow-hidden w-full">
           {personasDocsOpen ? (
             <PersonasDocsView
-              onBack={() => { setPersonasDocsOpen(false); setProfileOpen(true); }}
+              onBack={goBack}
             />
           ) : docsOpen ? (
             <FeatureDocs
               darkMode={darkMode}
               initialAnchor={docsAnchor}
-              onBack={() => { setDocsOpen(false); setProfileOpen(true); }}
+              onBack={goBack}
               featureState={Object.fromEntries(FEATURES.map(({ key }) => [key, _o(key, _rawFlagValues[key] ?? false)]))}
               onToggle={(key) => setUserFeatureOverrides(prev => ({ ...prev, [key]: !_o(key, _rawFlagValues[key] ?? false) }))}
             />
           ) : profileOpen ? (
             <ProfilePanel
-              onBack={() => setProfileOpen(false)}
-              onOpenDocs={(anchor) => { setDocsOpen(true); setDocsAnchor(anchor); setProfileOpen(false); }}
-              onOpenPersonasDocs={() => { setPersonasDocsOpen(true); setProfileOpen(false); }}
+              onBack={goBack}
+              onOpenDocs={handleOpenDocs}
+              onOpenPersonasDocs={handleOpenPersonasDocs}
               favorites={favorites}
               completedStories={completedStories}
               totalStories={stories.length}
@@ -715,7 +792,16 @@ const GrimmMarchenApp = () => {
               isFlashing={isFlashing}
               srWords={srWords}
               speedReaderMode={speedReaderMode}
-              onSetSpeedReaderMode={setSpeedReaderMode}
+              onSetSpeedReaderMode={(update) => {
+                const next = typeof update === 'function' ? update(speedReaderMode) : update;
+                if (next === speedReaderMode) return;
+                if (next) {
+                  pushBreadcrumb(() => setSpeedReaderMode(false));
+                  setSpeedReaderMode(true);
+                } else {
+                  goBack();
+                }
+              }}
               onGoToPage={goToPage}
               showEinkFlash={showEinkFlash}
               showTapZones={showTapZones}
@@ -754,7 +840,7 @@ const GrimmMarchenApp = () => {
               favorites={favorites}
               onShare={() => handleShare(selectedStory)}
               onToggleFavorite={() => toggleFavoriteById(selectedStory.id)}
-              onClose={() => setSelectedStory(null)}
+              onClose={goBack}
               srFontSizeMin={SPEED_READER_FONT_SIZE.min}
               srFontSizeMax={SPEED_READER_FONT_SIZE.max}
               srFontSizeStep={SPEED_READER_FONT_SIZE.step}
@@ -803,7 +889,7 @@ const GrimmMarchenApp = () => {
           overlay is open so the reader view isn't cluttered. */}
       {!profileOpen && !docsOpen && !personasDocsOpen && !menuOpen && (
         <button
-          onClick={() => setProfileOpen(true)}
+          onClick={handleOpenProfile}
           data-testid="profile-fab"
           aria-label="Mein Profil"
           className={`lg:hidden fixed bottom-5 right-5 z-20 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-all active:scale-95 ${
@@ -817,6 +903,11 @@ const GrimmMarchenApp = () => {
       )}
     </div>
 
+    <LeaveAppDialog
+      open={leavePromptOpen}
+      onConfirm={confirmLeave}
+      onCancel={cancelLeave}
+    />
     {showDebugBadges && <DebugOverlay flagValues={_rawFlagValues} />}
     </ThemeContext.Provider>
   );

--- a/hooks/useBreadcrumbNavigation.js
+++ b/hooks/useBreadcrumbNavigation.js
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Intercepts the device back button so it walks back through in-app
+ * breadcrumbs (e.g. source -> story -> speed-reader) before ever leaving /app.
+ *
+ * Each forward navigation registers an undo via `pushBreadcrumb(undoFn)`. The
+ * hook pushes a matching `history.pushState` entry; when the user triggers
+ * popstate (device back) we pop the stack and run the undo. With the stack
+ * empty, the user is at the app's landing page and further back would leave
+ * /app entirely - the hook surfaces a confirmation dialog via `leavePromptOpen`
+ * instead of letting the browser exit immediately.
+ */
+const SENTINEL = '__wr_breadcrumb_root__';
+const ENTRY = '__wr_breadcrumb_entry__';
+
+export function useBreadcrumbNavigation({ onLeaveApp } = {}) {
+  const stackRef = useRef([]);
+  const [leavePromptOpen, setLeavePromptOpen] = useState(false);
+  const onLeaveAppRef = useRef(onLeaveApp);
+
+  useEffect(() => {
+    onLeaveAppRef.current = onLeaveApp;
+  }, [onLeaveApp]);
+
+  useEffect(() => {
+    // Seed history with a sentinel so the very first device-back press hits
+    // our popstate handler instead of exiting /app straight away.
+    if (!window.history.state || window.history.state.__wrBreadcrumb !== SENTINEL) {
+      window.history.pushState({ __wrBreadcrumb: SENTINEL }, '');
+    }
+
+    const onPop = () => {
+      const handlers = stackRef.current;
+      if (handlers.length > 0) {
+        const back = handlers.pop();
+        try { back(); } catch { /* noop */ }
+        return;
+      }
+      // Stack empty: user would have left /app. Re-seed so follow-up back
+      // presses stay captured, then show the confirmation dialog.
+      window.history.pushState({ __wrBreadcrumb: SENTINEL }, '');
+      setLeavePromptOpen(true);
+    };
+
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+
+  const pushBreadcrumb = useCallback((backFn) => {
+    if (typeof backFn !== 'function') return;
+    stackRef.current.push(backFn);
+    window.history.pushState({ __wrBreadcrumb: ENTRY }, '');
+  }, []);
+
+  const goBack = useCallback(() => {
+    window.history.back();
+  }, []);
+
+  const confirmLeave = useCallback(() => {
+    setLeavePromptOpen(false);
+    onLeaveAppRef.current?.();
+  }, []);
+
+  const cancelLeave = useCallback(() => {
+    setLeavePromptOpen(false);
+  }, []);
+
+  return {
+    pushBreadcrumb,
+    goBack,
+    leavePromptOpen,
+    confirmLeave,
+    cancelLeave,
+  };
+}


### PR DESCRIPTION
Each forward navigation (source, directory, story, profile, docs, personas
docs, speed reader) registers an undo via a new useBreadcrumbNavigation hook
that mirrors the undo onto the history stack via pushState. The popstate
handler pops one breadcrumb at a time so a device-back press now unwinds the
user's path inside /app instead of dropping them on the landing page after
the first press.

When the breadcrumb stack is empty the user would otherwise leave /app, so
the hook surfaces a confirmation dialog (LeaveAppDialog) and only calls the
existing close-app flow when the user opts in.

https://claude.ai/code/session_016ETa6m4JejZZTHtE3E9ms4