### PR TITLE
feat(profile): group feature toggles with master group switch

### DIFF
--- a/components/ProfileFeatureList.jsx
+++ b/components/ProfileFeatureList.jsx
@@ -1,0 +1,226 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useTheme } from '../ui/ThemeContext';
+import Toggle from '../ui/Toggle';
+import VariantPicker from '../ui/VariantPicker';
+import { ROLES, ROLE_LABELS } from '../hooks/useRole';
+import { FEATURE_GROUPS } from '../src/lib/featureRegistry';
+
+const APP_ANIMATION_OPTIONS = [
+  { value: 'seal',    label: 'Portal',   testId: 'app-animation-variant-seal' },
+  { value: 'fade',    label: 'Minimal',  testId: 'app-animation-variant-fade' },
+  { value: 'sparkle', label: 'Funken',   testId: 'app-animation-variant-sparkle' },
+  { value: 'ink',     label: 'Tinte',    testId: 'app-animation-variant-ink' },
+];
+
+function partitionByGroup(visibleFeatures) {
+  const byGroup = new Map();
+  for (const g of FEATURE_GROUPS) byGroup.set(g.id, []);
+  const unknown = [];
+  for (const f of visibleFeatures) {
+    if (byGroup.has(f.group)) byGroup.get(f.group).push(f);
+    else unknown.push(f);
+  }
+  const sections = FEATURE_GROUPS
+    .map((g) => ({ ...g, items: byGroup.get(g.id) }))
+    .filter((g) => g.items.length > 0);
+  if (unknown.length > 0) {
+    sections.push({
+      id: 'other', label: 'Weitere', description: '', Icon: () => null, items: unknown,
+    });
+  }
+  return sections;
+}
+
+/**
+ * Collapsible, group-aware feature-toggle list for the profile panel.
+ *
+ * Each group renders as a bordered section with a header that shows
+ * icon + label + "N/M aktiv" + chevron, plus a master Toggle that
+ * switches every child in the group on or off. The group definitions
+ * come from FEATURE_GROUPS in the registry.
+ */
+export default function ProfileFeatureList({
+  visibleFeatures,
+  _rawFlagValues,
+  userFeatureOverrides,
+  onToggleFeature,
+  onSetFeaturesEnabled,
+  isAdmin,
+  isFeatureAssignedToRole,
+  toggleFeatureForRole,
+  onOpenDocs,
+  appAnimationVariant = 'seal',
+  onSetAppAnimationVariant,
+}) {
+  const { dark } = useTheme();
+  const _o = (key, raw) => Object.hasOwn(userFeatureOverrides, key) ? userFeatureOverrides[key] : raw;
+  const nonAdminRoles = ROLES.filter((r) => r !== 'admin');
+  const groupedFeatures = partitionByGroup(visibleFeatures);
+
+  const [collapsedGroups, setCollapsedGroups] = useState(() => new Set());
+  const toggleGroupCollapsed = (groupId) =>
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId); else next.add(groupId);
+      return next;
+    });
+
+  const masterToggle = (items) => {
+    const allOn = items.every((f) => _o(f.key, _rawFlagValues[f.key] ?? false));
+    const nextValue = !allOn;
+    const keys = items.map((f) => f.key);
+    if (onSetFeaturesEnabled) {
+      onSetFeaturesEnabled(keys, nextValue);
+    } else {
+      for (const f of items) {
+        const current = _o(f.key, _rawFlagValues[f.key] ?? false);
+        if (current !== nextValue) onToggleFeature(f.key);
+      }
+    }
+  };
+
+  const renderFeatureRow = ({ key, label, description, Icon }) => {
+    const effective = _o(key, _rawFlagValues[key] ?? false);
+    const isUnreleased = !Object.hasOwn(_rawFlagValues, key);
+    return (
+      <div key={key} className={`px-5 py-4 flex items-start gap-4 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+        <div className={`flex-shrink-0 mt-0.5 w-10 h-10 rounded-xl flex items-center justify-center transition-colors ${
+          effective
+            ? dark ? 'bg-amber-700/40 text-amber-300' : 'bg-amber-100 text-amber-700'
+            : dark ? 'bg-slate-700/60 text-amber-700' : 'bg-amber-50/80 text-amber-400'
+        }`}>
+          <div className="w-5 h-5"><Icon /></div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 min-w-0">
+              <p className={`text-sm font-medium transition-opacity ${effective ? '' : 'opacity-40'}`}>{label}</p>
+              {isUnreleased && (
+                <span className={`flex-shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
+                  dark ? 'bg-violet-900/60 text-violet-300' : 'bg-violet-100 text-violet-700'
+                }`}>
+                  unveröffentlicht
+                </span>
+              )}
+            </div>
+            <Toggle checked={effective} onChange={() => onToggleFeature(key)} label={label} />
+          </div>
+          <p className={`text-xs mt-1 leading-relaxed ${dark ? 'text-amber-600' : 'text-amber-500'}`}>{description}</p>
+          <button
+            onClick={() => onOpenDocs(key)}
+            className={`text-xs mt-1 inline-block transition-colors hover:underline ${
+              dark ? 'text-amber-400/70 hover:text-amber-400' : 'text-amber-600/70 hover:text-amber-700'
+            }`}
+          >
+            Mehr erfahren →
+          </button>
+          {key === 'app-animation' && effective && onSetAppAnimationVariant && (
+            <div className="mt-3" data-testid="app-animation-variant-picker">
+              <VariantPicker
+                ariaLabel="App-Animation Variante"
+                options={APP_ANIMATION_OPTIONS}
+                value={appAnimationVariant}
+                onChange={onSetAppAnimationVariant}
+              />
+            </div>
+          )}
+          {isAdmin && (
+            <div className="flex items-center gap-3 mt-2">
+              <span className={`text-[10px] uppercase tracking-wider ${dark ? 'text-amber-700' : 'text-amber-400'}`}>Rollen:</span>
+              {nonAdminRoles.map((r) => {
+                const assigned = isFeatureAssignedToRole(key, r);
+                return (
+                  <button
+                    key={r}
+                    data-testid={`role-assign-${key}-${r}`}
+                    onClick={() => toggleFeatureForRole(key, r)}
+                    className={`text-[10px] font-medium px-2 py-0.5 rounded-full border transition-colors ${
+                      assigned
+                        ? dark ? 'bg-violet-700/60 border-violet-500 text-violet-200' : 'bg-violet-100 border-violet-400 text-violet-800'
+                        : dark ? 'border-amber-800/50 text-amber-800 hover:text-amber-600' : 'border-amber-300 text-amber-400 hover:text-amber-600'
+                    }`}
+                  >
+                    {ROLE_LABELS[r]}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      {groupedFeatures.map((group) => {
+        const collapsed = collapsedGroups.has(group.id);
+        const onCount = group.items.reduce(
+          (n, f) => n + (_o(f.key, _rawFlagValues[f.key] ?? false) ? 1 : 0),
+          0,
+        );
+        const allOn = onCount === group.items.length;
+        const anyOn = onCount > 0;
+        const GroupIcon = group.Icon;
+        return (
+          <div
+            key={group.id}
+            data-testid={`feature-group-${group.id}`}
+            className={`rounded-2xl border overflow-hidden ${dark ? 'border-amber-700/30' : 'border-amber-200'}`}
+          >
+            <div className={`flex items-center gap-3 px-5 py-3 ${dark ? 'text-amber-200' : 'text-amber-900'}`}>
+              <button
+                type="button"
+                onClick={() => toggleGroupCollapsed(group.id)}
+                data-testid={`feature-group-header-${group.id}`}
+                aria-expanded={!collapsed}
+                className={`flex-1 min-w-0 flex items-center gap-3 text-left transition-colors rounded-lg -mx-1 px-1 py-1 ${
+                  dark ? 'hover:bg-amber-900/20' : 'hover:bg-amber-50'
+                }`}
+              >
+                <span className={`flex-shrink-0 w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
+                  anyOn
+                    ? dark ? 'bg-amber-700/40 text-amber-300' : 'bg-amber-100 text-amber-700'
+                    : dark ? 'bg-slate-700/60 text-amber-700' : 'bg-amber-50/80 text-amber-400'
+                }`}>
+                  <GroupIcon />
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="block text-sm font-semibold truncate">{group.label}</span>
+                  <span
+                    data-testid={`feature-group-count-${group.id}`}
+                    className={`block text-[11px] mt-0.5 ${dark ? 'text-amber-600' : 'text-amber-500'}`}
+                  >
+                    {onCount}/{group.items.length} aktiv
+                  </span>
+                </span>
+                <ChevronDown
+                  size={16}
+                  className={`flex-shrink-0 transition-transform ${collapsed ? '' : 'rotate-180'} ${
+                    dark ? 'text-amber-600' : 'text-amber-500'
+                  }`}
+                />
+              </button>
+              <span data-testid={`feature-group-toggle-${group.id}`} className="flex-shrink-0">
+                <Toggle
+                  checked={allOn}
+                  onChange={() => masterToggle(group.items)}
+                  label={`Alle „${group.label}" umschalten`}
+                />
+              </span>
+            </div>
+            {!collapsed && (
+              <div
+                data-testid={`feature-group-body-${group.id}`}
+                className={`border-t divide-y ${dark ? 'border-amber-700/30 divide-amber-700/30' : 'border-amber-200 divide-amber-200'}`}
+              >
+                {group.items.map(renderFeatureRow)}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ProfilePanel.jsx
+++ b/components/ProfilePanel.jsx
@@ -1,16 +1,8 @@
 import { ChevronLeft, X, User, Shield, FlameKindling, Users } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
-import Toggle from '../ui/Toggle';
-import VariantPicker from '../ui/VariantPicker';
 import { ROLES, ROLE_LABELS } from '../hooks/useRole';
 import ABTestingPanel from './ABTestingPanel';
-
-const APP_ANIMATION_OPTIONS = [
-  { value: 'seal',    label: 'Portal',   testId: 'app-animation-variant-seal' },
-  { value: 'fade',    label: 'Minimal',  testId: 'app-animation-variant-fade' },
-  { value: 'sparkle', label: 'Funken',   testId: 'app-animation-variant-sparkle' },
-  { value: 'ink',     label: 'Tinte',    testId: 'app-animation-variant-ink' },
-];
+import ProfileFeatureList from './ProfileFeatureList';
 
 /**
  * Profile panel - user stats, word blacklist, feature toggles, and admin tools.
@@ -33,6 +25,7 @@ export default function ProfilePanel({
   _rawFlagValues,
   userFeatureOverrides,
   onToggleFeature,
+  onSetFeaturesEnabled,
   // Role props
   role,
   setRole,
@@ -63,8 +56,6 @@ export default function ProfilePanel({
   ]);
   const { dark, hc, tc } = useTheme();
 
-  const _o = (key, raw) => Object.hasOwn(userFeatureOverrides, key) ? userFeatureOverrides[key] : raw;
-
   // Admin sees all features; others see only role-assigned features
   let visibleFeatures = isAdmin
     ? features
@@ -72,8 +63,6 @@ export default function ProfilePanel({
   if (simplifiedUi && !isAdmin) {
     visibleFeatures = visibleFeatures.filter((f) => !SIMPLIFIED_HIDDEN.has(f.key));
   }
-
-  const nonAdminRoles = ROLES.filter((r) => r !== 'admin');
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -312,102 +301,19 @@ export default function ProfilePanel({
             </p>
           )}
 
-          <div className={`rounded-2xl border divide-y ${
-            dark ? 'border-amber-700/30 divide-amber-700/30' : 'border-amber-200 divide-amber-200'
-          }`}>
-            {visibleFeatures.map(({ key, label, description, Icon }) => {
-              const effective = _o(key, _rawFlagValues[key] ?? false);
-              const isUnreleased = !Object.hasOwn(_rawFlagValues, key);
-
-              return (
-                <div key={key} className={`px-5 py-4 flex items-start gap-4 ${
-                  dark ? 'text-amber-200' : 'text-amber-900'
-                }`}>
-                  <div className={`flex-shrink-0 mt-0.5 w-10 h-10 rounded-xl flex items-center justify-center transition-colors ${
-                    effective
-                      ? dark ? 'bg-amber-700/40 text-amber-300' : 'bg-amber-100 text-amber-700'
-                      : dark ? 'bg-slate-700/60 text-amber-700' : 'bg-amber-50/80 text-amber-400'
-                  }`}>
-                    <div className="w-5 h-5"><Icon /></div>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <p className={`text-sm font-medium transition-opacity ${
-                          effective ? '' : 'opacity-40'
-                        }`}>{label}</p>
-                        {isUnreleased && (
-                          <span className={`flex-shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
-                            dark ? 'bg-violet-900/60 text-violet-300' : 'bg-violet-100 text-violet-700'
-                          }`}>
-                            unveröffentlicht
-                          </span>
-                        )}
-                      </div>
-                      <Toggle
-                        checked={effective}
-                        onChange={() => onToggleFeature(key)}
-                        label={label}
-                      />
-                    </div>
-                    <p className={`text-xs mt-1 leading-relaxed ${
-                      dark ? 'text-amber-600' : 'text-amber-500'
-                    }`}>{description}</p>
-                    <button
-                      onClick={() => onOpenDocs(key)}
-                      className={`text-xs mt-1 inline-block transition-colors hover:underline ${
-                        dark ? 'text-amber-400/70 hover:text-amber-400' : 'text-amber-600/70 hover:text-amber-700'
-                      }`}
-                    >
-                      Mehr erfahren →
-                    </button>
-
-                    {/* App-animation variant picker — inline under the toggle */}
-                    {key === 'app-animation' && effective && onSetAppAnimationVariant && (
-                      <div className="mt-3" data-testid="app-animation-variant-picker">
-                        <VariantPicker
-                          ariaLabel="App-Animation Variante"
-                          options={APP_ANIMATION_OPTIONS}
-                          value={appAnimationVariant}
-                          onChange={onSetAppAnimationVariant}
-                        />
-                      </div>
-                    )}
-
-                    {/* Admin: role-assignment row */}
-                    {isAdmin && (
-                      <div className="flex items-center gap-3 mt-2">
-                        <span className={`text-[10px] uppercase tracking-wider ${
-                          dark ? 'text-amber-700' : 'text-amber-400'
-                        }`}>Rollen:</span>
-                        {nonAdminRoles.map((r) => {
-                          const assigned = isFeatureAssignedToRole(key, r);
-                          return (
-                            <button
-                              key={r}
-                              data-testid={`role-assign-${key}-${r}`}
-                              onClick={() => toggleFeatureForRole(key, r)}
-                              className={`text-[10px] font-medium px-2 py-0.5 rounded-full border transition-colors ${
-                                assigned
-                                  ? dark
-                                    ? 'bg-violet-700/60 border-violet-500 text-violet-200'
-                                    : 'bg-violet-100 border-violet-400 text-violet-800'
-                                  : dark
-                                    ? 'border-amber-800/50 text-amber-800 hover:text-amber-600'
-                                    : 'border-amber-300 text-amber-400 hover:text-amber-600'
-                              }`}
-                            >
-                              {ROLE_LABELS[r]}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+          <ProfileFeatureList
+            visibleFeatures={visibleFeatures}
+            _rawFlagValues={_rawFlagValues}
+            userFeatureOverrides={userFeatureOverrides}
+            onToggleFeature={onToggleFeature}
+            onSetFeaturesEnabled={onSetFeaturesEnabled}
+            isAdmin={isAdmin}
+            isFeatureAssignedToRole={isFeatureAssignedToRole}
+            toggleFeatureForRole={toggleFeatureForRole}
+            onOpenDocs={onOpenDocs}
+            appAnimationVariant={appAnimationVariant}
+            onSetAppAnimationVariant={onSetAppAnimationVariant}
+          />
         </div>
 
         {/* A/B testing panel */}

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -880,6 +880,7 @@ const GrimmMarchenApp = () => {
               _rawFlagValues={_rawFlagValues}
               userFeatureOverrides={userFeatureOverrides}
               onToggleFeature={(key) => setUserFeatureOverrides(prev => ({ ...prev, [key]: !_o(key, _rawFlagValues[key] ?? false) }))}
+              onSetFeaturesEnabled={(keys, enabled) => setUserFeatureOverrides(prev => ({ ...prev, ...Object.fromEntries(keys.map(k => [k, enabled])) }))}
               role={role}
               setRole={setRole}
               isAdmin={isAdmin}

--- a/guidelines.config.json
+++ b/guidelines.config.json
@@ -13,8 +13,8 @@
     },
     {
       "file": "src/lib/featureRegistry.jsx",
-      "limit": 700,
-      "reason": "Declarative registry — large by design; grew with retireBy annotations (rule 4), the age-filter/collections entries, and the enhanced-gestures beta entry. Target: move role-default tables into a sibling registry; aim <500 lines."
+      "limit": 820,
+      "reason": "Declarative registry — large by design; grew with retireBy annotations (rule 4), the age-filter/collections entries, the enhanced-gestures beta entry, and the new FEATURE_GROUPS table plus per-entry `group` field that drives grouped profile-panel sections. Target: move role-default tables and group metadata into sibling registries; aim <500 lines."
     },
     {
       "file": "components/SidebarV2.jsx",
@@ -40,11 +40,6 @@
       "file": "components/DebugOverlay.jsx",
       "limit": 480,
       "reason": "Debug-only panel. Target: split into DebugOverlayPanel + DebugOverlayFlags sections."
-    },
-    {
-      "file": "components/ProfilePanel.jsx",
-      "limit": 460,
-      "reason": "Base profile panel. Target: extract the feature-toggle list into a ProfileFeatureList subcomponent."
     },
     {
       "file": "ui/SpeedReaderView.jsx",

--- a/src/lib/featureRegistry.jsx
+++ b/src/lib/featureRegistry.jsx
@@ -79,6 +79,66 @@ const ALL_USERS = ['guest', 'subscriber', 'tester', 'sales'];
 export const RELEASE_STATUSES = ['released', 'beta', 'experimental'];
 export const TOGGLEABLE_KINDS = ['boolean', 'variant'];
 
+/**
+ * Ordered logical groups used to render features as collapsible sections
+ * with a master toggle in the profile panel. Every registry entry declares
+ * a `group` that maps to one of these ids.
+ *
+ * Shape: { id, label, description, Icon }
+ */
+export const FEATURE_GROUPS = [
+  {
+    id: 'reading',
+    label: 'Lesen & Favoriten',
+    description: 'Lesezeit, Wörteranzahl, Favoriten und Quellenangaben.',
+    Icon: () => <Heart size={16} strokeWidth={1.75} />,
+  },
+  {
+    id: 'typography',
+    label: 'Schrift & Darstellung',
+    description: 'Schriftgröße, Typografie, Themen und Darstellung.',
+    Icon: () => <Type size={16} strokeWidth={1.75} />,
+  },
+  {
+    id: 'navigation',
+    label: 'Seitensteuerung',
+    description: 'Tipp-Zonen, Gesten und Seitenumblättern.',
+    Icon: () => <Hand size={16} strokeWidth={1.75} />,
+  },
+  {
+    id: 'content',
+    label: 'Geschichten & Inhalte',
+    description: 'Quellenstruktur, Sammlungen, Filter und Suche.',
+    Icon: () => <Folder size={16} strokeWidth={1.75} />,
+  },
+  {
+    id: 'speed',
+    label: 'Schnellleser',
+    description: 'RSVP-Modus und ORP-Lesemarke.',
+    Icon: () => <ClockFading size={16} strokeWidth={1.75} />,
+  },
+  {
+    id: 'voice',
+    label: 'Audio & Sprache',
+    description: 'Audio-Player, Text-zu-Sprache und Sprachbefehle.',
+    Icon: () => <Mic size={16} strokeWidth={1.75} />,
+  },
+  {
+    id: 'commerce',
+    label: 'Tarife & Verkauf',
+    description: 'Paywalls, Promo-Codes und Abrechnung.',
+    Icon: () => <CreditCard size={16} strokeWidth={1.75} />,
+  },
+  {
+    id: 'dev',
+    label: 'Entwicklung & Tests',
+    description: 'Debug-Werkzeuge, A/B-Tests und experimentelle Varianten.',
+    Icon: () => <Bug size={16} strokeWidth={1.75} />,
+  },
+];
+
+export const FEATURE_GROUP_IDS = new Set(FEATURE_GROUPS.map((g) => g.id));
+
 export const FEATURE_REGISTRY = [
   // -------- Released foundations --------
   {
@@ -91,6 +151,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'reading',
   },
   {
     key: 'favorites-only-toggle',
@@ -102,6 +163,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'reading',
   },
   {
     key: 'word-count',
@@ -113,6 +175,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ['subscriber', 'tester', 'sales'],
+    group: 'reading',
   },
   {
     key: 'reading-duration',
@@ -124,6 +187,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ['subscriber', 'tester', 'sales'],
+    group: 'reading',
   },
   {
     key: 'font-size-controls',
@@ -135,6 +199,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'typography',
   },
   {
     key: 'pinch-font-size',
@@ -146,6 +211,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'typography',
   },
   {
     key: 'eink-flash',
@@ -157,6 +223,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'navigation',
   },
   {
     key: 'tap-zones',
@@ -168,6 +235,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'navigation',
   },
   {
     key: 'tap-middle-toggle',
@@ -179,6 +247,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'navigation',
   },
   {
     key: 'adaption-switcher',
@@ -190,6 +259,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ['subscriber', 'tester', 'sales'],
+    group: 'content',
   },
   {
     key: 'typography-panel',
@@ -201,6 +271,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'typography',
   },
   {
     key: 'subscriber-fonts',
@@ -212,6 +283,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ['subscriber', 'tester', 'sales'],
+    group: 'typography',
   },
   {
     key: 'attribution',
@@ -223,6 +295,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'reading',
   },
   {
     key: 'audio-player',
@@ -234,6 +307,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'voice',
   },
   {
     key: 'high-contrast-theme',
@@ -245,6 +319,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'typography',
   },
   {
     key: 'story-directories',
@@ -256,6 +331,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ['subscriber', 'tester', 'sales'],
+    group: 'content',
   },
   {
     key: 'age-filter',
@@ -266,6 +342,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ALL_USERS,
+    group: 'content',
   },
   {
     key: 'collections',
@@ -277,6 +354,7 @@ export const FEATURE_REGISTRY = [
     status: 'released',
     retireBy: '2026-12-31',
     roles: ALL_USERS,
+    group: 'content',
   },
 
   // -------- Released but hidden (variant / infra flags) --------
@@ -294,6 +372,7 @@ export const FEATURE_REGISTRY = [
     retireBy: '2027-06-30',
     roles: ALL_USERS,
     hidden: true,
+    group: 'typography',
   },
   {
     key: 'theme-toggle',
@@ -306,6 +385,7 @@ export const FEATURE_REGISTRY = [
     retireBy: '2027-06-30',
     roles: ALL_USERS,
     hidden: true,
+    group: 'typography',
   },
 
   // -------- Beta: works, opt-in --------
@@ -318,6 +398,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['subscriber', 'tester'],
+    group: 'speed',
   },
   {
     key: 'speedreader-orp',
@@ -328,6 +409,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['subscriber', 'tester'],
+    group: 'speed',
   },
   {
     key: 'word-blacklist',
@@ -338,6 +420,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['subscriber', 'tester'],
+    group: 'content',
   },
   {
     key: 'deep-search',
@@ -348,6 +431,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['subscriber', 'tester'],
+    group: 'content',
   },
   {
     key: 'simplified-ui',
@@ -358,6 +442,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['tester'],
+    group: 'typography',
   },
   {
     key: 'enhanced-gestures',
@@ -368,6 +453,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['subscriber', 'tester'],
+    group: 'navigation',
   },
   {
     key: 'text-to-speech',
@@ -378,6 +464,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['tester'],
+    group: 'voice',
   },
   {
     key: 'big-fonts',
@@ -392,6 +479,7 @@ export const FEATURE_REGISTRY = [
     status: 'beta',
     roles: ALL_USERS,
     hidden: true,
+    group: 'typography',
   },
   {
     key: 'app-animation',
@@ -402,6 +490,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: [],
+    group: 'dev',
   },
   {
     key: 'ab-testing',
@@ -412,6 +501,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['subscriber', 'tester', 'sales'],
+    group: 'dev',
   },
 
   // -------- Beta: commerce / sales --------
@@ -424,6 +514,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'paywall',
@@ -434,6 +525,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'upgrade-cta',
@@ -444,6 +536,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'trial-banner',
@@ -454,6 +547,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'pricing-page',
@@ -464,6 +558,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'promo-code',
@@ -474,6 +569,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'referral-program',
@@ -484,6 +580,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'sales-mode',
@@ -494,6 +591,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'conversion-analytics',
@@ -504,6 +602,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
   {
     key: 'billing-portal-stub',
@@ -514,6 +613,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ['sales'],
+    group: 'commerce',
   },
 
   // -------- Experimental: admin / tester only --------
@@ -526,6 +626,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: ['tester'],
+    group: 'voice',
   },
   {
     key: 'illustrations',
@@ -536,6 +637,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ALL_USERS,
+    group: 'content',
   },
   {
     key: 'child-profile',
@@ -546,6 +648,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'beta',
     roles: ALL_USERS,
+    group: 'content',
   },
   {
     key: 'story-quiz',
@@ -556,6 +659,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: ['tester'],
+    group: 'content',
   },
   {
     key: 'voice-control',
@@ -566,6 +670,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: [],
+    group: 'voice',
   },
   {
     key: 'voice-resume',
@@ -576,6 +681,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: [],
+    group: 'voice',
   },
   {
     key: 'voice-navigation',
@@ -586,6 +692,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: [],
+    group: 'voice',
   },
   {
     key: 'voice-reading-control',
@@ -596,6 +703,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: [],
+    group: 'voice',
   },
   {
     key: 'voice-discovery',
@@ -606,6 +714,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: [],
+    group: 'voice',
   },
   {
     key: 'voice-hands-free',
@@ -616,6 +725,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: [],
+    group: 'voice',
   },
   {
     key: 'debug-badges',
@@ -626,6 +736,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: ['tester'],
+    group: 'dev',
   },
   {
     key: 'error-page-simulator',
@@ -636,6 +747,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: ['tester'],
+    group: 'dev',
   },
   {
     key: 'ab-testing-admin',
@@ -646,6 +758,7 @@ export const FEATURE_REGISTRY = [
     flag: bool('off'),
     status: 'experimental',
     roles: [],
+    group: 'dev',
   },
   {
     key: 'hero-tagline',
@@ -657,6 +770,7 @@ export const FEATURE_REGISTRY = [
     status: 'experimental',
     roles: [],
     hidden: true,
+    group: 'dev',
   },
 ];
 
@@ -687,6 +801,10 @@ export function getDefaultRoleFeatures() {
 
 export function getFeaturesByStatus(status) {
   return FEATURE_REGISTRY.filter((e) => e.status === status).map((e) => e.key);
+}
+
+export function getFeaturesByGroup(groupId) {
+  return FEATURE_REGISTRY.filter((e) => e.group === groupId).map((e) => e.key);
 }
 
 /**

--- a/tests/unit/registryConsistency.test.js
+++ b/tests/unit/registryConsistency.test.js
@@ -2,8 +2,11 @@ import flagsJson from '../../flags.json';
 import {
   FEATURE_REGISTRY,
   FEATURES,
+  FEATURE_GROUPS,
+  FEATURE_GROUP_IDS,
   getFlagConfig,
   getDefaultRoleFeatures,
+  getFeaturesByGroup,
 } from '../../src/lib/featureRegistry';
 import { AB_EXPERIMENTS, AB_DEFAULT_CONFIG } from '../../src/lib/abExperiments';
 import { ROLES } from '../../hooks/useRole';
@@ -52,6 +55,32 @@ describe('registry ↔ role defaults consistency', () => {
     const defaults = getDefaultRoleFeatures();
     for (const role of Object.keys(defaults)) {
       expect(ROLES).toContain(role);
+    }
+  });
+});
+
+describe('registry feature groups', () => {
+  it('every registry entry declares a group', () => {
+    for (const entry of FEATURE_REGISTRY) {
+      expect(typeof entry.group).toBe('string');
+      expect(entry.group.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every entry group matches a FEATURE_GROUPS id', () => {
+    for (const entry of FEATURE_REGISTRY) {
+      expect(FEATURE_GROUP_IDS.has(entry.group)).toBe(true);
+    }
+  });
+
+  it('FEATURE_GROUPS ids are unique', () => {
+    const ids = FEATURE_GROUPS.map((g) => g.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every group has at least one registry entry', () => {
+    for (const group of FEATURE_GROUPS) {
+      expect(getFeaturesByGroup(group.id).length).toBeGreaterThan(0);
     }
   });
 });


### PR DESCRIPTION
Introduces a FEATURE_GROUPS layer in the registry so every feature
declares a logical group (reading, typography, navigation, content,
speed, voice, commerce, dev). ProfilePanel renders each non-empty
group as a collapsible section with a master Toggle that flips all
contained features on/off at once.

- featureRegistry: add FEATURE_GROUPS table and per-entry `group`
- ProfileFeatureList: new subcomponent rendering grouped sections
- ProfilePanel: delegate the toggle list to ProfileFeatureList
- grimm-reader: wire onSetFeaturesEnabled for bulk overrides
- registryConsistency tests: assert every entry has a valid group
- guidelines: drop ProfilePanel allowlist (now under default budget)

https://claude.ai/code/session_01YC4RL9iVdsvucbYYmwhuxi