### PR TITLE
feat(collections): add opening, ending and paragraph ornament illustrations

### DIFF
--- a/components/PageContent.jsx
+++ b/components/PageContent.jsx
@@ -1,4 +1,5 @@
 import { useTheme } from '../ui/ThemeContext';
+import { getStoryIllustrations } from '../src/lib/storyLibrary';
 
 /**
  * Renders the current page content with title, text, and action buttons.
@@ -31,6 +32,10 @@ export default function PageContent({
   const page = pages[currentPage];
   const isLastPage = currentPage === totalPages - 1;
   const isFavorite = favorites.has(selectedStory.id);
+  const illustrations = showIllustrations ? getStoryIllustrations(selectedStory.id) : null;
+  const ornamentColor = highContrast
+    ? (darkMode ? '#ffffff' : '#000000')
+    : darkMode ? '#b8a66b' : '#8b6914';
 
   return (
     <div
@@ -51,6 +56,14 @@ export default function PageContent({
                 className="mb-6 w-full rounded-xl object-cover max-h-80"
               />
             )}
+            {showIllustrations && !selectedStory.coverUrl && illustrations?.opening && (
+              <img
+                data-testid="story-opening-illustration"
+                src={illustrations.opening}
+                alt=""
+                className="mb-6 w-full rounded-xl object-cover max-h-80"
+              />
+            )}
             <h2 style={{ fontFamily }} className={`text-4xl font-bold mb-2 ${
               highContrast ? (darkMode ? 'text-white' : 'text-gray-900') : darkMode ? 'text-amber-200' : 'text-amber-900'
             }`}>
@@ -59,6 +72,14 @@ export default function PageContent({
             <div className={`h-1 w-20 rounded-full mb-8 ${
               highContrast ? (darkMode ? 'bg-white' : 'bg-black') : darkMode ? 'bg-amber-700' : 'bg-amber-300'
             }`} />
+            {showIllustrations && illustrations?.opening && selectedStory.coverUrl && (
+              <img
+                data-testid="story-opening-illustration"
+                src={illustrations.opening}
+                alt=""
+                className="mb-8 w-full rounded-xl object-cover max-h-64"
+              />
+            )}
           </>
         )}
 
@@ -70,27 +91,63 @@ export default function PageContent({
           {(() => {
             const paras = [];
             let currentPara = [];
+            let hadTrailingFullPara = false;
 
             page.tokens.forEach((token) => {
               currentPara.push(token.word);
               if (token.isPara) {
-                paras.push(currentPara.join(' '));
+                paras.push({ text: currentPara.join(' '), isComplete: true });
                 currentPara = [];
+                hadTrailingFullPara = true;
+              } else {
+                hadTrailingFullPara = false;
               }
             });
 
-            // If there are leftover words (happens when page breaks mid-paragraph)
+            // If there are leftover words (page breaks mid-paragraph), push as incomplete
             if (currentPara.length > 0) {
-              paras.push(currentPara.join(' '));
+              paras.push({ text: currentPara.join(' '), isComplete: false });
             }
 
-            return paras.map((text, idx) => (
-              <p key={idx} className="mb-6 first-letter:font-bold">
-                {text}
-              </p>
-            ));
+            const ornamentUrl = showIllustrations && illustrations?.ornament;
+
+            return paras.map((para, idx) => {
+              const isLastOnPage = idx === paras.length - 1;
+              const showOrnament = ornamentUrl && para.isComplete && !isLastOnPage;
+              return (
+                <div key={idx}>
+                  <p className="mb-6 first-letter:font-bold">{para.text}</p>
+                  {showOrnament && (
+                    <div
+                      data-testid="paragraph-ornament"
+                      aria-hidden="true"
+                      className="my-4 flex justify-center"
+                      style={{ color: ornamentColor }}
+                    >
+                      <img
+                        src={ornamentUrl}
+                        alt=""
+                        className="h-6 opacity-70"
+                        style={{ maxWidth: '200px' }}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            });
           })()}
         </div>
+
+        {showIllustrations && isLastPage && illustrations?.ending && (
+          <div className="mt-8 flex justify-center">
+            <img
+              data-testid="story-ending-illustration"
+              src={illustrations.ending}
+              alt=""
+              className="w-full rounded-xl object-cover max-h-80"
+            />
+          </div>
+        )}
 
         {showAttribution && isLastPage && (
           <div className={`mt-8 pt-6 border-t ${

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -10,8 +10,12 @@ Current model: **build-time install.** Installed collections are picked up by a 
 packages/collection-<id>/
 ├── package.json        # name: @tweakch/collection-<id>
 ├── collection.json     # manifest
-├── index.js            # ESM entrypoint, exports { manifest, stories, covers?, adaptions? }
+├── index.js            # ESM entrypoint, exports { manifest, stories, covers?, illustrations?, adaptions? }
 ├── README.md
+├── assets/             # optional collection-level illustrations
+│   ├── opening.svg     #   beautiful opening art (shown on first page when cover is absent)
+│   ├── ending.svg      #   beautiful ending art (shown on the last page)
+│   └── ornament.svg    #   monochrome divider (uses currentColor), shown between paragraphs
 └── stories/
     └── <slug>/
         ├── content.md                      # markdown with the same frontmatter as stories/
@@ -56,17 +60,27 @@ import manifest from './collection.json';
 import aschenputtel from './stories/aschenputtel/content.md?raw';
 import aschenputtelCover from './stories/aschenputtel/cover.svg?url';
 import aschenputtelSchweizerdeutsch from './stories/aschenputtel/adaptions/schweizerdeutsch/content.md?raw';
+import openingIllustration from './assets/opening.svg?url';
+import endingIllustration from './assets/ending.svg?url';
+import ornamentIllustration from './assets/ornament.svg?url';
 
 export { manifest };
 export const stories = { aschenputtel };
 export const covers = { aschenputtel: aschenputtelCover };
+export const illustrations = {
+  opening: openingIllustration,
+  ending: endingIllustration,
+  ornament: ornamentIllustration,
+};
 export const adaptions = {
   aschenputtel: { schweizerdeutsch: aschenputtelSchweizerdeutsch },
 };
-export default { manifest, stories, covers, adaptions };
+export default { manifest, stories, covers, illustrations, adaptions };
 ```
 
-The `?raw` and `?url` queries are Vite features, so collections are consumed by a Vite build only. `covers` and `adaptions` are optional — omit them if the collection has neither.
+The `?raw` and `?url` queries are Vite features, so collections are consumed by a Vite build only. `covers`, `illustrations` and `adaptions` are optional — omit any key the collection doesn't provide.
+
+The `illustrations.ornament` SVG should use `stroke="currentColor"` / `fill="currentColor"` so it inherits the reader theme's accent color when rendered between paragraphs.
 
 ## Discovery
 

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -414,6 +414,7 @@ const GrimmMarchenApp = () => {
     selectedVariant,
     typographyValues: { fontSize, lineHeight, textWidth, hPadding, wordSpacing, fontFamily },
     showSpeedReader,
+    showIllustrations,
     pendingResumePageRef,
   });
 

--- a/hooks/useReader.js
+++ b/hooks/useReader.js
@@ -1,5 +1,9 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from 'react';
 
+// Ornament block height when illustrations are rendered between paragraphs:
+// my-4 (32px) + h-6 (24px) = 56px reserved after each completed paragraph.
+const ORNAMENT_RESERVE_PX = 56;
+
 /**
  * useReader - encapsulates page pagination, navigation, and speed reader logic.
  *
@@ -10,6 +14,8 @@ import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } fr
  * - selectedVariant: optional variant object with { adaptionName, content }
  * - typographyValues: { fontSize, lineHeight, textWidth, hPadding, wordSpacing, fontFamily }
  * - showSpeedReader: feature flag for speed reader
+ * - showIllustrations: when true, reserves vertical space between paragraphs
+ *   so rendered monochrome ornaments fit within the measured page.
  * - pendingResumePageRef: ref for resume page restoration
  *
  * Returns:
@@ -31,6 +37,7 @@ export function useReader({
   selectedVariant,
   typographyValues: { fontSize, lineHeight, textWidth, hPadding, wordSpacing, fontFamily },
   showSpeedReader,
+  showIllustrations = false,
   pendingResumePageRef,
 }) {
   const [pages, setPages] = useState([]);
@@ -136,8 +143,13 @@ export function useReader({
         tokens.shift();
         pageTokens.push(token);
 
-        // If paragraph ends, add a new paragraph element for the next word
+        // If paragraph ends, add a new paragraph element for the next word.
+        // When illustrations are shown, the completed paragraph is followed by
+        // an ornament in the rendered output — reserve that vertical space.
         if (token.isPara && tokens.length > 0) {
+          if (showIllustrations) {
+            currentPara.style.marginBottom = `calc(1.5rem + ${ORNAMENT_RESERVE_PX}px)`;
+          }
           currentPara = document.createElement('p');
           currentPara.style.cssText = 'margin:0 0 1.5rem;';
           contentDiv.appendChild(currentPara);
@@ -167,7 +179,7 @@ export function useReader({
       // Subsequent builds (resize, font change): clamp to valid range.
       setCurrentPage(p => Math.min(p, pages.length - 1));
     }
-  }, [selectedStory, selectedVariant, fontSize, lineHeight, textWidth, hPadding, wordSpacing, fontFamily]);
+  }, [selectedStory, selectedVariant, fontSize, lineHeight, textWidth, hPadding, wordSpacing, fontFamily, showIllustrations]);
 
   // Build pages synchronously before paint when story or font size changes
   useLayoutEffect(() => {

--- a/packages/collection-grimm-klassiker/assets/ending.svg
+++ b/packages/collection-grimm-klassiker/assets/ending.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="t d">
+  <title id="t">Ende</title>
+  <desc id="d">Ending illustration: open storybook with key, heart and rose on a starry background.</desc>
+  <defs>
+    <linearGradient id="kEbg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#211a3a"/>
+      <stop offset="1" stop-color="#0b0a1a"/>
+    </linearGradient>
+    <radialGradient id="kGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#f4e4b2" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#f4e4b2" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="360" fill="url(#kEbg)"/>
+  <ellipse cx="300" cy="220" rx="250" ry="90" fill="url(#kGlow)"/>
+  <g fill="#f4e4b2" opacity="0.9">
+    <circle cx="70" cy="55" r="1.3"/>
+    <circle cx="140" cy="40" r="1"/>
+    <circle cx="220" cy="70" r="1.4"/>
+    <circle cx="360" cy="50" r="1.1"/>
+    <circle cx="450" cy="65" r="1.4"/>
+    <circle cx="520" cy="40" r="1"/>
+    <circle cx="540" cy="90" r="1.2"/>
+    <circle cx="50" cy="110" r="1"/>
+    <circle cx="560" cy="150" r="1.3"/>
+    <circle cx="30" cy="180" r="1"/>
+    <circle cx="100" cy="200" r="1.1"/>
+    <circle cx="500" cy="210" r="1.3"/>
+  </g>
+  <g transform="translate(300 225)">
+    <path d="M -130 0 q -6 -14 -12 -12 q -4 2 0 8 q -36 -2 -48 22 q -4 12 8 10 q 36 -6 52 -28 z"
+          fill="#e8dcb9" stroke="#8b6914" stroke-width="1"/>
+    <path d="M 130 0 q 6 -14 12 -12 q 4 2 0 8 q 36 -2 48 22 q 4 12 -8 10 q -36 -6 -52 -28 z"
+          fill="#e8dcb9" stroke="#8b6914" stroke-width="1"/>
+    <path d="M -130 -10 q 0 -22 22 -28 q 44 -14 108 -14 q 64 0 108 14 q 22 6 22 28 l 0 24 q 0 -20 -22 -26 q -44 -12 -108 -12 q -64 0 -108 12 q -22 6 -22 26 z"
+          fill="#f4e4b2" stroke="#8b6914" stroke-width="1.2"/>
+    <line x1="0" y1="-52" x2="0" y2="12" stroke="#8b6914" stroke-width="1"/>
+    <g stroke="#8b6914" stroke-width="0.4" fill="none" opacity="0.7">
+      <line x1="-108" y1="-32" x2="-14" y2="-32"/>
+      <line x1="-108" y1="-24" x2="-14" y2="-24"/>
+      <line x1="-108" y1="-16" x2="-14" y2="-16"/>
+      <line x1="14" y1="-32" x2="108" y2="-32"/>
+      <line x1="14" y1="-24" x2="108" y2="-24"/>
+      <line x1="14" y1="-16" x2="108" y2="-16"/>
+    </g>
+  </g>
+  <g transform="translate(300 100)" fill="none" stroke="#d4af37" stroke-width="1.4">
+    <path d="M -90 15 q 30 -45 90 -20 q 50 20 70 -10" opacity="0.9"/>
+    <path d="M -90 15 q 30 -32 80 -16" opacity="0.4"/>
+  </g>
+  <g transform="translate(230 275)">
+    <circle cx="0" cy="0" r="8" fill="none" stroke="#d4af37" stroke-width="1.6"/>
+    <circle cx="0" cy="0" r="3" fill="#0b0a1a"/>
+    <rect x="7" y="-1.5" width="22" height="3" fill="#d4af37"/>
+    <rect x="22" y="2" width="3" height="4" fill="#d4af37"/>
+    <rect x="27" y="2" width="3" height="6" fill="#d4af37"/>
+  </g>
+  <g transform="translate(300 278)" fill="#c94a4a" stroke="#6b1f1f" stroke-width="0.5">
+    <path d="M 0 6 q -14 -10 -14 -20 q 0 -8 7 -8 q 5 0 7 6 q 2 -6 7 -6 q 7 0 7 8 q 0 10 -14 20 z"/>
+  </g>
+  <g transform="translate(370 278)">
+    <g fill="#c94a4a" stroke="#6b1f1f" stroke-width="0.5">
+      <circle cx="0" cy="0" r="8"/>
+      <path d="M -6 -2 q 4 -6 12 0 q 2 4 -4 4 q -6 0 -8 -4 z" opacity="0.7"/>
+      <path d="M 6 -2 q -4 -6 -12 0 q -2 4 4 4 q 6 0 8 -4 z" opacity="0.7"/>
+      <circle cx="0" cy="-1" r="3" fill="#8b2a2a" stroke="none"/>
+    </g>
+    <path d="M 0 8 q 0 10 -4 20" fill="none" stroke="#4a6b5f" stroke-width="1.2"/>
+    <path d="M -2 14 q -6 0 -10 -4" fill="#4a6b5f" opacity="0.8"/>
+  </g>
+  <text x="300" y="220" text-anchor="middle" font-family="Georgia, serif" font-size="30" font-style="italic" fill="#5b3a1a">Ende</text>
+  <rect x="30" y="30" width="540" height="300" fill="none" stroke="#d4af37" stroke-width="1.5"/>
+  <g fill="#d4af37">
+    <path d="M 30 30 l 16 0 l 0 3 l -13 0 l 0 13 l -3 0 z"/>
+    <path d="M 570 30 l -16 0 l 0 3 l 13 0 l 0 13 l 3 0 z"/>
+    <path d="M 30 330 l 16 0 l 0 -3 l -13 0 l 0 -13 l -3 0 z"/>
+    <path d="M 570 330 l -16 0 l 0 -3 l 13 0 l 0 -13 l 3 0 z"/>
+  </g>
+</svg>

--- a/packages/collection-grimm-klassiker/assets/opening.svg
+++ b/packages/collection-grimm-klassiker/assets/opening.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="t d">
+  <title id="t">Klassische Märchen</title>
+  <desc id="d">Opening illustration: forest path leading to a distant castle under a starry dusk sky.</desc>
+  <defs>
+    <linearGradient id="kSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f7d9a0"/>
+      <stop offset="0.45" stop-color="#c28a6c"/>
+      <stop offset="1" stop-color="#2d2548"/>
+    </linearGradient>
+    <linearGradient id="kPath" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#d4b47c"/>
+      <stop offset="1" stop-color="#7a5a2f"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="360" fill="#f8efd9"/>
+  <rect x="30" y="30" width="540" height="300" fill="url(#kSky)"/>
+  <circle cx="300" cy="155" r="36" fill="#fde9b7" opacity="0.85"/>
+  <g fill="#f4e4b2" opacity="0.85">
+    <circle cx="90" cy="60" r="1.1"/>
+    <circle cx="170" cy="50" r="1.3"/>
+    <circle cx="410" cy="55" r="1"/>
+    <circle cx="500" cy="75" r="1.3"/>
+    <circle cx="540" cy="50" r="1"/>
+  </g>
+  <g transform="translate(300 170)" fill="#16182a" stroke="#0a0a18" stroke-width="0.6">
+    <rect x="-26" y="-16" width="52" height="46"/>
+    <rect x="-34" y="-20" width="16" height="50"/>
+    <rect x="18" y="-20" width="16" height="50"/>
+    <polygon points="-34,-20 -26,-30 -18,-20"/>
+    <polygon points="18,-20 26,-30 34,-20"/>
+    <polygon points="-26,-16 0,-32 26,-16"/>
+    <rect x="-3" y="-4" width="6" height="12" fill="#ffdd77"/>
+    <rect x="-32" y="-10" width="4" height="6" fill="#ffdd77"/>
+    <rect x="28" y="-10" width="4" height="6" fill="#ffdd77"/>
+    <line x1="-30" y1="-33" x2="-30" y2="-42" stroke="#0a0a18"/>
+    <polygon points="-30,-42 -22,-39 -30,-36" fill="#c94a4a" stroke="none"/>
+    <line x1="30" y1="-33" x2="30" y2="-42" stroke="#0a0a18"/>
+    <polygon points="30,-42 38,-39 30,-36" fill="#c94a4a" stroke="none"/>
+  </g>
+  <path d="M 280 220 Q 200 260 120 320" fill="none" stroke="url(#kPath)" stroke-width="14" stroke-linecap="round"/>
+  <path d="M 320 220 Q 400 260 480 320" fill="none" stroke="url(#kPath)" stroke-width="14" stroke-linecap="round"/>
+  <g fill="#1a2030">
+    <path d="M 30 240 q 30 -10 70 -8 l 0 100 l -70 0 z"/>
+    <path d="M 70 210 l 0 24 l -8 0 z" opacity="0.8"/>
+    <path d="M 570 230 q -40 -10 -90 -6 l 0 106 l 90 0 z"/>
+    <path d="M 500 200 l 0 28 l -8 0 z" opacity="0.8"/>
+  </g>
+  <g fill="#1a2030">
+    <path d="M 95 280 l -5 -10 l -4 10 l -5 -12 l -5 12 l -4 -8 l -4 8 l 0 10 l 28 0 z"/>
+    <path d="M 520 280 l -5 -10 l -4 10 l -5 -12 l -5 12 l -4 -8 l -4 8 l 0 10 l 28 0 z"/>
+  </g>
+  <g fill="#2b2f3a">
+    <ellipse cx="200" cy="296" rx="22" ry="4" opacity="0.5"/>
+    <ellipse cx="400" cy="296" rx="22" ry="4" opacity="0.5"/>
+  </g>
+  <rect x="30" y="30" width="540" height="300" fill="none" stroke="#8b6914" stroke-width="2"/>
+  <rect x="36" y="36" width="528" height="288" fill="none" stroke="#d4af37" stroke-width="0.7"/>
+  <g fill="#8b6914">
+    <circle cx="30" cy="30" r="4"/>
+    <circle cx="570" cy="30" r="4"/>
+    <circle cx="30" cy="330" r="4"/>
+    <circle cx="570" cy="330" r="4"/>
+  </g>
+  <text x="300" y="320" text-anchor="middle" font-family="Georgia, serif" font-size="16" font-style="italic" fill="#5b3a1a">Es war einmal ein Märchen ...</text>
+</svg>

--- a/packages/collection-grimm-klassiker/assets/ornament.svg
+++ b/packages/collection-grimm-klassiker/assets/ornament.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 40" role="img" aria-labelledby="t">
+  <title id="t">Ornament</title>
+  <g fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round">
+    <line x1="12" y1="20" x2="92" y2="20"/>
+    <line x1="148" y1="20" x2="228" y2="20"/>
+    <path d="M 97 20 q 6 -10 12 -2 q 5 8 11 0 q 5 -8 11 0 q 6 8 12 -2" opacity="0.9"/>
+    <g fill="currentColor" stroke="none">
+      <path d="M 120 10 l 2 6 l 6 0 l -5 4 l 2 6 l -5 -4 l -5 4 l 2 -6 l -5 -4 l 6 0 z"/>
+      <circle cx="95" cy="20" r="1.2"/>
+      <circle cx="145" cy="20" r="1.2"/>
+    </g>
+  </g>
+</svg>

--- a/packages/collection-grimm-klassiker/index.js
+++ b/packages/collection-grimm-klassiker/index.js
@@ -15,6 +15,10 @@ import rumpelstilzchen from './stories/rumpelstilzchen/content.md?raw';
 import schneewittchen from './stories/schneewittchen/content.md?raw';
 import tischchen_deck_dich_goldesel_und_knuppel_aus_dem_sack from './stories/tischchen_deck_dich_goldesel_und_knuppel_aus_dem_sack/content.md?raw';
 
+import openingIllustration from './assets/opening.svg?url';
+import endingIllustration from './assets/ending.svg?url';
+import ornamentIllustration from './assets/ornament.svg?url';
+
 export { manifest };
 
 export const stories = {
@@ -35,4 +39,10 @@ export const stories = {
   tischchen_deck_dich_goldesel_und_knuppel_aus_dem_sack,
 };
 
-export default { manifest, stories };
+export const illustrations = {
+  opening: openingIllustration,
+  ending: endingIllustration,
+  ornament: ornamentIllustration,
+};
+
+export default { manifest, stories, illustrations };

--- a/packages/collection-grimm-tiere/assets/ending.svg
+++ b/packages/collection-grimm-tiere/assets/ending.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="t d">
+  <title id="t">Ende der Tiergeschichte</title>
+  <desc id="d">Ending illustration: tree silhouette with sleeping animals under crescent moon and stars.</desc>
+  <defs>
+    <linearGradient id="ebgT" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1e2f55"/>
+      <stop offset="1" stop-color="#0b1220"/>
+    </linearGradient>
+    <radialGradient id="moonGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#f4e4b2" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#f4e4b2" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="360" fill="url(#ebgT)"/>
+  <circle cx="450" cy="110" r="60" fill="url(#moonGlow)"/>
+  <g transform="translate(450 110)">
+    <path d="M 0 -28 a 28 28 0 1 0 0 56 a 22 22 0 1 1 0 -56 z" fill="#f4e4b2"/>
+  </g>
+  <g fill="#f4e4b2" opacity="0.9">
+    <circle cx="80" cy="70" r="1.3"/>
+    <circle cx="140" cy="55" r="1"/>
+    <circle cx="220" cy="80" r="1.5"/>
+    <circle cx="360" cy="60" r="1.1"/>
+    <circle cx="520" cy="100" r="1.4"/>
+    <circle cx="560" cy="60" r="1"/>
+    <circle cx="60" cy="130" r="1.2"/>
+    <circle cx="540" cy="160" r="1.1"/>
+  </g>
+  <g fill="#1a2030">
+    <path d="M 30 300 q 80 -20 180 -10 q 120 10 240 -10 q 60 -8 120 5 l 0 40 l -540 0 z"/>
+  </g>
+  <g transform="translate(200 300)">
+    <path d="M 0 0 q -4 -40 0 -80 q 2 -30 6 -60 q 4 30 6 60 q 4 40 0 80 z" fill="#0a0f18"/>
+    <g fill="#0a0f18">
+      <path d="M -5 -100 q -20 -10 -40 -2 q 20 -4 40 6"/>
+      <path d="M 11 -100 q 20 -10 40 -2 q -20 -4 -40 6"/>
+      <path d="M -5 -70 q -30 -6 -50 10 q 30 -10 50 0"/>
+      <path d="M 11 -70 q 30 -6 50 10 q -30 -10 -50 0"/>
+      <path d="M -4 -40 q -25 0 -40 14 q 25 -10 40 -4"/>
+      <path d="M 10 -40 q 25 0 40 14 q -25 -10 -40 -4"/>
+      <ellipse cx="3" cy="-120" rx="30" ry="18"/>
+    </g>
+  </g>
+  <g transform="translate(150 300)" fill="#1a1a1a">
+    <ellipse cx="0" cy="0" rx="22" ry="6" opacity="0.5"/>
+    <path d="M -18 -2 q 0 -10 8 -12 q 4 -1 6 2 q 4 -8 12 -8 q 10 0 12 10 q 2 -2 6 -1 q 4 2 2 10 l 0 3 z"/>
+    <circle cx="-12" cy="-10" r="2.2" opacity="0.6"/>
+    <path d="M -10 -14 l 2 -4 l 2 3 z"/>
+  </g>
+  <g transform="translate(260 305)" fill="#1a1a1a">
+    <ellipse cx="0" cy="0" rx="18" ry="5" opacity="0.5"/>
+    <path d="M -14 -2 l 0 -8 q 0 -5 5 -5 l 14 0 q 5 0 5 5 l 0 8 z"/>
+    <path d="M -10 -14 l 1 -6 l 3 4 z"/>
+    <path d="M 10 -14 l -1 -6 l -3 4 z"/>
+  </g>
+  <g transform="translate(350 310)" fill="#1a1a1a">
+    <ellipse cx="0" cy="0" rx="20" ry="5" opacity="0.5"/>
+    <path d="M -16 -2 q 2 -10 10 -12 q 10 -2 14 4 q 4 -4 10 -1 q 6 4 2 12 z"/>
+    <path d="M -10 -14 q -4 -6 0 -8 q 4 0 4 6 z"/>
+    <path d="M 14 -14 l 2 -6 l 3 4 z"/>
+  </g>
+  <g transform="translate(300 175)" fill="none" stroke="#d4af37" stroke-width="1.2">
+    <path d="M -70 0 q 20 -18 40 -6 q 20 12 40 -4" opacity="0.7"/>
+  </g>
+  <text x="300" y="240" text-anchor="middle" font-family="Georgia, serif" font-size="28" font-style="italic" fill="#f4e4b2">Gute Nacht</text>
+  <text x="300" y="265" text-anchor="middle" font-family="Georgia, serif" font-size="14" fill="#b8a66b" letter-spacing="4">ENDE</text>
+  <rect x="30" y="30" width="540" height="300" fill="none" stroke="#d4af37" stroke-width="1.5"/>
+  <g fill="#d4af37">
+    <circle cx="30" cy="30" r="3"/>
+    <circle cx="570" cy="30" r="3"/>
+    <circle cx="30" cy="330" r="3"/>
+    <circle cx="570" cy="330" r="3"/>
+  </g>
+</svg>

--- a/packages/collection-grimm-tiere/assets/opening.svg
+++ b/packages/collection-grimm-tiere/assets/opening.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="t d">
+  <title id="t">Tiergeschichten</title>
+  <desc id="d">Opening illustration: forest clearing with silhouetted animals gathered around a lantern.</desc>
+  <defs>
+    <linearGradient id="tsky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffd79a"/>
+      <stop offset="0.6" stop-color="#d98a55"/>
+      <stop offset="1" stop-color="#5c3b4a"/>
+    </linearGradient>
+    <radialGradient id="tglow" cx="0.5" cy="0.6" r="0.5">
+      <stop offset="0" stop-color="#fff3c2" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#fff3c2" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="360" fill="#f8efd9"/>
+  <rect x="30" y="30" width="540" height="300" fill="url(#tsky)"/>
+  <ellipse cx="300" cy="240" rx="240" ry="90" fill="url(#tglow)"/>
+  <circle cx="300" cy="170" r="38" fill="#fde9b7" opacity="0.6"/>
+  <g fill="#2b2f3a">
+    <path d="M 30 260 q 40 -20 90 -10 l 0 80 l -90 0 z"/>
+    <path d="M 80 230 l 0 20 l -10 0 z" opacity="0.8"/>
+    <path d="M 560 250 q -40 -20 -90 -10 l 0 90 l 90 0 z"/>
+    <path d="M 510 220 l 0 24 l -10 0 z" opacity="0.8"/>
+  </g>
+  <g fill="#2b2f3a">
+    <path d="M 80 260 l -6 -12 l -6 12 l -6 -14 l -6 14 l -6 -10 l -6 10 l 0 8 l 36 0 z" opacity="0.9"/>
+    <path d="M 560 265 l -6 -12 l -6 12 l -6 -14 l -6 14 l -6 -10 l -6 10 l 0 8 l 36 0 z" opacity="0.9"/>
+  </g>
+  <g transform="translate(300 255)" fill="#1a1a1a">
+    <ellipse cx="0" cy="10" rx="16" ry="4" opacity="0.5"/>
+    <path d="M -10 8 l 0 -8 q 0 -4 4 -5 q 2 -1 3 2 l 1 3 q 2 -3 5 -3 q 3 0 4 3 l 1 3 q 1 -3 4 -3 q 4 0 4 5 l 0 8 z"/>
+    <circle cx="-6" cy="-6" r="3"/>
+    <path d="M -8 -10 q -2 -4 1 -6 q 3 -1 4 3 z"/>
+    <path d="M -4 -10 q 1 -4 4 -4 q 2 1 1 4 z"/>
+  </g>
+  <g transform="translate(220 270)" fill="#1a1a1a">
+    <ellipse cx="0" cy="6" rx="18" ry="3" opacity="0.4"/>
+    <path d="M -14 4 q -2 -10 4 -12 q 4 -1 6 2 q 2 -8 10 -8 q 8 0 10 8 q 2 -3 6 -2 q 6 2 4 12 z"/>
+    <circle cx="-10" cy="-4" r="2"/>
+    <circle cx="10" cy="-4" r="2"/>
+    <path d="M -12 -9 l 2 -5 l 3 4 z"/>
+    <path d="M 12 -9 l -2 -5 l -3 4 z"/>
+  </g>
+  <g transform="translate(380 265)" fill="#1a1a1a">
+    <ellipse cx="0" cy="10" rx="14" ry="3" opacity="0.4"/>
+    <path d="M -12 8 l 0 -12 q 0 -5 5 -5 l 14 0 q 5 0 5 5 l 0 12 z"/>
+    <path d="M -10 -4 l -2 -6 l 4 0 z"/>
+    <path d="M 10 -4 l 2 -6 l -4 0 z"/>
+    <path d="M 8 6 q 6 -2 8 4 q -4 2 -8 -4" opacity="0.8"/>
+  </g>
+  <g transform="translate(470 200)">
+    <circle cx="0" cy="0" r="10" fill="#f4c77a" stroke="#8b6914" stroke-width="1.2"/>
+    <circle cx="0" cy="0" r="6" fill="#fff3c2" opacity="0.8"/>
+    <rect x="-2" y="-20" width="4" height="12" fill="#5b3a1a"/>
+    <path d="M -10 10 q 10 12 20 0" fill="#5b3a1a"/>
+  </g>
+  <g fill="#f4e4b2" opacity="0.8">
+    <circle cx="100" cy="70" r="1.2"/>
+    <circle cx="170" cy="50" r="1"/>
+    <circle cx="460" cy="60" r="1.3"/>
+    <circle cx="520" cy="50" r="1"/>
+  </g>
+  <rect x="30" y="30" width="540" height="300" fill="none" stroke="#8b6914" stroke-width="2"/>
+  <rect x="36" y="36" width="528" height="288" fill="none" stroke="#d4af37" stroke-width="0.7"/>
+  <g fill="#8b6914">
+    <circle cx="30" cy="30" r="4"/>
+    <circle cx="570" cy="30" r="4"/>
+    <circle cx="30" cy="330" r="4"/>
+    <circle cx="570" cy="330" r="4"/>
+  </g>
+  <text x="300" y="320" text-anchor="middle" font-family="Georgia, serif" font-size="16" font-style="italic" fill="#5b3a1a">Von Tieren und Menschen ...</text>
+</svg>

--- a/packages/collection-grimm-tiere/assets/ornament.svg
+++ b/packages/collection-grimm-tiere/assets/ornament.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 40" role="img" aria-labelledby="t">
+  <title id="t">Ornament</title>
+  <g fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round">
+    <line x1="10" y1="20" x2="90" y2="20"/>
+    <line x1="150" y1="20" x2="230" y2="20"/>
+    <path d="M 96 20 q 3 -5 8 -5 q 5 0 6 5 q 1 -5 6 -5 q 5 0 8 5" opacity="0.9"/>
+    <path d="M 116 20 q 3 5 8 5 q 5 0 6 -5 q 1 5 6 5 q 5 0 8 -5" opacity="0.9"/>
+    <g fill="currentColor" stroke="none">
+      <circle cx="120" cy="14" r="2.2"/>
+      <circle cx="120" cy="26" r="1.2"/>
+      <circle cx="94" cy="20" r="1.1"/>
+      <circle cx="146" cy="20" r="1.1"/>
+    </g>
+  </g>
+</svg>

--- a/packages/collection-grimm-tiere/index.js
+++ b/packages/collection-grimm-tiere/index.js
@@ -12,6 +12,10 @@ import der_hase_und_der_igel from './stories/der_hase_und_der_igel/content.md?ra
 import die_scholle from './stories/die_scholle/content.md?raw';
 import rohrdommel_und_wiedehopf from './stories/rohrdommel_und_wiedehopf/content.md?raw';
 
+import openingIllustration from './assets/opening.svg?url';
+import endingIllustration from './assets/ending.svg?url';
+import ornamentIllustration from './assets/ornament.svg?url';
+
 export { manifest };
 
 export const stories = {
@@ -29,4 +33,10 @@ export const stories = {
   rohrdommel_und_wiedehopf,
 };
 
-export default { manifest, stories };
+export const illustrations = {
+  opening: openingIllustration,
+  ending: endingIllustration,
+  ornament: ornamentIllustration,
+};
+
+export default { manifest, stories, illustrations };

--- a/packages/collection-grimm-top5/assets/ending.svg
+++ b/packages/collection-grimm-top5/assets/ending.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="t d">
+  <title id="t">Und wenn sie nicht gestorben sind</title>
+  <desc id="d">Ending illustration: open storybook with swirling ribbon and rose under starry sky.</desc>
+  <defs>
+    <linearGradient id="ebg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a2855"/>
+      <stop offset="1" stop-color="#0b1428"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#f4e4b2" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#f4e4b2" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="360" fill="url(#ebg)"/>
+  <ellipse cx="300" cy="220" rx="220" ry="80" fill="url(#glow)"/>
+  <g fill="#f4e4b2" opacity="0.9">
+    <circle cx="80" cy="60" r="1.3"/>
+    <circle cx="140" cy="40" r="1"/>
+    <circle cx="220" cy="70" r="1.5"/>
+    <circle cx="360" cy="45" r="1.1"/>
+    <circle cx="450" cy="60" r="1.4"/>
+    <circle cx="520" cy="40" r="1"/>
+    <circle cx="540" cy="90" r="1.2"/>
+    <circle cx="50" cy="110" r="1"/>
+    <circle cx="560" cy="150" r="1.3"/>
+    <circle cx="30" cy="180" r="1"/>
+  </g>
+  <g transform="translate(300 220)">
+    <path d="M -120 0 q -5 -12 -10 -10 q -4 2 0 8 q -30 -2 -40 20 q -4 10 6 8 q 30 -4 44 -26 z"
+          fill="#e8dcb9" stroke="#8b6914" stroke-width="1"/>
+    <path d="M -120 0 q -8 -4 -20 -4 q -20 0 -30 16" fill="none" stroke="#8b6914" stroke-width="0.6"/>
+    <path d="M 120 0 q 5 -12 10 -10 q 4 2 0 8 q 30 -2 40 20 q 4 10 -6 8 q -30 -4 -44 -26 z"
+          fill="#e8dcb9" stroke="#8b6914" stroke-width="1"/>
+    <path d="M 120 0 q 8 -4 20 -4 q 20 0 30 16" fill="none" stroke="#8b6914" stroke-width="0.6"/>
+    <path d="M -120 -10 q 0 -20 20 -26 q 40 -12 100 -12 q 60 0 100 12 q 20 6 20 26 l 0 22 q 0 -18 -20 -24 q -40 -10 -100 -10 q -60 0 -100 10 q -20 6 -20 24 z"
+          fill="#f4e4b2" stroke="#8b6914" stroke-width="1.2"/>
+    <line x1="0" y1="-48" x2="0" y2="12" stroke="#8b6914" stroke-width="1"/>
+    <g stroke="#8b6914" stroke-width="0.4" fill="none" opacity="0.7">
+      <line x1="-100" y1="-30" x2="-10" y2="-30"/>
+      <line x1="-100" y1="-22" x2="-10" y2="-22"/>
+      <line x1="-100" y1="-14" x2="-10" y2="-14"/>
+      <line x1="10" y1="-30" x2="100" y2="-30"/>
+      <line x1="10" y1="-22" x2="100" y2="-22"/>
+      <line x1="10" y1="-14" x2="100" y2="-14"/>
+    </g>
+    <text x="-55" y="-2" text-anchor="middle" font-family="Georgia, serif" font-size="14" font-style="italic" fill="#8b6914">Ende</text>
+    <text x="55" y="-2" text-anchor="middle" font-family="Georgia, serif" font-size="14" font-style="italic" fill="#8b6914">gut</text>
+  </g>
+  <g transform="translate(300 130)" fill="none" stroke="#d4af37" stroke-width="1.4">
+    <path d="M -80 10 q 30 -40 80 -20 q 40 16 60 -10"/>
+    <path d="M -80 10 q 30 -30 70 -14" opacity="0.5"/>
+  </g>
+  <g transform="translate(300 285)">
+    <g fill="#c94a4a" stroke="#6b1f1f" stroke-width="0.5">
+      <circle cx="0" cy="0" r="8"/>
+      <path d="M -6 -2 q 4 -6 12 0 q 2 4 -4 4 q -6 0 -8 -4 z" opacity="0.7"/>
+      <path d="M 6 -2 q -4 -6 -12 0 q -2 4 4 4 q 6 0 8 -4 z" opacity="0.7"/>
+      <circle cx="0" cy="-1" r="3" fill="#8b2a2a" stroke="none"/>
+    </g>
+    <path d="M -2 6 q -8 10 -14 22" fill="none" stroke="#4a6b5f" stroke-width="1.2"/>
+    <path d="M -8 12 q -6 0 -10 -4" fill="#4a6b5f" opacity="0.8"/>
+    <path d="M 2 6 q 8 10 14 22" fill="none" stroke="#4a6b5f" stroke-width="1.2"/>
+    <path d="M 8 12 q 6 0 10 -4" fill="#4a6b5f" opacity="0.8"/>
+  </g>
+  <rect x="30" y="30" width="540" height="300" fill="none" stroke="#d4af37" stroke-width="1.5"/>
+  <g fill="#d4af37">
+    <path d="M 30 30 l 16 0 l 0 3 l -13 0 l 0 13 l -3 0 z"/>
+    <path d="M 570 30 l -16 0 l 0 3 l 13 0 l 0 13 l 3 0 z"/>
+    <path d="M 30 330 l 16 0 l 0 -3 l -13 0 l 0 -13 l -3 0 z"/>
+    <path d="M 570 330 l -16 0 l 0 -3 l 13 0 l 0 -13 l 3 0 z"/>
+  </g>
+</svg>

--- a/packages/collection-grimm-top5/assets/opening.svg
+++ b/packages/collection-grimm-top5/assets/opening.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360" role="img" aria-labelledby="t d">
+  <title id="t">Es war einmal</title>
+  <desc id="d">Opening illustration: castle on hills at dawn framed by a golden arch.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f4c77a"/>
+      <stop offset="0.5" stop-color="#e89a6e"/>
+      <stop offset="1" stop-color="#9a5a7d"/>
+    </linearGradient>
+    <linearGradient id="hill1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#4a6b5f"/>
+      <stop offset="1" stop-color="#2b3f38"/>
+    </linearGradient>
+    <linearGradient id="hill2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#6b8575"/>
+      <stop offset="1" stop-color="#3d5248"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="360" fill="#f8efd9"/>
+  <rect x="30" y="30" width="540" height="300" fill="url(#sky)"/>
+  <circle cx="300" cy="180" r="52" fill="#fde9b7" opacity="0.85"/>
+  <g fill="#f4e4b2" opacity="0.9">
+    <circle cx="110" cy="85" r="1.2"/>
+    <circle cx="170" cy="60" r="1"/>
+    <circle cx="480" cy="75" r="1.4"/>
+    <circle cx="430" cy="55" r="1"/>
+    <circle cx="520" cy="110" r="1.1"/>
+  </g>
+  <g fill="url(#hill2)">
+    <path d="M 30 260 Q 150 200 280 240 Q 410 270 570 220 L 570 330 L 30 330 Z"/>
+  </g>
+  <g fill="url(#hill1)">
+    <path d="M 30 290 Q 180 240 320 280 Q 450 305 570 260 L 570 330 L 30 330 Z"/>
+  </g>
+  <g transform="translate(270 200)" fill="#2b2f3a" stroke="#0f1220" stroke-width="1">
+    <rect x="0" y="20" width="60" height="50"/>
+    <rect x="-10" y="10" width="20" height="60"/>
+    <rect x="50" y="10" width="20" height="60"/>
+    <polygon points="-10,10 0,-5 10,10"/>
+    <polygon points="50,10 60,-5 70,10"/>
+    <polygon points="0,20 30,-5 60,20"/>
+    <rect x="25" y="35" width="10" height="20" fill="#f4c77a"/>
+    <rect x="-6" y="30" width="6" height="8" fill="#f4c77a"/>
+    <rect x="56" y="30" width="6" height="8" fill="#f4c77a"/>
+    <line x1="5" y1="-8" x2="5" y2="-18" stroke="#0f1220"/>
+    <polygon points="5,-18 14,-15 5,-12" fill="#c94a4a" stroke="none"/>
+    <line x1="65" y1="-8" x2="65" y2="-18" stroke="#0f1220"/>
+    <polygon points="65,-18 74,-15 65,-12" fill="#c94a4a" stroke="none"/>
+  </g>
+  <rect x="30" y="30" width="540" height="300" fill="none" stroke="#8b6914" stroke-width="2"/>
+  <rect x="36" y="36" width="528" height="288" fill="none" stroke="#d4af37" stroke-width="0.7"/>
+  <g fill="#8b6914">
+    <circle cx="30" cy="30" r="4"/>
+    <circle cx="570" cy="30" r="4"/>
+    <circle cx="30" cy="330" r="4"/>
+    <circle cx="570" cy="330" r="4"/>
+  </g>
+  <g transform="translate(300 48)" fill="#5b3a1a">
+    <path d="M -50 0 q 25 -16 50 0 q 25 16 50 0" fill="none" stroke="#5b3a1a" stroke-width="1.2"/>
+    <circle cx="0" cy="0" r="2.5"/>
+    <circle cx="-25" cy="-2" r="1.5"/>
+    <circle cx="25" cy="-2" r="1.5"/>
+  </g>
+  <text x="300" y="320" text-anchor="middle" font-family="Georgia, serif" font-size="16" font-style="italic" fill="#5b3a1a">Es war einmal ...</text>
+</svg>

--- a/packages/collection-grimm-top5/assets/ornament.svg
+++ b/packages/collection-grimm-top5/assets/ornament.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 40" role="img" aria-labelledby="t">
+  <title id="t">Ornament</title>
+  <g fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round">
+    <line x1="10" y1="20" x2="95" y2="20"/>
+    <line x1="145" y1="20" x2="230" y2="20"/>
+    <circle cx="120" cy="20" r="4" fill="currentColor" stroke="none"/>
+    <path d="M 105 20 q 7 -8 15 0 q 8 8 15 0"/>
+    <path d="M 105 20 q 7 8 15 0 q 8 -8 15 0"/>
+    <circle cx="100" cy="20" r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="140" cy="20" r="1.2" fill="currentColor" stroke="none"/>
+    <path d="M 70 20 q 5 -6 10 0 q 5 6 10 0" opacity="0.7"/>
+    <path d="M 150 20 q 5 -6 10 0 q 5 6 10 0" opacity="0.7"/>
+  </g>
+</svg>

--- a/packages/collection-grimm-top5/index.js
+++ b/packages/collection-grimm-top5/index.js
@@ -13,6 +13,10 @@ import schneewittchenCover from './stories/schneewittchen/cover.svg?url';
 
 import aschenputtelSchweizerdeutsch from './stories/aschenputtel/adaptions/schweizerdeutsch/content.md?raw';
 
+import openingIllustration from './assets/opening.svg?url';
+import endingIllustration from './assets/ending.svg?url';
+import ornamentIllustration from './assets/ornament.svg?url';
+
 export { manifest };
 
 export const stories = {
@@ -31,10 +35,16 @@ export const covers = {
   schneewittchen: schneewittchenCover,
 };
 
+export const illustrations = {
+  opening: openingIllustration,
+  ending: endingIllustration,
+  ornament: ornamentIllustration,
+};
+
 export const adaptions = {
   aschenputtel: {
     schweizerdeutsch: aschenputtelSchweizerdeutsch,
   },
 };
 
-export default { manifest, stories, covers, adaptions };
+export default { manifest, stories, covers, illustrations, adaptions };

--- a/src/lib/storyLibrary.js
+++ b/src/lib/storyLibrary.js
@@ -40,10 +40,18 @@ export function buildCoverMap(modules) {
 const collectionStoryMap = new Map();
 const collectionAdaptionMap = new Map();
 const collectionCoverMap = new Map();
+const collectionIllustrationsMap = new Map();
 for (const pkg of collections) {
   if (!pkg || !pkg.manifest || !pkg.stories) continue;
-  const { manifest, stories, covers = {}, adaptions: pkgAdaptions = {} } = pkg;
+  const { manifest, stories, covers = {}, illustrations, adaptions: pkgAdaptions = {} } = pkg;
   const source = manifest.id;
+  if (illustrations && typeof illustrations === 'object') {
+    collectionIllustrationsMap.set(source, {
+      opening: typeof illustrations.opening === 'string' ? illustrations.opening : null,
+      ending: typeof illustrations.ending === 'string' ? illustrations.ending : null,
+      ornament: typeof illustrations.ornament === 'string' ? illustrations.ornament : null,
+    });
+  }
   for (const entry of manifest.stories || []) {
     const slug = entry.slug;
     const raw = stories[slug];
@@ -311,6 +319,12 @@ export async function loadAdaptionsByStoryId(storyId) {
 
 export function getStoryCoverUrl(storyId) {
   return collectionCoverMap.get(storyId) || null;
+}
+
+export function getStoryIllustrations(storyId) {
+  if (!storyId) return null;
+  const sourceId = storyId.split('/')[0];
+  return collectionIllustrationsMap.get(sourceId) || null;
 }
 
 export async function loadStoryAudioMap() {

--- a/tests/unit/guidelines/__fixtures__/data-testids.txt
+++ b/tests/unit/guidelines/__fixtures__/data-testids.txt
@@ -33,6 +33,7 @@ orp-panel-toggle
 orp-preview
 page-content
 page-counter
+paragraph-ornament
 prev-page
 profile-back-bottom
 profile-back-top
@@ -66,6 +67,8 @@ speed-reader-wpm-decrease
 speed-reader-wpm-increase
 story-close
 story-cover
+story-ending-illustration
+story-opening-illustration
 subscription-upgrade-cta
 tap-zone-left
 tap-zone-middle


### PR DESCRIPTION
Collections can now ship three new SVG assets at the collection level:
- opening.svg: beautiful opening art shown on the first page when no
  per-story cover exists (otherwise rendered under the title alongside it)
- ending.svg: beautiful ending art shown on the last page
- ornament.svg: monochrome divider rendered between complete paragraphs,
  inheriting the reader's theme color via currentColor

Each of the three existing collections ships its own styled variants.

The page-measurement algorithm in useReader reserves vertical space for
each paragraph-break ornament when showIllustrations is on, so rendered
content continues to fit inside the viewport.

https://claude.ai/code/session_01SjjHpb4Q3zWzCB3wh44bgp