### PR TITLE
feat(profile): add grouped profile layout as A/B variant

### DIFF
--- a/components/ProfilePanelGrouped.jsx
+++ b/components/ProfilePanelGrouped.jsx
@@ -1,0 +1,520 @@
+import { useState, useMemo } from 'react';
+import {
+  ChevronLeft, ChevronDown, X, User, Shield, FlameKindling, Users,
+  BadgeCheck, BookOpen, Zap, SlidersHorizontal, Bug,
+} from 'lucide-react';
+import { useTheme } from '../ui/ThemeContext';
+import Toggle from '../ui/Toggle';
+import { ROLES, ROLE_LABELS } from '../hooks/useRole';
+import ABTestingPanel from './ABTestingPanel';
+
+/**
+ * Grouped profile panel (A/B variants: 'grouped', 'role-opt').
+ *
+ * Same data and actions as ProfilePanel, but content is organised into
+ * collapsible sections. The set of sections is fixed; which ones are
+ * open by default depends on the variant:
+ *   - 'grouped'  : every non-empty section is open.
+ *   - 'role-opt' : sections are pre-opened per role (see ROLE_OPEN_SECTIONS).
+ *
+ * Section ids (stable, used in localStorage):
+ *   identity, reading, power, features, admin
+ */
+
+const SECTION_IDS = ['identity', 'reading', 'power', 'features', 'admin'];
+
+const ROLE_OPEN_SECTIONS = {
+  guest:      ['identity', 'reading'],
+  subscriber: ['identity', 'reading', 'power'],
+  tester:     ['identity', 'features', 'admin'],
+  sales:      ['identity', 'reading', 'features'],
+  admin:      SECTION_IDS,
+};
+
+// Features that belong under the "Power-Lesen" section when visible.
+const POWER_FEATURE_KEYS = new Set([
+  'speed-reader', 'speedreader-orp', 'deep-search',
+  'word-blacklist', 'subscriber-fonts',
+]);
+
+function Section({ id, title, Icon, open, onToggle, children, dark, testIdPrefix }) {
+  return (
+    <div className={`rounded-2xl border overflow-hidden ${
+      dark ? 'border-amber-700/30' : 'border-amber-200'
+    }`}>
+      <button
+        type="button"
+        onClick={onToggle}
+        data-testid={`${testIdPrefix}-header-${id}`}
+        aria-expanded={open}
+        className={`w-full flex items-center justify-between gap-3 px-5 py-3.5 text-left transition-colors ${
+          dark ? 'text-amber-200 hover:bg-amber-900/20' : 'text-amber-900 hover:bg-amber-50'
+        }`}
+      >
+        <span className="flex items-center gap-3">
+          <span className={dark ? 'text-amber-500' : 'text-amber-600'}>
+            <Icon size={16} />
+          </span>
+          <span className="text-sm font-semibold">{title}</span>
+        </span>
+        <ChevronDown
+          size={16}
+          className={`transition-transform ${open ? 'rotate-180' : ''} ${
+            dark ? 'text-amber-600' : 'text-amber-500'
+          }`}
+        />
+      </button>
+      {open && (
+        <div
+          data-testid={`${testIdPrefix}-body-${id}`}
+          className={`border-t ${dark ? 'border-amber-700/30' : 'border-amber-200'} p-5`}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ProfilePanelGrouped({
+  onBack,
+  onOpenDocs,
+  onOpenPersonasDocs,
+  favorites,
+  completedStories,
+  totalStories,
+  showWordBlacklist,
+  blacklist,
+  blacklistInput,
+  onBlacklistInputChange,
+  onAddBlacklistWord,
+  onRemoveBlacklistWord,
+  features,
+  _rawFlagValues,
+  userFeatureOverrides,
+  onToggleFeature,
+  role,
+  setRole,
+  isAdmin,
+  visibleFeatureKeys,
+  isFeatureAssignedToRole,
+  toggleFeatureForRole,
+  showErrorPageSimulator,
+  onSimulateError,
+  showAbTesting,
+  showAbTestingAdmin,
+  ab,
+  simplifiedUi = false,
+  variant = 'grouped',
+}) {
+  const { dark } = useTheme();
+
+  const SIMPLIFIED_HIDDEN = new Set([
+    'debug-badges', 'error-page-simulator', 'ab-testing', 'ab-testing-admin',
+    'app-animation', 'word-blacklist', 'speed-reader', 'speedreader-orp',
+    'subscriber-fonts', 'story-directories', 'deep-search', 'pinch-font-size',
+    'read-along', 'illustrations', 'child-profile', 'story-quiz',
+  ]);
+
+  const _o = (key, raw) => Object.hasOwn(userFeatureOverrides, key) ? userFeatureOverrides[key] : raw;
+
+  let visibleFeatures = isAdmin
+    ? features
+    : features.filter((f) => visibleFeatureKeys.has(f.key));
+  if (simplifiedUi && !isAdmin) {
+    visibleFeatures = visibleFeatures.filter((f) => !SIMPLIFIED_HIDDEN.has(f.key));
+  }
+
+  // Partition features: "power" features get their own section.
+  const powerFeatures = visibleFeatures.filter((f) => POWER_FEATURE_KEYS.has(f.key));
+  const otherFeatures = visibleFeatures.filter((f) => !POWER_FEATURE_KEYS.has(f.key));
+
+  const hasAdminTools = isAdmin || showErrorPageSimulator || (ab && (showAbTesting || showAbTestingAdmin));
+
+  // Compute initial-open set for the current variant. Skip sections that would be empty.
+  const initialOpen = useMemo(() => {
+    const wanted = variant === 'role-opt'
+      ? new Set(ROLE_OPEN_SECTIONS[role] ?? ROLE_OPEN_SECTIONS.guest)
+      : new Set(SECTION_IDS);
+    const out = {};
+    for (const id of SECTION_IDS) out[id] = wanted.has(id);
+    return out;
+  }, [variant, role]);
+
+  const [openSections, setOpenSections] = useState(initialOpen);
+  const toggleSection = (id) =>
+    setOpenSections((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  const nonAdminRoles = ROLES.filter((r) => r !== 'admin');
+
+  const renderFeatureRow = ({ key, label, description, Icon }) => {
+    const effective = _o(key, _rawFlagValues[key] ?? false);
+    const isUnreleased = !Object.hasOwn(_rawFlagValues, key);
+    return (
+      <div key={key} className={`px-1 py-3 flex items-start gap-4 border-t first:border-t-0 ${
+        dark ? 'border-amber-700/20 text-amber-200' : 'border-amber-100 text-amber-900'
+      }`}>
+        <div className={`flex-shrink-0 mt-0.5 w-10 h-10 rounded-xl flex items-center justify-center transition-colors ${
+          effective
+            ? dark ? 'bg-amber-700/40 text-amber-300' : 'bg-amber-100 text-amber-700'
+            : dark ? 'bg-slate-700/60 text-amber-700' : 'bg-amber-50/80 text-amber-400'
+        }`}>
+          <div className="w-5 h-5"><Icon /></div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 min-w-0">
+              <p className={`text-sm font-medium transition-opacity ${effective ? '' : 'opacity-40'}`}>{label}</p>
+              {isUnreleased && (
+                <span className={`flex-shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
+                  dark ? 'bg-violet-900/60 text-violet-300' : 'bg-violet-100 text-violet-700'
+                }`}>
+                  unveröffentlicht
+                </span>
+              )}
+            </div>
+            <Toggle checked={effective} onChange={() => onToggleFeature(key)} label={label} />
+          </div>
+          <p className={`text-xs mt-1 leading-relaxed ${dark ? 'text-amber-600' : 'text-amber-500'}`}>{description}</p>
+          <button
+            onClick={() => onOpenDocs(key)}
+            className={`text-xs mt-1 inline-block transition-colors hover:underline ${
+              dark ? 'text-amber-400/70 hover:text-amber-400' : 'text-amber-600/70 hover:text-amber-700'
+            }`}
+          >
+            Mehr erfahren →
+          </button>
+          {isAdmin && (
+            <div className="flex items-center gap-3 mt-2">
+              <span className={`text-[10px] uppercase tracking-wider ${dark ? 'text-amber-700' : 'text-amber-400'}`}>Rollen:</span>
+              {nonAdminRoles.map((r) => {
+                const assigned = isFeatureAssignedToRole(key, r);
+                return (
+                  <button
+                    key={r}
+                    data-testid={`role-assign-${key}-${r}`}
+                    onClick={() => toggleFeatureForRole(key, r)}
+                    className={`text-[10px] font-medium px-2 py-0.5 rounded-full border transition-colors ${
+                      assigned
+                        ? dark ? 'bg-violet-700/60 border-violet-500 text-violet-200' : 'bg-violet-100 border-violet-400 text-violet-800'
+                        : dark ? 'border-amber-800/50 text-amber-800 hover:text-amber-600' : 'border-amber-300 text-amber-400 hover:text-amber-600'
+                    }`}
+                  >
+                    {ROLE_LABELS[r]}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const testIdPrefix = 'profile-section';
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0" data-testid="profile-panel-grouped" data-variant={variant}>
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-lg mx-auto px-6 pt-12 pb-28 lg:pb-12 space-y-4">
+          <button
+            onClick={onBack}
+            data-testid="profile-back-top"
+            className={`hidden lg:flex items-center gap-2 mb-2 text-sm font-medium transition-colors ${
+              dark ? 'text-amber-400 hover:text-amber-200' : 'text-amber-700 hover:text-amber-900'
+            }`}
+          >
+            <ChevronLeft size={16} />
+            Zurück
+          </button>
+
+          {/* §1 Identität */}
+          <Section
+            id="identity"
+            title="Identität"
+            Icon={BadgeCheck}
+            open={openSections.identity}
+            onToggle={() => toggleSection('identity')}
+            dark={dark}
+            testIdPrefix={testIdPrefix}
+          >
+            <div className="flex flex-col items-center gap-4 mb-6">
+              <div className={`w-20 h-20 rounded-full flex items-center justify-center ${
+                isAdmin
+                  ? dark ? 'bg-violet-800 text-violet-200' : 'bg-violet-100 text-violet-700'
+                  : dark ? 'bg-slate-700 text-amber-300' : 'bg-amber-100 text-amber-700'
+              }`}>
+                {isAdmin ? <Shield size={36} /> : <User size={36} />}
+              </div>
+              <div className="text-center">
+                <p className={`text-xl font-serif font-bold ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+                  {ROLE_LABELS[role] ?? role}
+                </p>
+                <p className={`text-sm mt-0.5 ${dark ? 'text-amber-600' : 'text-amber-600'}`}>
+                  {isAdmin ? 'Administrator' : 'Gast-Konto'}
+                </p>
+              </div>
+            </div>
+
+            <h3 className={`text-xs font-semibold uppercase tracking-wider mb-2 px-1 ${
+              dark ? 'text-amber-500' : 'text-amber-600'
+            }`}>
+              Rolle
+            </h3>
+            <div className={`flex rounded-2xl border overflow-hidden ${
+              dark ? 'border-amber-700/30' : 'border-amber-200'
+            }`}>
+              {ROLES.map((r) => (
+                <button
+                  key={r}
+                  data-testid={`role-button-${r}`}
+                  onClick={() => setRole(r)}
+                  className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                    role === r
+                      ? isAdmin && r === 'admin'
+                        ? dark ? 'bg-violet-700 text-white' : 'bg-violet-600 text-white'
+                        : dark ? 'bg-amber-700/50 text-amber-100' : 'bg-amber-100 text-amber-900'
+                      : dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-800'
+                  }`}
+                >
+                  {ROLE_LABELS[r]}
+                </button>
+              ))}
+            </div>
+          </Section>
+
+          {/* §2 Mein Lesen */}
+          <Section
+            id="reading"
+            title="Mein Lesen"
+            Icon={BookOpen}
+            open={openSections.reading}
+            onToggle={() => toggleSection('reading')}
+            dark={dark}
+            testIdPrefix={testIdPrefix}
+          >
+            <div className={`rounded-2xl border divide-y ${
+              dark ? 'border-amber-700/30 divide-amber-700/30' : 'border-amber-200 divide-amber-200'
+            }`}>
+              {[
+                { label: 'Favoriten', value: favorites.size },
+                { label: 'Gelesen', value: completedStories.size },
+                { label: 'Verfügbare Märchen', value: totalStories.toLocaleString('de') },
+              ].map(({ label, value }) => (
+                <div key={label} className={`flex items-center justify-between px-5 py-4 ${
+                  dark ? 'text-amber-200' : 'text-amber-900'
+                }`}>
+                  <span className="text-sm">{label}</span>
+                  <span className="text-sm font-medium tabular-nums">{value}</span>
+                </div>
+              ))}
+            </div>
+            {onOpenPersonasDocs && (
+              <button
+                onClick={onOpenPersonasDocs}
+                className={`mt-4 w-full flex items-center justify-between px-5 py-3.5 rounded-2xl border transition-colors ${
+                  dark
+                    ? 'border-amber-700/30 text-amber-300 hover:bg-amber-900/20'
+                    : 'border-amber-200 text-amber-800 hover:bg-amber-50'
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <Users size={16} className={dark ? 'text-amber-500' : 'text-amber-600'} />
+                  <span className="text-sm font-medium">Product Vision</span>
+                </div>
+                <span className={`text-xs ${dark ? 'text-amber-600' : 'text-amber-500'}`}>
+                  Personas & Feature Map →
+                </span>
+              </button>
+            )}
+          </Section>
+
+          {/* §3 Power-Lesen */}
+          {(powerFeatures.length > 0 || showWordBlacklist) && (
+            <Section
+              id="power"
+              title="Power-Lesen"
+              Icon={Zap}
+              open={openSections.power}
+              onToggle={() => toggleSection('power')}
+              dark={dark}
+              testIdPrefix={testIdPrefix}
+            >
+              {powerFeatures.length > 0 && (
+                <div className="mb-4">
+                  {powerFeatures.map(renderFeatureRow)}
+                </div>
+              )}
+              {showWordBlacklist && (
+                <div>
+                  <h3 className={`text-xs font-semibold uppercase tracking-wider mb-2 px-1 ${
+                    dark ? 'text-amber-500' : 'text-amber-600'
+                  }`}>
+                    Wort-Blacklist
+                  </h3>
+                  <div className={`rounded-2xl border ${dark ? 'border-amber-700/30' : 'border-amber-200'}`}>
+                    <div className={`flex gap-2 px-4 py-3 ${
+                      blacklist.size > 0 ? `border-b ${dark ? 'border-amber-700/30' : 'border-amber-200'}` : ''
+                    }`}>
+                      <input
+                        data-testid="blacklist-input"
+                        type="text"
+                        value={blacklistInput}
+                        onChange={e => onBlacklistInputChange(e.target.value)}
+                        onKeyDown={e => { if (e.key === 'Enter') onAddBlacklistWord(); }}
+                        placeholder="Wort hinzufügen…"
+                        className={`flex-1 bg-transparent text-sm outline-none placeholder:opacity-40 ${
+                          dark ? 'text-amber-100' : 'text-amber-900'
+                        }`}
+                      />
+                      <button
+                        data-testid="blacklist-add"
+                        onClick={onAddBlacklistWord}
+                        disabled={!blacklistInput.trim()}
+                        className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors disabled:opacity-30 ${
+                          dark ? 'bg-amber-700/40 text-amber-200 hover:bg-amber-700/60' : 'bg-amber-100 text-amber-800 hover:bg-amber-200'
+                        }`}
+                      >
+                        Hinzufügen
+                      </button>
+                    </div>
+                    {[...blacklist].map(word => (
+                      <div key={word} className={`flex items-center justify-between px-4 py-2.5 border-b last:border-b-0 ${
+                        dark ? 'border-amber-700/30 text-amber-200' : 'border-amber-200 text-amber-900'
+                      }`}>
+                        <span className="text-sm">{word}</span>
+                        <button
+                          data-testid="blacklist-remove"
+                          onClick={() => onRemoveBlacklistWord(word)}
+                          className={`p-1 rounded transition-colors ${
+                            dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-400 hover:text-amber-700'
+                          }`}
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <p className={`mt-2 px-1 text-xs ${dark ? 'text-amber-700' : 'text-amber-500'}`}>
+                    Märchen, die eines dieser Wörter enthalten, werden in der Seitenleiste ausgeblendet.
+                  </p>
+                </div>
+              )}
+            </Section>
+          )}
+
+          {/* §4 Funktionen */}
+          {otherFeatures.length > 0 && (
+            <Section
+              id="features"
+              title="Funktionen"
+              Icon={SlidersHorizontal}
+              open={openSections.features}
+              onToggle={() => toggleSection('features')}
+              dark={dark}
+              testIdPrefix={testIdPrefix}
+            >
+              <div className="flex items-center justify-between mb-2 px-1">
+                {isAdmin && (
+                  <span className={`text-[10px] normal-case font-normal ${dark ? 'text-violet-400' : 'text-violet-600'}`}>
+                    alle sichtbar (Admin)
+                  </span>
+                )}
+                <button
+                  onClick={() => onOpenDocs()}
+                  className={`ml-auto text-xs transition-colors hover:underline ${
+                    dark ? 'text-amber-400/70 hover:text-amber-400' : 'text-amber-600/70 hover:text-amber-700'
+                  }`}
+                >
+                  Alle Funktionen erklärt →
+                </button>
+              </div>
+              {otherFeatures.map(renderFeatureRow)}
+            </Section>
+          )}
+
+          {/* §5 Entwicklung & Tests — admins + anyone with error simulator / a/b access */}
+          {hasAdminTools && (
+            <Section
+              id="admin"
+              title="Entwicklung & Tests"
+              Icon={Bug}
+              open={openSections.admin}
+              onToggle={() => toggleSection('admin')}
+              dark={dark}
+              testIdPrefix={testIdPrefix}
+            >
+              {showErrorPageSimulator && (
+                <div className="mb-4">
+                  <h3 className={`text-xs font-semibold uppercase tracking-wider mb-2 px-1 flex items-center gap-1.5 ${
+                    dark ? 'text-amber-500' : 'text-amber-600'
+                  }`}>
+                    <FlameKindling size={12} />
+                    Fehlerseiten-Simulator
+                  </h3>
+                  <div className={`rounded-2xl border divide-y ${
+                    dark ? 'border-amber-700/30 divide-amber-700/30' : 'border-amber-200 divide-amber-200'
+                  }`}>
+                    {[
+                      { type: 'not-found', label: '404 – Seite nicht gefunden', desc: 'Navigiert zu einer nicht vorhandenen URL.' },
+                      { type: 'unexpected', label: '500 – Unerwarteter Fehler', desc: 'Wirft eine Exception und löst die Error Boundary aus.' },
+                    ].map(({ type, label, desc }) => (
+                      <div key={type} className={`px-5 py-3.5 flex items-center justify-between gap-4 ${
+                        dark ? 'text-amber-200' : 'text-amber-900'
+                      }`}>
+                        <div>
+                          <p className="text-sm font-medium">{label}</p>
+                          <p className={`text-xs mt-0.5 ${dark ? 'text-amber-600' : 'text-amber-500'}`}>{desc}</p>
+                        </div>
+                        <button
+                          onClick={() => onSimulateError(type)}
+                          className={`flex-shrink-0 text-xs font-medium px-3 py-1.5 rounded-lg transition-colors ${
+                            dark
+                              ? 'bg-amber-700/30 text-amber-300 hover:bg-amber-700/50'
+                              : 'bg-amber-100 text-amber-800 hover:bg-amber-200'
+                          }`}
+                        >
+                          Auslösen
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {ab && (
+                <ABTestingPanel
+                  showAbTesting={showAbTesting}
+                  showAbTestingAdmin={showAbTestingAdmin}
+                  isAdmin={isAdmin}
+                  experiments={ab.experiments}
+                  accessibleExperiments={ab.accessibleExperiments}
+                  getExperimentConfig={ab.getExperimentConfig}
+                  getVariant={ab.getVariant}
+                  setExperimentActive={ab.setExperimentActive}
+                  toggleRoleAccess={ab.toggleRoleAccess}
+                  revokeExperiment={ab.revokeExperiment}
+                  selectVariant={ab.selectVariant}
+                />
+              )}
+            </Section>
+          )}
+        </div>
+      </div>
+
+      <div className={`flex-shrink-0 lg:hidden border-t backdrop-blur-sm ${
+        dark ? 'border-amber-700/30 bg-slate-950/90' : 'border-amber-200 bg-white/90'
+      }`}>
+        <button
+          onClick={onBack}
+          data-testid="profile-back-bottom"
+          className={`w-full flex items-center justify-center gap-2 px-6 py-4 text-base font-medium transition-colors ${
+            dark ? 'text-amber-300 hover:bg-slate-800 active:bg-slate-800' : 'text-amber-800 hover:bg-amber-50 active:bg-amber-100'
+          }`}
+        >
+          <ChevronLeft size={20} />
+          Zurück
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -14,6 +14,7 @@ import { ThemeContext } from './ui/ThemeContext';
 import Toggle from './ui/Toggle';
 import IconButton from './ui/IconButton';
 import ProfilePanel from './components/ProfilePanel';
+import ProfilePanelGrouped from './components/ProfilePanelGrouped';
 import PersonasDocsView from './components/PersonasDocsView';
 import HomeView from './components/HomeView';
 import ReaderView from './components/ReaderView';
@@ -60,6 +61,7 @@ const GrimmMarchenApp = () => {
   // A/B testing
   const ab = useABTesting({ role, isAdmin });
   const sidebarVariant = ab.getVariant('sidebar');
+  const profileLayoutVariant = ab.getVariant('profile-layout');
 
   // Typography
   const typo = useTypography({ maxFontSize, subscriberFonts: showSubscriberFonts });
@@ -745,7 +747,13 @@ const GrimmMarchenApp = () => {
               onToggle={(key) => setUserFeatureOverrides(prev => ({ ...prev, [key]: !_o(key, _rawFlagValues[key] ?? false) }))}
             />
           ) : profileOpen ? (
-            <ProfilePanel
+            (() => {
+              const ProfileComponent = (profileLayoutVariant === 'grouped' || profileLayoutVariant === 'role-opt')
+                ? ProfilePanelGrouped
+                : ProfilePanel;
+              return (
+            <ProfileComponent
+              variant={profileLayoutVariant}
               onBack={goBack}
               onOpenDocs={handleOpenDocs}
               onOpenPersonasDocs={handleOpenPersonasDocs}
@@ -781,6 +789,8 @@ const GrimmMarchenApp = () => {
                 }
               }}
             />
+              );
+            })()
           ) : selectedStory ? (
             <ReaderView
               readerAreaRef={readerAreaRef}

--- a/src/lib/abExperiments.js
+++ b/src/lib/abExperiments.js
@@ -74,6 +74,17 @@ export const AB_EXPERIMENTS = [
     ],
   },
   {
+    id: 'profile-layout',
+    label: 'Profil-Layout',
+    description: 'Gruppierte, ausklappbare Sektionen im Profil vs. heutige flache Liste.',
+    defaultVariant: 'flat',
+    variants: [
+      { id: 'flat',     label: 'Heute (flach)',       description: 'Alle Bloecke untereinander, keine Ausklappen.' },
+      { id: 'grouped',  label: 'Gruppiert',           description: 'Abschnitte sind ausklappbar und standardmaessig offen.' },
+      { id: 'role-opt', label: 'Rollen-optimiert',    description: 'Abschnitte sind ausklappbar, pro Rolle sind andere Abschnitte standardmaessig offen.' },
+    ],
+  },
+  {
     id: 'hero-pitch',
     label: 'Hero-Pitch',
     description: 'Welche Positionierung spricht welche Persona am staerksten an?',
@@ -111,6 +122,10 @@ export const AB_DEFAULT_CONFIG = {
   'hero-pitch': {
     active: false,
     allowedRoles: ['sales', 'tester', 'admin'],
+  },
+  'profile-layout': {
+    active: true,
+    allowedRoles: ['guest', 'subscriber', 'tester', 'sales', 'admin'],
   },
 };
 


### PR DESCRIPTION
Register `profile-layout` experiment (flat/grouped/role-opt) and add a
grouped ProfilePanel variant with five collapsible sections (Identitaet,
Mein Lesen, Power-Lesen, Funktionen, Entwicklung & Tests). In the
role-opt variant, different sections are pre-opened per role so each
audience (guest, subscriber, tester, sales, admin) sees their most
relevant block first.

https://claude.ai/code/session_01875FRk6hxfLozKdpqFL8NF