### PR TITLE
fix(tests): repair 7 e2e failures across three specs

### DIFF
--- a/components/SidebarV2.jsx
+++ b/components/SidebarV2.jsx
@@ -358,6 +358,7 @@ export default function SidebarV2({
     <button
       key={`src-${src.id}`}
       data-testid="source-button"
+      data-source-id={src.id}
       onClick={() => toggleSource(src.id)}
       className={`w-full flex items-center gap-2 px-3 py-2.5 rounded-lg transition-all ${
         darkMode ? 'text-amber-100 hover:bg-slate-800' : 'text-amber-900 hover:bg-amber-100'

--- a/tests/animation-navigation.spec.js
+++ b/tests/animation-navigation.spec.js
@@ -161,13 +161,14 @@ test.describe('C – Sidebar open/close animation', () => {
     await disableAppAnimation(page);
   });
 
-  test('sidebar carries transition-transform duration-300 classes', async ({ page }) => {
+  test('sidebar carries a duration-300 transition for the slide animation', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/app');
     await page.waitForLoadState('networkidle');
 
     const sidebar = page.locator('aside').first();
-    await expect(sidebar).toHaveClass(/transition-transform/);
+    // Sidebar animates both width and transform, so it uses `transition-all`.
+    await expect(sidebar).toHaveClass(/transition-(?:transform|all)/);
     await expect(sidebar).toHaveClass(/duration-300/);
   });
 

--- a/tests/enhanced-gestures.spec.js
+++ b/tests/enhanced-gestures.spec.js
@@ -29,7 +29,7 @@ async function dispatchSwipe(page, selector, from, to) {
   await page.evaluate(({ selector, from, to }) => {
     const el = document.querySelector(selector);
     if (!el) throw new Error(`No element: ${selector}`);
-    const mkTouch = (x, y) => ({
+    const mkTouch = (x, y) => new Touch({
       identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y,
     });
     const fire = (type, x, y) => {
@@ -100,7 +100,7 @@ test.describe('Enhanced gestures', () => {
     // Only dispatch start + move (no end) so the indicator is still visible.
     await page.evaluate(({ cx, yStart, yMove }) => {
       const el = document.querySelector('[data-testid="reader-viewport"]');
-      const mk = (x, y) => ({ identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y });
+      const mk = (x, y) => new Touch({ identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y });
       const start = new TouchEvent('touchstart', { bubbles: true, cancelable: true,
         touches: [mk(cx, yStart)], targetTouches: [mk(cx, yStart)], changedTouches: [mk(cx, yStart)] });
       const move = new TouchEvent('touchmove', { bubbles: true, cancelable: true,

--- a/tests/young-readers.spec.js
+++ b/tests/young-readers.spec.js
@@ -36,8 +36,10 @@ test.describe('Young-reader features', () => {
     await page.waitForLoadState('networkidle');
     await openMenu(page);
 
-    // Drill into Grimm and pick Aschenputtel (has cover.svg)
-    const grimmSrc = page.locator('[data-testid="source-button"]').first();
+    // Drill into the base Grimm source. `.first()` is unstable now that
+    // curated Grimm collections also appear as sources; `data-source-id`
+    // is stable regardless of the label's lazy-metadata state.
+    const grimmSrc = page.locator('[data-testid="source-button"][data-source-id="grimm"]');
     await expect(grimmSrc).toBeVisible({ timeout: 5000 });
     await grimmSrc.click();
 
@@ -49,7 +51,9 @@ test.describe('Young-reader features', () => {
     const cover = page.locator('[data-testid="story-cover"]');
     await expect(cover).toBeVisible();
     const src = await cover.getAttribute('src');
-    expect(src).toMatch(/cover\.svg$/);
+    // Cover may be served as a file (`cover.svg`) or inlined as a
+    // `data:image/svg+xml,...` URL depending on collection packaging.
+    expect(src).toMatch(/(?:cover\.svg$|^data:image\/svg\+xml,)/);
   });
 
   test('age-filter: picker is hidden by default and shown when flag is on', async ({ page }) => {
@@ -73,8 +77,9 @@ test.describe('Young-reader features', () => {
     await page.waitForLoadState('networkidle');
     await openMenu(page);
 
-    // Drill into Grimm — story metadata loads lazily per-source
-    const grimmSrc = page.locator('[data-testid="source-button"]').first();
+    // Drill into the base Grimm source (see note above about `.first()`
+    // instability and why `data-source-id` is the stable selector).
+    const grimmSrc = page.locator('[data-testid="source-button"][data-source-id="grimm"]');
     await expect(grimmSrc).toBeVisible({ timeout: 5000 });
     await grimmSrc.click();
 

--- a/ui/SourceButton.jsx
+++ b/ui/SourceButton.jsx
@@ -15,6 +15,7 @@ export default function SourceButton({ src, onClick, simplifiedUi = false }) {
   return (
     <button
       data-testid="source-button"
+      data-source-id={src.id}
       onClick={onClick}
       className={cn(
         'w-full flex items-center justify-between rounded-lg transition-all',


### PR DESCRIPTION
## Summary

All seven `npm run test` failures on `main` were test-side issues — no product regression.

- **`enhanced-gestures.spec.js` (4 tests)** — `dispatchSwipe` passed plain `{}` objects to `TouchEvent`; Chromium's constructor needs real `Touch` instances. Swapped in `new Touch(init)`.
- **`animation-navigation.spec.js` (1 test)** — the sidebar component now uses `transition-all` (it animates width, transform, and colors together) but the assertion still required `transition-transform`. Relaxed matcher to accept either.
- **`young-readers.spec.js` (2 tests)** — `source-button.first()` became unstable once three curated Grimm collections (`klassiker`, `tiere`, `top5`) started shipping alongside the base Grimm source. Added a `data-source-id` attribute to both `Sidebar`'s `SourceButton` and `SidebarV2` so tests can target the base source stably. Also accepted inline `data:image/svg+xml,…` cover URLs in addition to file-backed `cover.svg` (the `grimm-top5` collection inlines covers).

## Test plan

- [x] `npx playwright test` — 59 passed (0 failed)
- [x] `npm run test:unit` — 229 passed (0 failed)
- [x] Verified the `enhanced-gestures` error on `main` before fixing, to rule out any interaction with the vite bump in #38

## Notes

- The new `data-source-id="<source-id>"` attribute is a small AX win: agents and tests can target a specific source without depending on the label's lazy-metadata-load state. Worth documenting in `CLAUDE.md`'s data-testid section later.

https://claude.ai/code/session_016XzbLGygjetDXcRhtQr9Ad