### PR TITLE
feat(sidebar-v2): add collections blade + swipe gestures

### DIFF
--- a/components/SidebarV2.jsx
+++ b/components/SidebarV2.jsx
@@ -17,10 +17,15 @@ import StoryButton from '../ui/StoryButton';
  *  - Auto-scroll: the active story is scrolled into view when it changes.
  *  - Persistent expansion state in localStorage; opens the source containing
  *    the active story automatically.
+ *  - Collections blade: when the `collections` flag is on, installed collections
+ *    render in their own vertical blade, separate from the main stories list.
+ *  - Swipe gestures: swipe right from the left edge opens the sidebar; swipe
+ *    left anywhere while it's open closes it.
  */
 export default function SidebarV2({
   menuOpen,
   onMenuToggle,
+  onMenuOpenChange,
   searchTerm,
   onSearchChange,
   showDeepSearch,
@@ -45,6 +50,8 @@ export default function SidebarV2({
   filteredStories,
   sources,
   storiesBySource,
+  showCollections,
+  collectionSources,
   onOpenProfile,
   profileOpen,
   profileActiveTab,
@@ -63,6 +70,17 @@ export default function SidebarV2({
   const EXPANDED_DIRS_KEY = 'wr-sidebar-v2-expanded-dirs';
   const FAVSHELF_KEY = 'wr-sidebar-v2-favshelf-open';
   const PROFILE_GROUP_KEY = 'wr-sidebar-v2-profile-open';
+  const COLLECTIONS_GROUP_KEY = 'wr-sidebar-v2-collections-open';
+
+  const collectionSourceIds = useMemo(
+    () => new Set((collectionSources ?? []).map((s) => s.id)),
+    [collectionSources],
+  );
+  const storySources = useMemo(
+    () => (showCollections ? sources.filter((s) => !collectionSourceIds.has(s.id)) : sources),
+    [sources, collectionSourceIds, showCollections],
+  );
+  const hasCollectionsBlade = showCollections && (collectionSources?.length ?? 0) > 0;
 
   const [expandedSources, setExpandedSources] = useState(() => {
     const stored = localStorage.getItem(EXPANDED_KEY);
@@ -80,6 +98,7 @@ export default function SidebarV2({
   });
   const [favShelfOpen, setFavShelfOpen] = useState(() => localStorage.getItem(FAVSHELF_KEY) !== '0');
   const [profileGroupOpen, setProfileGroupOpen] = useState(() => localStorage.getItem(PROFILE_GROUP_KEY) !== '0');
+  const [collectionsGroupOpen, setCollectionsGroupOpen] = useState(() => localStorage.getItem(COLLECTIONS_GROUP_KEY) !== '0');
   const [showShortcuts, setShowShortcuts] = useState(false);
 
   useEffect(() => {
@@ -97,6 +116,69 @@ export default function SidebarV2({
   useEffect(() => {
     localStorage.setItem(PROFILE_GROUP_KEY, profileGroupOpen ? '1' : '0');
   }, [profileGroupOpen]);
+
+  useEffect(() => {
+    localStorage.setItem(COLLECTIONS_GROUP_KEY, collectionsGroupOpen ? '1' : '0');
+  }, [collectionsGroupOpen]);
+
+  // Swipe gestures: swipe right from the left edge opens the sidebar;
+  // swipe left while the sidebar is open closes it. Ignored on larger viewports
+  // where the sidebar is statically visible.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const EDGE_PX = 32;
+    const MIN_DX = 60;
+    const MAX_DY = 60;
+    const MAX_DT = 500;
+    let startX = 0;
+    let startY = 0;
+    let startTime = 0;
+    let tracking = false;
+
+    const isDesktop = () => window.matchMedia('(min-width: 1024px)').matches;
+
+    const onStart = (e) => {
+      if (e.touches.length !== 1) { tracking = false; return; }
+      if (isDesktop()) { tracking = false; return; }
+      const t = e.touches[0];
+      // To open: gesture must start near the left edge.
+      // To close: only meaningful while the sidebar is open; the sidebar
+      // covers the left side up to w-80 (~320px), so accept from anywhere.
+      if (!menuOpen && t.clientX > EDGE_PX) { tracking = false; return; }
+      startX = t.clientX;
+      startY = t.clientY;
+      startTime = Date.now();
+      tracking = true;
+    };
+
+    const onEnd = (e) => {
+      if (!tracking) return;
+      tracking = false;
+      const t = e.changedTouches[0];
+      const dx = t.clientX - startX;
+      const dy = t.clientY - startY;
+      const dt = Date.now() - startTime;
+      if (dt > MAX_DT) return;
+      if (Math.abs(dy) > MAX_DY) return;
+      if (Math.abs(dx) < MIN_DX) return;
+      if (dx > 0 && !menuOpen) {
+        onMenuOpenChange?.(true);
+      } else if (dx < 0 && menuOpen) {
+        onMenuOpenChange?.(false);
+      }
+    };
+
+    const onCancel = () => { tracking = false; };
+
+    window.addEventListener('touchstart', onStart, { passive: true });
+    window.addEventListener('touchend', onEnd, { passive: true });
+    window.addEventListener('touchcancel', onCancel, { passive: true });
+    return () => {
+      window.removeEventListener('touchstart', onStart);
+      window.removeEventListener('touchend', onEnd);
+      window.removeEventListener('touchcancel', onCancel);
+    };
+  }, [menuOpen, onMenuOpenChange]);
 
   // Auto-open the profile group when the profile panel is open, so the active
   // tab indicator is visible in the sidebar.
@@ -158,7 +240,7 @@ export default function SidebarV2({
     if (searchTerm) return filteredStories;
     if (favoritesOnly && showFavorites) return favoriteStories;
     const out = [];
-    for (const src of sources) {
+    for (const src of storySources) {
       if (!expandedSources.has(src.id)) continue;
       const srcStories = storiesBySource[src.id] ?? [];
       const dirs = showStoryDirectories ? (directoriesBySource[src.id] ?? []) : [];
@@ -173,7 +255,7 @@ export default function SidebarV2({
       }
     }
     return out;
-  }, [sources, storiesBySource, directoriesBySource, expandedSources, expandedDirs, searchTerm, filteredStories, favoritesOnly, showFavorites, favoriteStories, showStoryDirectories]);
+  }, [storySources, storiesBySource, directoriesBySource, expandedSources, expandedDirs, searchTerm, filteredStories, favoritesOnly, showFavorites, favoriteStories, showStoryDirectories]);
 
   const [focusIdx, setFocusIdx] = useState(-1);
   const asideRef = useRef(null);
@@ -499,6 +581,56 @@ export default function SidebarV2({
           </div>
         )}
 
+        {/* Collections blade — a separate vertical section for installed collections */}
+        {hasCollectionsBlade && !searchTerm && !favoritesOnly && (
+          <div className="px-3 pt-3" data-testid="collections-blade">
+            <button
+              data-testid="sidebar-v2-collections-group"
+              onClick={() => setCollectionsGroupOpen((v) => !v)}
+              aria-expanded={collectionsGroupOpen}
+              className={`w-full flex items-center gap-2 px-3 py-1.5 rounded-lg text-[11px] font-semibold uppercase tracking-wider transition-colors ${
+                darkMode ? 'text-violet-400 hover:bg-slate-800' : 'text-violet-600 hover:bg-violet-50'
+              }`}
+            >
+              {collectionsGroupOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+              <Sparkles size={12} />
+              <span>Sammlungen</span>
+              <span className={`ml-auto tabular-nums normal-case ${darkMode ? 'text-violet-500' : 'text-violet-400'}`}>
+                {collectionSources.length}
+              </span>
+            </button>
+            {collectionsGroupOpen && (
+              <div className="mt-1 space-y-1">
+                {collectionSources.map((src) => {
+                  const isOpen = expandedSources.has(src.id);
+                  const srcStories = storiesBySource[src.id] ?? [];
+                  return (
+                    <div key={`coll-${src.id}`}>
+                      {sourceHeader(src, isOpen)}
+                      {isOpen && srcStories.map((story) => (
+                        <div key={`coll-s-${story.id}`} ref={storyRowRef(story)} className="pl-4">
+                          <StoryButton
+                            story={story}
+                            isActive={selectedStory?.id === story.id}
+                            isCompleted={completedStories.has(story.id)}
+                            isFavorite={favorites.has(story.id)}
+                            showWordCount={showWordCount}
+                            showFavoriteButton={showFavorites}
+                            testId="story-button"
+                            onClick={() => { onSelectStory(story); onMenuToggle(); }}
+                            onFavoriteClick={(e) => onToggleFavorite(story.id, e)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            <div className={`mt-3 mx-1 h-px ${darkMode ? 'bg-amber-800/40' : 'bg-amber-200'}`} />
+          </div>
+        )}
+
         {/* Main content */}
         <div className="px-3 pt-3 pb-4 space-y-1">
           {favoritesOnly && showFavorites ? (
@@ -509,12 +641,12 @@ export default function SidebarV2({
             filteredStories.length === 0 ? (
               <p className={`px-2 py-3 text-sm ${darkMode ? 'text-amber-600' : 'text-amber-700'}`}>Keine Ergebnisse</p>
             ) : filteredStories.map((s, i) => renderStory(s, i, { showSourceBadge: true, inlineBadges: true }))
-          ) : sources.length === 0 ? (
+          ) : storySources.length === 0 ? (
             <p className={`px-2 py-3 text-sm ${darkMode ? 'text-amber-600' : 'text-amber-700'}`}>Keine Quellen verfügbar</p>
           ) : (
             (() => {
               let idxCursor = 0;
-              return sources.map((src) => {
+              return storySources.map((src) => {
                 const isOpen = expandedSources.has(src.id);
                 const srcStories = storiesBySource[src.id] ?? [];
                 const dirs = showStoryDirectories ? (directoriesBySource[src.id] ?? []) : [];

--- a/flags.json
+++ b/flags.json
@@ -111,6 +111,13 @@
       "off": false
     }
   },
+  "collections": {
+    "defaultVariant": "off",
+    "variants": {
+      "on": true,
+      "off": false
+    }
+  },
   "theme": {
     "defaultVariant": "light",
     "variants": {

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -28,7 +28,7 @@ import TypographyPanel, { LINE_HEIGHTS, WORD_SPACINGS, FONT_FAMILIES } from './u
 import AudioPlayer from './ui/AudioPlayer';
 import SpeedReaderView from './ui/SpeedReaderView';
 import DebugOverlay from './components/DebugOverlay';
-import { getStoryIndex, loadStoryById, loadStoryMetadataById, loadAdaptionsByStoryId, loadStoryAudioMap } from './src/lib/storyLibrary';
+import { getStoryIndex, getCollectionIndex, loadStoryById, loadStoryMetadataById, loadAdaptionsByStoryId, loadStoryAudioMap } from './src/lib/storyLibrary';
 
 const SPEED_READER_FONT_SIZE = {
   min: 40,
@@ -59,7 +59,7 @@ const GrimmMarchenApp = () => {
     showTapZones, showTapMiddleToggle, showAdaptionSwitcher, showTypographyPanel, showAttribution,
     showFavorites, showFavoritesOnlyToggle, showAudioPlayer, showHighContrastTheme,
     showSimplifiedUi, showTextToSpeech,
-    showSpeedReader, showSpeedreaderOrp, showWordBlacklist, showDeepSearch, showStoryDirectories, showDebugBadges, showSubscriberFonts, showErrorPageSimulator, showAppAnimation,
+    showSpeedReader, showSpeedreaderOrp, showWordBlacklist, showDeepSearch, showStoryDirectories, showCollections, showDebugBadges, showSubscriberFonts, showErrorPageSimulator, showAppAnimation,
     showAbTesting, showAbTestingAdmin,
     showVoiceControl, showVoiceResume, showVoiceNavigation, showVoiceReadingControl, showVoiceDiscovery, showVoiceHandsFree,
     _rawFlagValues,
@@ -331,6 +331,15 @@ const GrimmMarchenApp = () => {
       count: list.length,
     }))
   , [storiesBySource]);
+
+  const collectionSourceIds = React.useMemo(() => {
+    return new Set(getCollectionIndex().map((c) => c.id));
+  }, []);
+
+  const collectionSources = React.useMemo(
+    () => sources.filter((s) => collectionSourceIds.has(s.id)),
+    [sources, collectionSourceIds],
+  );
 
   const directoriesBySource = React.useMemo(() => {
     const map = {};
@@ -740,6 +749,7 @@ const GrimmMarchenApp = () => {
         <SidebarComponent
           menuOpen={menuOpen}
           onMenuToggle={() => setMenuOpen(false)}
+          onMenuOpenChange={setMenuOpen}
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}
           showDeepSearch={showDeepSearch}
@@ -766,6 +776,8 @@ const GrimmMarchenApp = () => {
           filteredStories={filteredStories}
           sources={sources}
           storiesBySource={storiesBySource}
+          showCollections={showCollections}
+          collectionSources={collectionSources}
           onOpenProfile={handleOpenProfile}
           profileOpen={profileOpen}
           profileActiveTab={profileActiveTab}

--- a/src/lib/abExperiments.js
+++ b/src/lib/abExperiments.js
@@ -25,7 +25,7 @@ export const AB_EXPERIMENTS = [
     defaultVariant: 'control',
     variants: [
       { id: 'control', label: 'Original', description: 'Die bestehende Drill-Down-Navigation.' },
-      { id: 'v2',      label: 'Baum v2',  description: 'Alles auf einer Ebene, Quellen ein- und ausklappbar, Tastatur-Navigation.' },
+      { id: 'v2',      label: 'Baum v2',  description: 'Baum-Navigation mit Sammlungen-Leiste und Wisch-Gesten zum Öffnen/Schließen.' },
     ],
   },
   {

--- a/src/lib/featureRegistry.jsx
+++ b/src/lib/featureRegistry.jsx
@@ -236,6 +236,16 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     roles: ['subscriber', 'tester', 'sales'],
   },
+  {
+    key: 'collections',
+    kind: 'boolean',
+    label: 'Sammlungen',
+    description: 'Hebt installierte Sammlungen als eigene Leiste in der Seitenleiste hervor - neben der Geschichten- und Profil-Leiste.',
+    Icon: () => <Sparkles size={20} strokeWidth={1.75} />,
+    flag: bool('off'),
+    status: 'released',
+    roles: ALL_USERS,
+  },
 
   // -------- Released but hidden (variant / infra flags) --------
   {


### PR DESCRIPTION
- New `collections` feature flag renders installed collections as a
  separate vertical blade in SidebarV2, alongside the stories and
  profile blades. When on, collection sources are split out of the
  main source list and shown in a collapsible "Sammlungen" section.
- SidebarV2 now listens for touch swipes on mobile: swipe right from
  the left edge opens the sidebar, swipe left closes it.
- A/B sidebar v2 description updated to reflect the iteration.