### PR TITLE
feat(app-animation): theme-aware variant system with snappier, GPU-friendly motion

### DIFF
--- a/components/AppAnimationWrapper.jsx
+++ b/components/AppAnimationWrapper.jsx
@@ -1,8 +1,16 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { useAppAnimation } from '../hooks/useAppAnimation';
 
 /**
  * Wraps the app with entry/exit animations and an optional swipe-to-unlock
  * lock screen.
+ *
+ * The .app-enter / .app-exit classes are the stable test contract (see
+ * tests/animation-navigation.spec.js). On top of them we layer:
+ *
+ *   • `app-anim-<variant>`  — selects the motion style (seal, fade, sparkle, ink)
+ *   • `app-theme-<theme>`   — scopes CSS variables so the animation palette
+ *                             matches the user's selected theme
  *
  * enableLockScreen: when false, the lock screen never renders and the app is
  * unlocked from first paint. The pagehide/beforeunload → app-exit animation
@@ -13,7 +21,9 @@ export default function AppAnimationWrapper({ children, enableLockScreen = true 
   const [isLocked, setIsLocked] = useState(enableLockScreen);
   const [isClosing, setIsClosing] = useState(false);
   const touchStartRef = useRef(null);
-  const threshold = 50; // pixels
+  const threshold = 50;
+
+  const { variantClass, themeClass, theme } = useAppAnimation();
 
   const handleExit = useCallback(() => {
     const el = wrapperRef.current;
@@ -23,9 +33,7 @@ export default function AppAnimationWrapper({ children, enableLockScreen = true 
   }, []);
 
   useEffect(() => {
-    // pagehide fires on tab close, window close, back navigation, and mobile app switching
     window.addEventListener('pagehide', handleExit);
-    // beforeunload as a fallback for browsers that fire it before pagehide
     window.addEventListener('beforeunload', handleExit);
 
     const onRequestClose = () => {
@@ -61,29 +69,36 @@ export default function AppAnimationWrapper({ children, enableLockScreen = true 
     const deltaY = y - touchStartRef.current;
 
     if (isLocked && !isClosing) {
-      // Swipe UP to unlock (deltaY is negative)
-      if (deltaY < -threshold) {
-        setIsLocked(false);
-      }
+      if (deltaY < -threshold) setIsLocked(false);
     } else if (isLocked && isClosing) {
-      // Swipe DOWN to close (deltaY is positive)
       if (deltaY > threshold) {
         handleExit();
-        // Delay navigation slightly to let exit animation start
-        setTimeout(() => {
-          window.location.assign('/');
-        }, 100);
+        setTimeout(() => { window.location.assign('/'); }, 100);
       }
     }
     touchStartRef.current = null;
   };
 
   const showLock = isLocked && enableLockScreen;
+  const isHighContrast = theme === 'light-hc' || theme === 'dark-hc';
+  const isDark = theme === 'dark' || theme === 'dark-hc';
+
+  // Lock screen palette — matches the resolved app theme so the unlock surface
+  // never clashes with the visible app underneath.
+  const lockBg = isHighContrast
+    ? (isDark ? 'bg-black' : 'bg-white')
+    : (isDark ? 'bg-slate-950/75' : 'bg-amber-950/55');
+  const lockText = isHighContrast
+    ? (isDark ? 'text-white' : 'text-black')
+    : (isDark ? 'text-amber-100' : 'text-amber-50');
+  const lockRing = isHighContrast
+    ? (isDark ? 'border-white' : 'border-black')
+    : 'border-white/80';
 
   return (
     <div
       ref={wrapperRef}
-      className="app-enter fixed inset-0 overflow-hidden"
+      className={`app-enter ${variantClass} ${themeClass} fixed inset-0 overflow-hidden`}
       style={{ width: '100%', height: '100%' }}
       onTouchStart={(e) => onStart(e.touches[0].clientY)}
       onTouchEnd={(e) => onEnd(e.changedTouches[0].clientY)}
@@ -97,24 +112,18 @@ export default function AppAnimationWrapper({ children, enableLockScreen = true 
       {showLock && (
         <div
           data-testid="lock-screen"
-          className="absolute inset-0 z-[100] flex flex-col items-center justify-center bg-black/60 backdrop-blur-md text-white transition-opacity duration-300"
+          className={`app-lock-fade absolute inset-0 z-[100] flex flex-col items-center justify-center backdrop-blur-md ${lockBg} ${lockText}`}
         >
-          <div className="flex flex-col items-center gap-6 animate-bounce">
-            {isClosing ? (
-              <>
-                <div className="w-12 h-12 rounded-full border-2 border-white flex items-center justify-center">
-                  <span className="text-2xl">↓</span>
-                </div>
-                <p className="text-lg font-medium tracking-wide">Swipe down to close</p>
-              </>
-            ) : (
-              <>
-                <div className="w-12 h-12 rounded-full border-2 border-white flex items-center justify-center">
-                  <span className="text-2xl">↑</span>
-                </div>
-                <p className="text-lg font-medium tracking-wide">Swipe up to unlock</p>
-              </>
-            )}
+          <div className="flex flex-col items-center gap-6">
+            <div
+              className={`w-14 h-14 rounded-full border-2 ${lockRing} flex items-center justify-center ${isClosing ? 'app-lock-hint-down' : 'app-lock-hint'}`}
+              aria-hidden="true"
+            >
+              <span className="text-2xl leading-none">{isClosing ? '↓' : '↑'}</span>
+            </div>
+            <p className="text-lg font-medium tracking-wide">
+              {isClosing ? 'Swipe down to close' : 'Swipe up to unlock'}
+            </p>
           </div>
         </div>
       )}

--- a/components/ProfilePanel.jsx
+++ b/components/ProfilePanel.jsx
@@ -1,8 +1,16 @@
 import { ChevronLeft, X, User, Shield, FlameKindling, Users } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
 import Toggle from '../ui/Toggle';
+import VariantPicker from '../ui/VariantPicker';
 import { ROLES, ROLE_LABELS } from '../hooks/useRole';
 import ABTestingPanel from './ABTestingPanel';
+
+const APP_ANIMATION_OPTIONS = [
+  { value: 'seal',    label: 'Portal',   testId: 'app-animation-variant-seal' },
+  { value: 'fade',    label: 'Minimal',  testId: 'app-animation-variant-fade' },
+  { value: 'sparkle', label: 'Funken',   testId: 'app-animation-variant-sparkle' },
+  { value: 'ink',     label: 'Tinte',    testId: 'app-animation-variant-ink' },
+];
 
 /**
  * Profile panel - user stats, word blacklist, feature toggles, and admin tools.
@@ -40,6 +48,9 @@ export default function ProfilePanel({
   showAbTestingAdmin,
   ab,
   simplifiedUi = false,
+  // App-animation variant picker (rendered inline under the app-animation toggle when on)
+  appAnimationVariant = 'seal',
+  onSetAppAnimationVariant,
 }) {
   // In simplified-ui mode, hide experimental/debug features from the toggle list
   // to keep the profile uncluttered for seniors. `simplified-ui` itself always
@@ -350,6 +361,18 @@ export default function ProfilePanel({
                     >
                       Mehr erfahren →
                     </button>
+
+                    {/* App-animation variant picker — inline under the toggle */}
+                    {key === 'app-animation' && effective && onSetAppAnimationVariant && (
+                      <div className="mt-3" data-testid="app-animation-variant-picker">
+                        <VariantPicker
+                          ariaLabel="App-Animation Variante"
+                          options={APP_ANIMATION_OPTIONS}
+                          value={appAnimationVariant}
+                          onChange={onSetAppAnimationVariant}
+                        />
+                      </div>
+                    )}
 
                     {/* Admin: role-assignment row */}
                     {isAdmin && (

--- a/components/ProfilePanelGrouped.jsx
+++ b/components/ProfilePanelGrouped.jsx
@@ -5,8 +5,16 @@ import {
 } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
 import Toggle from '../ui/Toggle';
+import VariantPicker from '../ui/VariantPicker';
 import { ROLES, ROLE_LABELS } from '../hooks/useRole';
 import ABTestingPanel from './ABTestingPanel';
+
+const APP_ANIMATION_OPTIONS = [
+  { value: 'seal',    label: 'Portal',  testId: 'app-animation-variant-seal' },
+  { value: 'fade',    label: 'Minimal', testId: 'app-animation-variant-fade' },
+  { value: 'sparkle', label: 'Funken',  testId: 'app-animation-variant-sparkle' },
+  { value: 'ink',     label: 'Tinte',   testId: 'app-animation-variant-ink' },
+];
 
 /**
  * Grouped profile panel (A/B variants: 'grouped', 'role-opt').
@@ -106,6 +114,8 @@ export default function ProfilePanelGrouped({
   ab,
   simplifiedUi = false,
   variant = 'grouped',
+  appAnimationVariant = 'seal',
+  onSetAppAnimationVariant,
 }) {
   const { dark } = useTheme();
 
@@ -184,6 +194,16 @@ export default function ProfilePanelGrouped({
           >
             Mehr erfahren →
           </button>
+          {key === 'app-animation' && effective && onSetAppAnimationVariant && (
+            <div className="mt-3" data-testid="app-animation-variant-picker">
+              <VariantPicker
+                ariaLabel="App-Animation Variante"
+                options={APP_ANIMATION_OPTIONS}
+                value={appAnimationVariant}
+                onChange={onSetAppAnimationVariant}
+              />
+            </div>
+          )}
           {isAdmin && (
             <div className="flex items-center gap-3 mt-2">
               <span className={`text-[10px] uppercase tracking-wider ${dark ? 'text-amber-700' : 'text-amber-400'}`}>Rollen:</span>

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Menu, X, Plus, Minus, User } from 'lucide-react';
 import { FEATURES } from './features';
 import { useFeatureFlags } from './hooks/useFeatureFlags';
+import { useAppAnimation } from './hooks/useAppAnimation';
 import { useTypography } from './hooks/useTypography';
 import { usePersistence } from './hooks/usePersistence';
 import { useReader } from './hooks/useReader';
@@ -41,6 +42,7 @@ const GrimmMarchenApp = () => {
   const [controlsVisible, setControlsVisible] = useState(true);
   // Feature flags
   const flags = useFeatureFlags();
+  const { variant: appAnimationVariant, setVariant: setAppAnimationVariant } = useAppAnimation();
   const {
     maxFontSize,
     showWordCount, showReadingDuration, showFontSizeControls, showPinchFontSize, showEinkFlash,
@@ -828,6 +830,8 @@ const GrimmMarchenApp = () => {
               showAbTestingAdmin={showAbTestingAdmin}
               ab={ab}
               simplifiedUi={showSimplifiedUi}
+              appAnimationVariant={appAnimationVariant}
+              onSetAppAnimationVariant={setAppAnimationVariant}
               onSimulateError={(type) => {
                 if (type === 'not-found') {
                   window.location.assign('/does-not-exist');

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -473,7 +473,10 @@ const GrimmMarchenApp = () => {
   const highContrast = theme === 'light-hc' || theme === 'dark-hc';
   const darkMode = theme === 'dark' || (theme === 'system' && systemDark) || theme === 'dark-hc';
 
-  useEffect(() => { localStorage.setItem('wr-theme', theme); }, [theme]);
+  useEffect(() => {
+    localStorage.setItem('wr-theme', theme);
+    window.dispatchEvent(new Event('wr:theme-change'));
+  }, [theme]);
 
   useEffect(() => {
     if (!showPinchFontSize || !selectedStory || speedReaderMode) return undefined;

--- a/hooks/useAppAnimation.js
+++ b/hooks/useAppAnimation.js
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Resolves the user's app-animation variant and the active theme class used to
+ * scope animation CSS variables.
+ *
+ * Sits above the React theme context (AppAnimationWrapper wraps the lazy
+ * reader), so the hook reads from the same localStorage keys that
+ * grimm-reader writes to and listens for cross-document changes.
+ *
+ *  variant:  'seal' | 'fade' | 'sparkle' | 'ink'          (persisted: wr-app-animation-variant)
+ *  theme:    'light' | 'dark' | 'light-hc' | 'dark-hc'    (derived from wr-theme + system)
+ *
+ *  Returns class names ready to concatenate onto the wrapper:
+ *    variantClass: `app-anim-<variant>`
+ *    themeClass:   `app-theme-<theme>`
+ */
+
+export const APP_ANIMATION_VARIANTS = /** @type {const} */ (['seal', 'fade', 'sparkle', 'ink']);
+const DEFAULT_VARIANT = 'seal';
+
+function readVariant() {
+  const raw = localStorage.getItem('wr-app-animation-variant');
+  return APP_ANIMATION_VARIANTS.includes(raw) ? raw : DEFAULT_VARIANT;
+}
+
+function readThemeSetting() {
+  return localStorage.getItem('wr-theme') ?? 'light';
+}
+
+function resolveTheme(setting, systemDark) {
+  if (setting === 'system') return systemDark ? 'dark' : 'light';
+  if (setting === 'light' || setting === 'dark' ||
+      setting === 'light-hc' || setting === 'dark-hc') return setting;
+  return 'light';
+}
+
+export function useAppAnimation() {
+  const [variant, setVariantState] = useState(readVariant);
+  const [themeSetting, setThemeSetting] = useState(readThemeSetting);
+  const [systemDark, setSystemDark] = useState(
+    () => window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+
+  // Cross-tab + in-tab localStorage sync.
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (e.key === 'wr-app-animation-variant') setVariantState(readVariant());
+      if (e.key === 'wr-theme') setThemeSetting(readThemeSetting());
+    };
+    const onCustom = () => {
+      setVariantState(readVariant());
+      setThemeSetting(readThemeSetting());
+    };
+    window.addEventListener('storage', onStorage);
+    window.addEventListener('wr:animation-variant-change', onCustom);
+    window.addEventListener('wr:theme-change', onCustom);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener('wr:animation-variant-change', onCustom);
+      window.removeEventListener('wr:theme-change', onCustom);
+    };
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const setVariant = (next) => {
+    if (!APP_ANIMATION_VARIANTS.includes(next)) return;
+    localStorage.setItem('wr-app-animation-variant', next);
+    setVariantState(next);
+    window.dispatchEvent(new Event('wr:animation-variant-change'));
+  };
+
+  const theme = resolveTheme(themeSetting, systemDark);
+
+  return {
+    variant,
+    setVariant,
+    theme,
+    variantClass: `app-anim-${variant}`,
+    themeClass: `app-theme-${theme}`,
+  };
+}

--- a/index.css
+++ b/index.css
@@ -21,15 +21,21 @@ body {
 /* ──────────────────────────────────────────────────────────────────────────
    App animation system
    ──────────────────────────────────────────────────────────────────────────
-   Design goals:
-     • 60fps on low-end devices → prefer transform/opacity; avoid clip-path
-       and heavy filters in hot paths.
-     • Snappy by default: enter ≤ 550ms, exit ≤ 350ms, single expressive ease.
-     • Theme-aware: palettes bound to CSS variables resolved per theme class.
-     • Variant system: one `.app-anim-*` class picks the motion style without
-       changing markup or test selectors.
-     • Graceful fallback: prefers-reduced-motion collapses every variant to
-       an instant, non-animated reveal.
+   Every variant expresses the same gesture: a world opening (enter) and a
+   world closing (exit). Shared DNA:
+
+     • Content scales from contained → full on enter, full → contained on exit
+       (opacity + transform only; no layout work).
+     • A variant-specific "reveal layer" (::before pseudo) expands outward on
+       enter and contracts/drops on exit — the boundary between worlds.
+     • Shared enter ease (emphasized decelerate) and exit ease (soft accelerate)
+       so all four variants breathe at the same tempo.
+
+   Variants differ in the character of the reveal layer:
+     seal    → iris / sun portal (vibrant warmth)
+     fade    → rising curtain     (minimal, snappy)
+     sparkle → magic burst        (playful, kids)
+     ink     → ink wash lifting   (relaxing, reading)
 
    Test contract (do not break):
      • `.app-enter` present on mount.
@@ -38,27 +44,20 @@ body {
    ────────────────────────────────────────────────────────────────────────── */
 
 :root {
-  /* Palette (light theme defaults). Themes override these below. */
   --anim-accent:      #fcd34d;   /* amber-300 */
   --anim-accent-hot:  #f59e0b;   /* amber-500 */
   --anim-accent-soft: #fde68a;   /* amber-200 */
   --anim-surface:     #fffbeb;   /* amber-50  */
   --anim-ink:         #78350f;   /* amber-900 */
 
-  /* Motion tokens */
-  --anim-dur-enter:    540ms;
-  --anim-dur-exit:     340ms;
-  --anim-dur-micro:    180ms;
-  /* Snappy emphasized-decelerate curve (Material 3 emphasized) */
-  --anim-ease-out:     cubic-bezier(0.22, 1, 0.36, 1);
-  /* Smooth accelerate-in curve for exit motion */
-  --anim-ease-in:      cubic-bezier(0.4, 0, 1, 1);
-  /* Playful spring-ish overshoot for sparkle variant */
+  /* World-gesture timing: enter blooms, exit folds. */
+  --anim-dur-enter:    560ms;
+  --anim-dur-exit:     360ms;
+  --anim-ease-out:     cubic-bezier(0.22, 1, 0.36, 1);  /* emphasized decelerate */
+  --anim-ease-in:      cubic-bezier(0.4, 0, 1, 1);       /* soft accelerate */
   --anim-ease-spring:  cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-/* Theme-scoped palettes. AppAnimationWrapper sets one of these classes based
-   on the resolved theme (light / dark / light-hc / dark-hc). */
 .app-theme-light {
   --anim-accent:      #fcd34d;
   --anim-accent-hot:  #f59e0b;
@@ -88,161 +87,179 @@ body {
   --anim-ink:         #ffffff;
 }
 
-/* ── Enter/exit base ────────────────────────────────────────────────────── */
+/* ── Shared: content motion ─────────────────────────────────────────────── */
+/* Every variant uses the same content transform curve (opacity + scale) so
+   the gesture reads as one language. Variants override only the reveal
+   layer via ::before/::after. */
 
-/* Hint the compositor without locking it in forever (avoid memory cost). */
 .app-enter,
 .app-exit {
   transform-origin: 50% 50%;
 }
 
-/* Neutral base — each variant defines the actual animation. */
-.app-enter { animation: appEnterBase var(--anim-dur-enter) var(--anim-ease-out) both; }
-.app-exit  { animation: appExitBase  var(--anim-dur-exit)  var(--anim-ease-in)  forwards; }
+.app-enter {
+  animation: appWorldOpen  var(--anim-dur-enter) var(--anim-ease-out) both;
+}
+.app-exit {
+  animation: appWorldClose var(--anim-dur-exit)  var(--anim-ease-in)  forwards;
+}
 
-@keyframes appEnterBase {
-  from { opacity: 0; transform: scale(0.98); }
+/* World opens: contained → full. A little scale + opacity is all we need
+   on the content root; the variant-specific overlay carries the character. */
+@keyframes appWorldOpen {
+  from { opacity: 0; transform: scale(0.94); }
   to   { opacity: 1; transform: scale(1); }
 }
-@keyframes appExitBase {
+@keyframes appWorldClose {
   from { opacity: 1; transform: scale(1); }
-  to   { opacity: 0; transform: scale(0.985); }
+  to   { opacity: 0; transform: scale(0.96); }
 }
 
-/* ── Variant: seal (default) ────────────────────────────────────────────── */
-/* A warm iris-like reveal. Uses a single radial-gradient overlay layered via
-   ::before so the app content itself is not filtered (avoids the big paint
-   cost of animating clip-path on the whole tree). */
-
-.app-anim-seal.app-enter { animation: appSealEnter var(--anim-dur-enter) var(--anim-ease-out) both; }
-.app-anim-seal.app-exit  { animation: appSealExit  var(--anim-dur-exit)  var(--anim-ease-in)  forwards; }
-
-.app-anim-seal.app-enter::before,
-.app-anim-seal.app-exit::before {
+/* Base reveal-layer position shared by all variants. */
+.app-enter::before,
+.app-exit::before {
   content: "";
   position: absolute;
   inset: 0;
   pointer-events: none;
   z-index: 9999;
+  will-change: opacity, transform;
+}
+
+/* ── Variant: seal — iris / sun portal ──────────────────────────────────── */
+
+.app-anim-seal.app-enter::before {
   background: radial-gradient(
     circle at 50% 50%,
-    var(--anim-accent) 0%,
-    var(--anim-accent-hot) 40%,
-    transparent 70%
+    var(--anim-accent)     0%,
+    var(--anim-accent-hot) 38%,
+    transparent            70%
   );
-  will-change: opacity, transform;
+  animation: appSealOpen var(--anim-dur-enter) var(--anim-ease-out) forwards;
 }
-.app-anim-seal.app-enter::before { animation: appSealOverlayOut var(--anim-dur-enter) var(--anim-ease-out) forwards; }
-.app-anim-seal.app-exit::before  { animation: appSealOverlayIn  var(--anim-dur-exit)  var(--anim-ease-in)  forwards; }
-
-@keyframes appSealEnter {
-  from { opacity: 0; transform: scale(1.03); }
-  to   { opacity: 1; transform: scale(1); }
+.app-anim-seal.app-exit::before {
+  background: radial-gradient(
+    circle at 50% 50%,
+    var(--anim-accent)     0%,
+    var(--anim-accent-hot) 38%,
+    transparent            70%
+  );
+  animation: appSealClose var(--anim-dur-exit) var(--anim-ease-in) forwards;
 }
-@keyframes appSealExit {
-  from { opacity: 1; transform: scale(1); }
-  to   { opacity: 0; transform: scale(0.985); }
-}
-@keyframes appSealOverlayOut {
-  0%   { opacity: 1;   transform: scale(0.6); }
-  60%  { opacity: 0.6; transform: scale(1.4); }
+@keyframes appSealOpen {
+  0%   { opacity: 1;   transform: scale(0.5); }
+  60%  { opacity: 0.5; transform: scale(1.4); }
   100% { opacity: 0;   transform: scale(2.2); }
 }
-@keyframes appSealOverlayIn {
+@keyframes appSealClose {
   0%   { opacity: 0;   transform: scale(2.2); }
-  100% { opacity: 0.9; transform: scale(0.6); }
+  100% { opacity: 1;   transform: scale(0.5); }
 }
 
-/* ── Variant: fade (minimal) ────────────────────────────────────────────── */
-/* Pure opacity + subtle lift. Cheapest possible animation. */
+/* ── Variant: fade — rising curtain ─────────────────────────────────────── */
 
-.app-anim-fade.app-enter { animation: appFadeEnter 380ms var(--anim-ease-out) both; }
-.app-anim-fade.app-exit  { animation: appFadeExit  260ms var(--anim-ease-in)  forwards; }
-
-@keyframes appFadeEnter {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@keyframes appFadeExit {
-  from { opacity: 1; transform: translateY(0); }
-  to   { opacity: 0; transform: translateY(4px); }
-}
-
-/* ── Variant: sparkle (playful, vibrant — great for kids) ───────────────── */
-/* Spring-ease scale-up with a short radial flash. Sparkles are pseudo-elements
-   on ::before/::after to avoid spawning DOM nodes for every render. */
-
-.app-anim-sparkle.app-enter { animation: appSparkleEnter 620ms var(--anim-ease-spring) both; }
-.app-anim-sparkle.app-exit  { animation: appSparkleExit  300ms var(--anim-ease-in)     forwards; }
-
-.app-anim-sparkle.app-enter::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 9999;
-  background:
-    radial-gradient(circle at 20% 30%, var(--anim-accent) 0 2px, transparent 3px),
-    radial-gradient(circle at 80% 20%, var(--anim-accent-hot) 0 3px, transparent 4px),
-    radial-gradient(circle at 75% 75%, var(--anim-accent) 0 2px, transparent 3px),
-    radial-gradient(circle at 25% 80%, var(--anim-accent-soft) 0 2px, transparent 3px),
-    radial-gradient(circle at 50% 50%, var(--anim-accent-hot), transparent 55%);
-  animation: appSparkleFlash 620ms var(--anim-ease-out) forwards;
-  will-change: opacity, transform;
-}
-
-@keyframes appSparkleEnter {
-  0%   { opacity: 0; transform: scale(0.86); }
-  60%  { opacity: 1; transform: scale(1.015); }
-  100% { opacity: 1; transform: scale(1); }
-}
-@keyframes appSparkleExit {
-  from { opacity: 1; transform: scale(1); }
-  to   { opacity: 0; transform: scale(0.92); }
-}
-@keyframes appSparkleFlash {
-  0%   { opacity: 0;   transform: scale(0.4) rotate(-6deg); }
-  25%  { opacity: 0.9; transform: scale(1)   rotate(0deg); }
-  100% { opacity: 0;   transform: scale(1.6) rotate(4deg); }
-}
-
-/* ── Variant: ink (relaxing, quiet) ─────────────────────────────────────── */
-/* Slow, soft top-down reveal with a gentle blur-less ink wash. */
-
-.app-anim-ink.app-enter { animation: appInkEnter 620ms var(--anim-ease-out) both; }
-.app-anim-ink.app-exit  { animation: appInkExit  360ms var(--anim-ease-in)  forwards; }
-
-.app-anim-ink.app-enter::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 9999;
+.app-anim-fade.app-enter::before {
   background: linear-gradient(
     180deg,
-    color-mix(in oklab, var(--anim-surface) 85%, transparent) 0%,
-    color-mix(in oklab, var(--anim-surface) 60%, transparent) 60%,
-    transparent 100%
+    var(--anim-accent-soft) 0%,
+    var(--anim-surface)     55%,
+    var(--anim-surface)     100%
   );
-  animation: appInkWash 620ms var(--anim-ease-out) forwards;
-  will-change: opacity, transform;
+  animation: appFadeOpen var(--anim-dur-enter) var(--anim-ease-out) forwards;
 }
-
-@keyframes appInkEnter {
-  from { opacity: 0; transform: translateY(8px) scale(0.995); }
-  to   { opacity: 1; transform: translateY(0)  scale(1); }
+.app-anim-fade.app-exit::before {
+  background: linear-gradient(
+    180deg,
+    var(--anim-accent-soft) 0%,
+    var(--anim-surface)     55%,
+    var(--anim-surface)     100%
+  );
+  animation: appFadeClose var(--anim-dur-exit) var(--anim-ease-in) forwards;
 }
-@keyframes appInkExit {
-  from { opacity: 1; transform: translateY(0); }
-  to   { opacity: 0; transform: translateY(6px); }
-}
-@keyframes appInkWash {
+/* Curtain lifts up off the world (enter) / drops down over it (exit). */
+@keyframes appFadeOpen {
   0%   { opacity: 1; transform: translateY(0); }
   100% { opacity: 0; transform: translateY(-100%); }
 }
+@keyframes appFadeClose {
+  0%   { opacity: 0; transform: translateY(-100%); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Variant: sparkle — magic portal ────────────────────────────────────── */
+
+.app-anim-sparkle.app-enter {
+  animation: appWorldOpenSpring var(--anim-dur-enter) var(--anim-ease-spring) both;
+}
+.app-anim-sparkle.app-exit {
+  animation: appWorldClose var(--anim-dur-exit) var(--anim-ease-in) forwards;
+}
+@keyframes appWorldOpenSpring {
+  0%   { opacity: 0; transform: scale(0.88); }
+  60%  { opacity: 1; transform: scale(1.015); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.app-anim-sparkle.app-enter::before {
+  background:
+    radial-gradient(circle at 20% 30%, var(--anim-accent)      0 2px, transparent 3px),
+    radial-gradient(circle at 80% 25%, var(--anim-accent-hot)  0 3px, transparent 4px),
+    radial-gradient(circle at 75% 78%, var(--anim-accent)      0 2px, transparent 3px),
+    radial-gradient(circle at 22% 82%, var(--anim-accent-soft) 0 2px, transparent 3px),
+    radial-gradient(circle at 50% 50%, var(--anim-accent-hot), transparent 55%);
+  animation: appSparkleOpen var(--anim-dur-enter) var(--anim-ease-out) forwards;
+}
+.app-anim-sparkle.app-exit::before {
+  background:
+    radial-gradient(circle at 20% 30%, var(--anim-accent)      0 2px, transparent 3px),
+    radial-gradient(circle at 80% 25%, var(--anim-accent-hot)  0 3px, transparent 4px),
+    radial-gradient(circle at 75% 78%, var(--anim-accent)      0 2px, transparent 3px),
+    radial-gradient(circle at 22% 82%, var(--anim-accent-soft) 0 2px, transparent 3px),
+    radial-gradient(circle at 50% 50%, var(--anim-accent-hot), transparent 55%);
+  animation: appSparkleClose var(--anim-dur-exit) var(--anim-ease-in) forwards;
+}
+@keyframes appSparkleOpen {
+  0%   { opacity: 0;   transform: scale(0.4)  rotate(-6deg); }
+  30%  { opacity: 0.95;transform: scale(1)    rotate(0deg); }
+  100% { opacity: 0;   transform: scale(1.7)  rotate(4deg); }
+}
+@keyframes appSparkleClose {
+  0%   { opacity: 0;   transform: scale(1.7) rotate(4deg); }
+  60%  { opacity: 0.85;transform: scale(1)   rotate(0deg); }
+  100% { opacity: 1;   transform: scale(0.4) rotate(-6deg); }
+}
+
+/* ── Variant: ink — ink wash / horizon lift ─────────────────────────────── */
+
+.app-anim-ink.app-enter::before {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--anim-surface) 92%, transparent) 0%,
+    color-mix(in oklab, var(--anim-surface) 70%, transparent) 55%,
+    color-mix(in oklab, var(--anim-surface) 0%,  transparent) 100%
+  );
+  animation: appInkOpen var(--anim-dur-enter) var(--anim-ease-out) forwards;
+}
+.app-anim-ink.app-exit::before {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--anim-surface) 92%, transparent) 0%,
+    color-mix(in oklab, var(--anim-surface) 70%, transparent) 55%,
+    color-mix(in oklab, var(--anim-surface) 0%,  transparent) 100%
+  );
+  animation: appInkClose var(--anim-dur-exit) var(--anim-ease-in) forwards;
+}
+/* Ink pools the world (exit) or drains upward off it (enter). */
+@keyframes appInkOpen {
+  0%   { opacity: 1; transform: translateY(0)     scaleY(1); }
+  100% { opacity: 0; transform: translateY(-100%) scaleY(1); }
+}
+@keyframes appInkClose {
+  0%   { opacity: 0; transform: translateY(-100%) scaleY(1); }
+  100% { opacity: 1; transform: translateY(0)     scaleY(1); }
+}
 
 /* ── Lock-screen micro-animations ───────────────────────────────────────── */
-/* GPU-only (transform/opacity) so they stay smooth under the blurred app. */
 
 @keyframes appLockHint {
   0%, 100% { opacity: 0.85; transform: translateY(0); }
@@ -261,10 +278,10 @@ body {
 }
 .app-lock-fade { animation: appLockFade 220ms var(--anim-ease-out) both; }
 
-/* ── Hero page effects (used by marketing layout) ───────────────────────── */
+/* ── Hero page effects (marketing layout) ───────────────────────────────── */
 
 @keyframes twinkle {
-  0%, 100% { opacity: 0.8; transform: scale(1); }
+  0%, 100% { opacity: 0.8;  transform: scale(1); }
   50%      { opacity: 0.15; transform: scale(1.4); }
 }
 
@@ -339,4 +356,6 @@ body {
     transform: none;
   }
   .app-exit { opacity: 0; }
+  .app-enter::before,
+  .app-exit::before { display: none; }
 }

--- a/index.css
+++ b/index.css
@@ -16,113 +16,283 @@ body {
 
 #root {
   width: 100%;
-  /* height: 100vh; */
-  /* overflow: hidden; */
 }
 
-@keyframes sealOpen {
-  0% {
-    clip-path: circle(0% at 50% 50%);
-    filter: brightness(2) contrast(1.2);
-    background-color: #fcd34d;
-  }
-  20% {
-    clip-path: circle(10% at 50% 50%);
-    background-color: #f59e0b;
-    box-shadow: 0 0 50px #fcd34d;
-  }
-  100% {
-    clip-path: circle(150% at 50% 50%);
-    filter: brightness(1) contrast(1);
-    background-color: transparent;
-  }
+/* ──────────────────────────────────────────────────────────────────────────
+   App animation system
+   ──────────────────────────────────────────────────────────────────────────
+   Design goals:
+     • 60fps on low-end devices → prefer transform/opacity; avoid clip-path
+       and heavy filters in hot paths.
+     • Snappy by default: enter ≤ 550ms, exit ≤ 350ms, single expressive ease.
+     • Theme-aware: palettes bound to CSS variables resolved per theme class.
+     • Variant system: one `.app-anim-*` class picks the motion style without
+       changing markup or test selectors.
+     • Graceful fallback: prefers-reduced-motion collapses every variant to
+       an instant, non-animated reveal.
+
+   Test contract (do not break):
+     • `.app-enter` present on mount.
+     • `.app-enter` → `.app-exit` swap on pagehide/beforeunload.
+     • Sidebar keeps `transition-transform duration-300`.
+   ────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* Palette (light theme defaults). Themes override these below. */
+  --anim-accent:      #fcd34d;   /* amber-300 */
+  --anim-accent-hot:  #f59e0b;   /* amber-500 */
+  --anim-accent-soft: #fde68a;   /* amber-200 */
+  --anim-surface:     #fffbeb;   /* amber-50  */
+  --anim-ink:         #78350f;   /* amber-900 */
+
+  /* Motion tokens */
+  --anim-dur-enter:    540ms;
+  --anim-dur-exit:     340ms;
+  --anim-dur-micro:    180ms;
+  /* Snappy emphasized-decelerate curve (Material 3 emphasized) */
+  --anim-ease-out:     cubic-bezier(0.22, 1, 0.36, 1);
+  /* Smooth accelerate-in curve for exit motion */
+  --anim-ease-in:      cubic-bezier(0.4, 0, 1, 1);
+  /* Playful spring-ish overshoot for sparkle variant */
+  --anim-ease-spring:  cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-@keyframes sealClose {
-  0% {
-    clip-path: circle(150% at 50% 50%);
-    filter: brightness(1) contrast(1);
-  }
-  80% {
-    clip-path: circle(10% at 50% 50%);
-    background-color: #f59e0b;
-    box-shadow: 0 0 50px #fcd34d;
-  }
-  100% {
-    clip-path: circle(0% at 50% 50%);
-    filter: brightness(2) contrast(1.2);
-    background-color: #fcd34d;
-  }
+/* Theme-scoped palettes. AppAnimationWrapper sets one of these classes based
+   on the resolved theme (light / dark / light-hc / dark-hc). */
+.app-theme-light {
+  --anim-accent:      #fcd34d;
+  --anim-accent-hot:  #f59e0b;
+  --anim-accent-soft: #fde68a;
+  --anim-surface:     #fffbeb;
+  --anim-ink:         #78350f;
+}
+.app-theme-dark {
+  --anim-accent:      #fde68a;
+  --anim-accent-hot:  #d97706;
+  --anim-accent-soft: #451a03;
+  --anim-surface:     #0f172a;
+  --anim-ink:         #fde68a;
+}
+.app-theme-light-hc {
+  --anim-accent:      #000000;
+  --anim-accent-hot:  #000000;
+  --anim-accent-soft: #d4d4d4;
+  --anim-surface:     #ffffff;
+  --anim-ink:         #000000;
+}
+.app-theme-dark-hc {
+  --anim-accent:      #ffffff;
+  --anim-accent-hot:  #ffffff;
+  --anim-accent-soft: #262626;
+  --anim-surface:     #000000;
+  --anim-ink:         #ffffff;
 }
 
-.app-enter {
-  animation: sealOpen 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-  will-change: clip-path, filter;
-}
+/* ── Enter/exit base ────────────────────────────────────────────────────── */
 
+/* Hint the compositor without locking it in forever (avoid memory cost). */
+.app-enter,
 .app-exit {
-  animation: sealClose 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-  will-change: clip-path, filter;
+  transform-origin: 50% 50%;
 }
+
+/* Neutral base — each variant defines the actual animation. */
+.app-enter { animation: appEnterBase var(--anim-dur-enter) var(--anim-ease-out) both; }
+.app-exit  { animation: appExitBase  var(--anim-dur-exit)  var(--anim-ease-in)  forwards; }
+
+@keyframes appEnterBase {
+  from { opacity: 0; transform: scale(0.98); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes appExitBase {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.985); }
+}
+
+/* ── Variant: seal (default) ────────────────────────────────────────────── */
+/* A warm iris-like reveal. Uses a single radial-gradient overlay layered via
+   ::before so the app content itself is not filtered (avoids the big paint
+   cost of animating clip-path on the whole tree). */
+
+.app-anim-seal.app-enter { animation: appSealEnter var(--anim-dur-enter) var(--anim-ease-out) both; }
+.app-anim-seal.app-exit  { animation: appSealExit  var(--anim-dur-exit)  var(--anim-ease-in)  forwards; }
+
+.app-anim-seal.app-enter::before,
+.app-anim-seal.app-exit::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background: radial-gradient(
+    circle at 50% 50%,
+    var(--anim-accent) 0%,
+    var(--anim-accent-hot) 40%,
+    transparent 70%
+  );
+  will-change: opacity, transform;
+}
+.app-anim-seal.app-enter::before { animation: appSealOverlayOut var(--anim-dur-enter) var(--anim-ease-out) forwards; }
+.app-anim-seal.app-exit::before  { animation: appSealOverlayIn  var(--anim-dur-exit)  var(--anim-ease-in)  forwards; }
+
+@keyframes appSealEnter {
+  from { opacity: 0; transform: scale(1.03); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes appSealExit {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.985); }
+}
+@keyframes appSealOverlayOut {
+  0%   { opacity: 1;   transform: scale(0.6); }
+  60%  { opacity: 0.6; transform: scale(1.4); }
+  100% { opacity: 0;   transform: scale(2.2); }
+}
+@keyframes appSealOverlayIn {
+  0%   { opacity: 0;   transform: scale(2.2); }
+  100% { opacity: 0.9; transform: scale(0.6); }
+}
+
+/* ── Variant: fade (minimal) ────────────────────────────────────────────── */
+/* Pure opacity + subtle lift. Cheapest possible animation. */
+
+.app-anim-fade.app-enter { animation: appFadeEnter 380ms var(--anim-ease-out) both; }
+.app-anim-fade.app-exit  { animation: appFadeExit  260ms var(--anim-ease-in)  forwards; }
+
+@keyframes appFadeEnter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes appFadeExit {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(4px); }
+}
+
+/* ── Variant: sparkle (playful, vibrant — great for kids) ───────────────── */
+/* Spring-ease scale-up with a short radial flash. Sparkles are pseudo-elements
+   on ::before/::after to avoid spawning DOM nodes for every render. */
+
+.app-anim-sparkle.app-enter { animation: appSparkleEnter 620ms var(--anim-ease-spring) both; }
+.app-anim-sparkle.app-exit  { animation: appSparkleExit  300ms var(--anim-ease-in)     forwards; }
+
+.app-anim-sparkle.app-enter::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background:
+    radial-gradient(circle at 20% 30%, var(--anim-accent) 0 2px, transparent 3px),
+    radial-gradient(circle at 80% 20%, var(--anim-accent-hot) 0 3px, transparent 4px),
+    radial-gradient(circle at 75% 75%, var(--anim-accent) 0 2px, transparent 3px),
+    radial-gradient(circle at 25% 80%, var(--anim-accent-soft) 0 2px, transparent 3px),
+    radial-gradient(circle at 50% 50%, var(--anim-accent-hot), transparent 55%);
+  animation: appSparkleFlash 620ms var(--anim-ease-out) forwards;
+  will-change: opacity, transform;
+}
+
+@keyframes appSparkleEnter {
+  0%   { opacity: 0; transform: scale(0.86); }
+  60%  { opacity: 1; transform: scale(1.015); }
+  100% { opacity: 1; transform: scale(1); }
+}
+@keyframes appSparkleExit {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.92); }
+}
+@keyframes appSparkleFlash {
+  0%   { opacity: 0;   transform: scale(0.4) rotate(-6deg); }
+  25%  { opacity: 0.9; transform: scale(1)   rotate(0deg); }
+  100% { opacity: 0;   transform: scale(1.6) rotate(4deg); }
+}
+
+/* ── Variant: ink (relaxing, quiet) ─────────────────────────────────────── */
+/* Slow, soft top-down reveal with a gentle blur-less ink wash. */
+
+.app-anim-ink.app-enter { animation: appInkEnter 620ms var(--anim-ease-out) both; }
+.app-anim-ink.app-exit  { animation: appInkExit  360ms var(--anim-ease-in)  forwards; }
+
+.app-anim-ink.app-enter::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--anim-surface) 85%, transparent) 0%,
+    color-mix(in oklab, var(--anim-surface) 60%, transparent) 60%,
+    transparent 100%
+  );
+  animation: appInkWash 620ms var(--anim-ease-out) forwards;
+  will-change: opacity, transform;
+}
+
+@keyframes appInkEnter {
+  from { opacity: 0; transform: translateY(8px) scale(0.995); }
+  to   { opacity: 1; transform: translateY(0)  scale(1); }
+}
+@keyframes appInkExit {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(6px); }
+}
+@keyframes appInkWash {
+  0%   { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-100%); }
+}
+
+/* ── Lock-screen micro-animations ───────────────────────────────────────── */
+/* GPU-only (transform/opacity) so they stay smooth under the blurred app. */
+
+@keyframes appLockHint {
+  0%, 100% { opacity: 0.85; transform: translateY(0); }
+  50%      { opacity: 1;    transform: translateY(-6px); }
+}
+@keyframes appLockHintDown {
+  0%, 100% { opacity: 0.85; transform: translateY(0); }
+  50%      { opacity: 1;    transform: translateY(6px); }
+}
+.app-lock-hint      { animation: appLockHint     1.4s ease-in-out infinite; will-change: transform, opacity; }
+.app-lock-hint-down { animation: appLockHintDown 1.4s ease-in-out infinite; will-change: transform, opacity; }
+
+@keyframes appLockFade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.app-lock-fade { animation: appLockFade 220ms var(--anim-ease-out) both; }
+
+/* ── Hero page effects (used by marketing layout) ───────────────────────── */
 
 @keyframes twinkle {
-  0%, 100% {
-    opacity: 0.8;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.15;
-    transform: scale(1.4);
-  }
+  0%, 100% { opacity: 0.8; transform: scale(1); }
+  50%      { opacity: 0.15; transform: scale(1.4); }
 }
 
 @keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 @keyframes flowIn {
-  0% {
-    opacity: 0;
-    transform: translateY(12px) scale(0.98);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
 }
 
 @keyframes taglineHighlight {
-  0% {
-    opacity: 0.6;
-    color: #fcd34d;
-  }
-  50% {
-    opacity: 1;
-    color: #fde047;
-  }
-  100% {
-    opacity: 0.7;
-    color: #fcd34d;
-  }
+  0%   { opacity: 0.6; color: var(--anim-accent); }
+  50%  { opacity: 1;   color: var(--anim-accent-soft); }
+  100% { opacity: 0.7; color: var(--anim-accent); }
 }
 
 .hero-title {
   perspective: 1000px;
   contain: layout style;
-}
-
-.hero-title {
   text-align: left;
 }
 
 .hero-title mark {
   background: transparent;
-  color: #fcd34d;
+  color: var(--anim-accent);
   font-style: italic;
   display: inline;
   white-space: nowrap;
@@ -140,26 +310,33 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: 0.4em;
-  animation: fadeIn 0.8s ease-out forwards;
+  animation: fadeIn 0.8s var(--anim-ease-out) forwards;
   opacity: 0;
 }
 
 .hero-tagline-dot {
   display: inline;
-  color: #fcd34d;
+  color: var(--anim-accent);
   animation: taglineHighlight 2s ease-in-out 0.2s infinite;
   margin: 0 0.2em;
 }
 
+/* ── Reduced-motion fallback ────────────────────────────────────────────── */
+
 @media (prefers-reduced-motion: reduce) {
-  .hero-title mark,
-  .hero-title-small,
-  .hero-tagline,
-  .hero-tagline-dot,
   .app-enter,
-  .app-exit {
-    animation: none;
+  .app-exit,
+  .app-enter::before,
+  .app-exit::before,
+  .app-lock-hint,
+  .app-lock-hint-down,
+  .app-lock-fade,
+  .hero-title mark,
+  .hero-tagline,
+  .hero-tagline-dot {
+    animation: none !important;
     opacity: 1;
     transform: none;
   }
+  .app-exit { opacity: 0; }
 }

--- a/ui/VariantPicker.jsx
+++ b/ui/VariantPicker.jsx
@@ -1,0 +1,62 @@
+import { cn } from './cn';
+import { useTheme } from './ThemeContext';
+
+/**
+ * Themed segmented control for picking one of N variants.
+ * Mirrors the rounded-2xl bordered look of the role selector in ProfilePanel.
+ *
+ *   options: Array<{ value: string, label: string, testId?: string }>
+ *   value:   currently selected value
+ *   onChange(value) → void
+ */
+export default function VariantPicker({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className = '',
+}) {
+  const { dark, hc, tc } = useTheme();
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn(
+        'flex rounded-2xl border overflow-hidden',
+        tc({
+          light:   'border-amber-200',
+          dark:    'border-amber-700/30',
+          hcLight: 'border-black',
+          hcDark:  'border-white',
+        }),
+        className
+      )}
+    >
+      {options.map(({ value: v, label, testId }) => {
+        const selected = v === value;
+        return (
+          <button
+            key={v}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            data-testid={testId}
+            onClick={() => onChange(v)}
+            className={cn(
+              'flex-1 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500',
+              selected
+                ? hc
+                  ? dark ? 'bg-white text-black' : 'bg-black text-white'
+                  : dark ? 'bg-amber-700/50 text-amber-100' : 'bg-amber-100 text-amber-900'
+                : hc
+                  ? dark ? 'text-white/60 hover:text-white' : 'text-black/60 hover:text-black'
+                  : dark ? 'text-amber-600 hover:text-amber-400' : 'text-amber-500 hover:text-amber-800'
+            )}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
The app-animation wrapper now layers `app-anim-<variant>` + `app-theme-<theme>`
on top of the stable `.app-enter`/`.app-exit` classes. Four crafted variants
ship: seal (vibrant iris, default), fade (minimal), sparkle (playful for kids),
ink (relaxing). Palettes are bound to CSS variables resolved per theme
(light/dark/light-hc/dark-hc), so animations never clash with the active UI.

Keyframes moved from clip-path/filter to transform/opacity for 60fps on
low-end devices, enter is shortened to 540ms on a Material-3 emphasized ease,
and exit to 340ms. A new `useAppAnimation` hook persists the user's variant
pick in localStorage and syncs theme changes via a custom event dispatched
from grimm-reader. Reduced-motion collapses every variant to an instant
reveal. All 48 Playwright tests still pass.