### PR TITLE
chore(audit): add CTC comments for unimplemented documented features

### DIFF
--- a/components/ProfilePanel.jsx
+++ b/components/ProfilePanel.jsx
@@ -129,6 +129,13 @@ export default function ProfilePanel({
           </div>
         </div>
 
+        {/* CTC: Wire `achievements` here — see docs/features/achievements.md
+              Render a badges grid below this stats block when the
+              `achievements` flag is on: streaks, breadth, depth, discovery,
+              completion. Source data from `completedStories` plus per-source
+              aggregates.
+            TODO(CTC): remove this comment once the achievements grid is
+              rendered and the FEATURES gap entry is removed. */}
         {/* Stats */}
         <div className={`rounded-2xl border divide-y ${
           dark ? 'border-amber-700/30 divide-amber-700/30' : 'border-amber-200 divide-amber-200'

--- a/components/ReaderView.jsx
+++ b/components/ReaderView.jsx
@@ -9,6 +9,17 @@ import SpeedReaderView from '../ui/SpeedReaderView';
 import TypographyPanel from '../ui/TypographyPanel';
 import AudioPlayer from '../ui/AudioPlayer';
 
+// CTC: Wire post-story content slot — see:
+//   - docs/features/discussion-questions.md (Socratic prompts)
+//   - docs/features/journaling-prompts.md (reflection prompts + textarea)
+//   - docs/features/cultural-annotations.md (inline footnotes during reading)
+//   - docs/features/parallel-texts.md (two-column language reading)
+// All four read story-side data (questions.json, annotation spans, content.<lang>.md)
+// and render either inline (annotations, parallel) or after the last page
+// (discussion, journaling) via this compositor.
+// TODO(CTC): remove this comment once the four features are wired and their
+//   FEATURES gap entries are removed.
+
 /**
  * Reader view compositor - manages the entire reading interface.
  * Conditionally renders speed reader mode or normal page view with all controls.

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -4,6 +4,13 @@ import SearchInput from '../ui/SearchInput';
 import StoryButton from '../ui/StoryButton';
 import SourceButton from '../ui/SourceButton';
 
+// CTC: Wire `age-filter` here — see docs/features/age-filter.md
+//   When the flag is on, read `ageMin`/`ageMax` from each story's frontmatter
+//   and hide stories outside the configured child age range. The age range
+//   itself comes from localStorage (set in the profile panel).
+// TODO(CTC): remove this comment once age-filter filtering runs in this file
+//   and the FEATURES gap entry is removed.
+
 /**
  * Sidebar navigation - two-level source/story list with search and profile.
  * Shows either source list, drilled story list, or search results.

--- a/features.jsx
+++ b/features.jsx
@@ -294,3 +294,83 @@ export const FEATURES = [
     Icon: () => <CreditCard size={20} strokeWidth={1.75} />,
   },
 ];
+
+// =============================================================================
+// FEATURE GAPS — registry audit
+// =============================================================================
+// The features below are documented in docs/features/ but NOT yet registered
+// here. Each CTC describes what to add to ship the feature end-to-end.
+//
+// CTC convention:
+//   - "CTC:" marks a Call-To-Claude action item.
+//   - Once the feature is implemented (FEATURES entry + flag in flags.json +
+//     wiring at the listed anchor file), DELETE the corresponding CTC block.
+//   - The matching anchor-site CTC comments in the integration files must be
+//     removed in the same change. Search for "CTC:" across the repo.
+//
+// Sorted by implementation readiness (MVP first, then near-term).
+//
+// --- MVP -------------------------------------------------------------------
+//
+// CTC: Implement `age-filter` — see docs/features/age-filter.md
+//   Add a FEATURES entry (Icon: Filter or BabyIcon), add a `age-filter` flag
+//   to flags.json, store age range in localStorage, and filter the story
+//   index in grimm-reader.jsx (anchor CTC in components/Sidebar.jsx).
+// TODO(CTC): remove this block once `age-filter` is registered above.
+//
+// CTC: Implement `bedtime-mode` — see docs/features/bedtime-mode.md
+//   Add a FEATURES entry (Icon: Moon), add a `bedtime-mode` flag, expose a
+//   nav-bar toggle that dims the screen, picks a curated story queue, and
+//   stops audio at session end. Pairs with sleep-timer.
+// TODO(CTC): remove this block once `bedtime-mode` is registered above.
+//
+// CTC: Implement `sleep-timer` — see docs/features/sleep-timer.md
+//   Add a FEATURES entry (Icon: TimerOff), add a `sleep-timer` flag. Anchor
+//   CTC lives in ui/AudioPlayer.jsx where the fade-out hook into the audio
+//   element belongs.
+// TODO(CTC): remove this block once `sleep-timer` is registered above.
+//
+// --- Near-term -------------------------------------------------------------
+//
+// CTC: Implement `audio-narration` — see docs/features/audio-narration.md
+//   Distinct from `audio-player` (which plays pre-recorded files): this is
+//   full-story narration with optional AI character voices. Add FEATURES
+//   entry (Icon: AudioLines), flag `audio-narration`, and a narration source
+//   field on stories.
+// TODO(CTC): remove this block once `audio-narration` is registered above.
+//
+// CTC: Implement `achievements` — see docs/features/achievements.md
+//   Streaks, breadth, depth, discovery, completion badges. Add FEATURES
+//   entry (Icon: Trophy), flag `achievements`, and a stats slot in the
+//   profile panel (anchor CTC in components/ProfilePanel.jsx near the stats
+//   block).
+// TODO(CTC): remove this block once `achievements` is registered above.
+//
+// CTC: Implement `cultural-annotations` — see docs/features/cultural-annotations.md
+//   Inline footnotes for idioms, history, regional context. Add FEATURES
+//   entry (Icon: Languages), flag `cultural-annotations`, render annotation
+//   spans in components/ReaderView.jsx.
+// TODO(CTC): remove this block once `cultural-annotations` is registered above.
+//
+// CTC: Implement `discussion-questions` — see docs/features/discussion-questions.md
+//   Socratic prompts after the last page. Add FEATURES entry (Icon:
+//   MessageCircleQuestion), flag `discussion-questions`, store prompts in a
+//   `questions.json` per story; render after the attribution slot.
+// TODO(CTC): remove this block once `discussion-questions` is registered above.
+//
+// CTC: Implement `journaling-prompts` — see docs/features/journaling-prompts.md
+//   Personal reflection prompts. Reuse the discussion-questions storage
+//   (type: journal) and add an in-app text area persisted in localStorage.
+//   Add FEATURES entry (Icon: NotebookPen), flag `journaling-prompts`.
+// TODO(CTC): remove this block once `journaling-prompts` is registered above.
+//
+// CTC: Implement `parallel-texts` — see docs/features/parallel-texts.md
+//   Two-column source/target reading. Add FEATURES entry (Icon: Columns2),
+//   flag `parallel-texts`, requires `content.<lang>.md` files. Reader must
+//   call `buildPages` per column with shared height constraints.
+// TODO(CTC): remove this block once `parallel-texts` is registered above.
+//
+// --- Vision (do not implement yet — listed for awareness) -----------------
+// choice-narratives, mood-recommendations, story-map, story-remix,
+// symbol-analysis, word-highlighting, story-api — see docs/features/.
+// =============================================================================

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -356,6 +356,13 @@ const GrimmMarchenApp = () => {
     setSpeedReaderMode,
     storyWordCount,
   } = useReader({
+    // CTC: Add `bedtimeMode` alongside `speedReaderMode` — see docs/features/bedtime-mode.md
+    //   When the `bedtime-mode` flag is on, expose a nav-bar toggle that:
+    //   (1) dims the screen after 30s idle, (2) auto-picks an age-appropriate
+    //   story queue, (3) starts narration, (4) at session end (or sleep-timer
+    //   expiry) fades audio and locks the app.
+    // TODO(CTC): remove this comment once bedtimeMode state and toggle exist
+    //   here and the FEATURES gap entry is removed.
     readerAreaRef,
     measureRef,
     selectedStory,

--- a/hooks/useFeatureFlags.js
+++ b/hooks/useFeatureFlags.js
@@ -109,6 +109,12 @@ export function useFeatureFlags() {
 
   // String flags
   const flagTheme = useStringFlagValue('theme', 'light');
+  // CTC: Register `big-fonts` in features.jsx — see docs/features/big-fonts.md
+  //   This flag is read here and drives `maxFontSize`, but the variant is not
+  //   listed in FEATURES, so users cannot toggle it from the profile panel.
+  //   Add a FEATURES entry that surfaces the four variants (off/big/bigger/
+  //   biggest) — likely as a small variant picker rather than a boolean.
+  // TODO(CTC): remove this comment once `big-fonts` is registered in FEATURES.
   const bigFontsVariant = useStringFlagValue('big-fonts', 'off');
   const maxFontSize = { off: 28, big: 28, bigger: 34, biggest: 40 }[bigFontsVariant] ?? 28;
 

--- a/ui/AudioPlayer.jsx
+++ b/ui/AudioPlayer.jsx
@@ -3,6 +3,14 @@ import { Play, Pause, RotateCcw } from 'lucide-react';
 import { cn } from './cn';
 import { useTheme } from './ThemeContext';
 
+// CTC: Wire `sleep-timer` here — see docs/features/sleep-timer.md
+//   Accept a `sleepAfterMs` prop (or read from a sleep-timer hook). When set,
+//   start a countdown; in the final 60 s tween `audioRef.current.volume`
+//   from 1 → 0 via requestAnimationFrame; on expiry call `pause()`. Surface
+//   timer chips (15 / 30 / 45 min · end of story) in the controls row.
+// TODO(CTC): remove this comment once sleep-timer drives playback here and
+//   the FEATURES gap entry is removed.
+
 /**
  * Self-contained audio player bar with progress, reset, play/pause, and time display.
  * Manages its own audio element and playback state.


### PR DESCRIPTION
Audit of docs/features/ vs FEATURES registry. Adds Call-To-Claude (CTC)
TODO comments at the registry plus the natural integration anchor for
each gap, referencing the feature doc and explaining what to wire.

Gaps surfaced:
  MVP        - age-filter, bedtime-mode, sleep-timer
  Near-term  - audio-narration, achievements, cultural-annotations,
               discussion-questions, journaling-prompts, parallel-texts
  Orphan     - big-fonts (flag exists, no FEATURES entry)

Each CTC includes a TODO instructing removal once the feature ships.

https://claude.ai/code/session_01875FRk6hxfLozKdpqFL8NF