### PR TITLE
feat(feeds): map suggestion-feed search terms and add simple matcher

### DIFF
--- a/components/HomeView.jsx
+++ b/components/HomeView.jsx
@@ -1,8 +1,9 @@
 import { Heart } from 'lucide-react';
 import { useTheme } from '../ui/ThemeContext';
+import SuggestionFeeds from './SuggestionFeeds';
 
 /**
- * Home view - resume banner and favorites grid.
+ * Home view - resume banner, suggestion feeds and favorites grid.
  * Shown when no story is selected.
  */
 export default function HomeView({
@@ -13,6 +14,8 @@ export default function HomeView({
   completedStories,
   showFavorites,
   showWordCount,
+  showSuggestionFeeds,
+  storyIndex,
   onSelectStory,
   onToggleFavorite,
 }) {
@@ -52,6 +55,15 @@ export default function HomeView({
             ×
           </button>
         </div>
+      )}
+
+      {/* Suggestion Feeds */}
+      {showSuggestionFeeds && (
+        <SuggestionFeeds
+          storyIndex={storyIndex}
+          onSelectStory={onSelectStory}
+          showWordCount={showWordCount}
+        />
       )}
 
       {/* Favorites Grid or Empty State */}
@@ -108,7 +120,7 @@ export default function HomeView({
             ))}
           </div>
         </div>
-      ) : (
+      ) : showSuggestionFeeds ? null : (
         <div className="w-full h-full flex flex-col items-center justify-center">
           <div className="text-6xl mb-4">📚</div>
           <p className={`text-2xl font-serif font-bold mb-2 ${

--- a/components/SuggestionFeeds.jsx
+++ b/components/SuggestionFeeds.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { useTheme } from '../ui/ThemeContext';
+import { buildDailyFeeds } from '../src/lib/suggestionFeeds';
+
+const AXIS_LABELS = {
+  seasonal: 'Saison',
+  regional: 'Region',
+  moral: 'Moral',
+  motif: 'Motiv',
+  mood: 'Stimmung',
+  context: 'Lesekontext',
+};
+
+function FeedCard({ story, dark, onSelect, showWordCount }) {
+  return (
+    <button
+      type="button"
+      data-testid="feed-card"
+      onClick={() => onSelect(story)}
+      className={`shrink-0 w-44 sm:w-52 text-left rounded-xl border p-3 transition-colors ${
+        dark
+          ? 'bg-slate-800/60 border-amber-700/20 hover:bg-slate-800'
+          : 'bg-white/80 border-amber-200/60 hover:bg-white'
+      }`}
+    >
+      <p
+        className={`font-serif text-sm font-medium leading-snug mb-2 line-clamp-3 ${
+          dark ? 'text-amber-100' : 'text-amber-950'
+        }`}
+      >
+        {story.title}
+      </p>
+      <div className="flex items-center gap-2 flex-wrap">
+        <span
+          className={`text-xs px-1.5 py-0.5 rounded ${
+            dark ? 'bg-slate-700 text-amber-400' : 'bg-amber-100 text-amber-700'
+          }`}
+        >
+          {story.sourceLabel}
+        </span>
+        {showWordCount && story.wordCount != null && (
+          <span className={`text-xs tabular-nums ${dark ? 'text-amber-600' : 'text-amber-500'}`}>
+            {story.wordCount.toLocaleString('de')} W
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function FeedRow({ feed, dark, onSelect, showWordCount }) {
+  return (
+    <section data-testid="feed-row" data-feed-id={feed.id} className="mb-8">
+      <div className="flex items-baseline justify-between mb-3">
+        <h3
+          data-testid="feed-label"
+          className={`font-serif text-lg font-bold ${
+            dark ? 'text-amber-200' : 'text-amber-900'
+          }`}
+        >
+          {feed.label}
+        </h3>
+        <span
+          className={`text-xs uppercase tracking-wide ${
+            dark ? 'text-amber-600' : 'text-amber-500'
+          }`}
+        >
+          {AXIS_LABELS[feed.axis] || feed.axis} · {feed.total}
+        </span>
+      </div>
+      <div className="flex gap-3 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
+        {feed.stories.map((story) => (
+          <div key={story.id} className="snap-start">
+            <FeedCard
+              story={story}
+              dark={dark}
+              onSelect={onSelect}
+              showWordCount={showWordCount}
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Renders a list of daily suggestion-feed carousels on the home view.
+ * Feeds are computed from the full story index via buildDailyFeeds(); only
+ * feeds whose calendar window is active today and that yield at least one
+ * match are rendered.
+ */
+export default function SuggestionFeeds({
+  storyIndex,
+  onSelectStory,
+  showWordCount,
+  limitPerFeed = 12,
+  maxRows = 10,
+}) {
+  const { dark } = useTheme();
+  const rows = React.useMemo(
+    () => buildDailyFeeds(storyIndex || [], { limitPerFeed }).slice(0, maxRows),
+    [storyIndex, limitPerFeed, maxRows],
+  );
+  if (rows.length === 0) return null;
+  return (
+    <div data-testid="suggestion-feeds" className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center gap-2 mb-6">
+        <h2
+          className={`font-serif text-xl font-bold ${
+            dark ? 'text-amber-200' : 'text-amber-900'
+          }`}
+        >
+          Für dich heute
+        </h2>
+      </div>
+      {rows.map((feed) => (
+        <FeedRow
+          key={feed.id}
+          feed={feed}
+          dark={dark}
+          onSelect={onSelectStory}
+          showWordCount={showWordCount}
+        />
+      ))}
+    </div>
+  );
+}

--- a/docs/features/suggestion-feeds.md
+++ b/docs/features/suggestion-feeds.md
@@ -1,0 +1,245 @@
+---
+id: "suggestion-feeds"
+name: "Suggestion Feeds"
+type: "strategic"
+status: "vision"
+category: "discovery"
+personas:
+  - "02-parents"
+  - "04-culture-explorers"
+  - "05-therapeutic"
+  - "07-passive-consumers"
+  - "09-seniors"
+  - "10-gamified-explorers"
+related_features:
+  - "mood-recommendations"
+  - "age-filter"
+  - "story-directories"
+  - "favorites"
+  - "deep-search"
+parent: null
+children: []
+---
+
+# Suggestion Feeds — Search-Term Landscape
+
+Configurable daily feeds that surface stories matching the user's current
+season, region, mood, preferred motifs, or moral focus. Each feed is a
+**search-term bundle** scored against the story index (slug, title,
+frontmatter, body) and rendered as a horizontal carousel on the home screen.
+
+This document maps the **landscape of search terms** that can source those
+feeds. Treat each axis as an independent generator: a user can enable any
+combination of feeds; the runtime picks today's matches.
+
+## Corpus inventory (term-search target)
+
+| Source | Stories | Depth | Locale | Notes |
+|---|---:|---|---|---|
+| `grimm` | 224 | 2-level | de-DE | Hochdeutsch, ageMin/ageMax populated |
+| `andersen` | ~50 | 2-level | de-DE | Hochdeutsch translation |
+| `swiss` | varies | 3-level (canton) | de-CH | Cantonal Sagen, regional axis built-in |
+| `hohler` | small | 2-level | gsw (Bärndütsch) | Dialect axis |
+| `maerchenstiftung` | small | 2-level | de-DE | Curated, includes calendar tales |
+| `idiotikon` | small | 2-level | gsw / archaic | Dialect / linguistic axis |
+| `@tweakch/collection-grimm-klassiker` | 15 | collection | de | "Canon" affinity |
+| `@tweakch/collection-grimm-tiere` | 12 | collection | de | "Animal tales" affinity |
+| `@tweakch/collection-grimm-top5` | 5 | collection | de | "Quick start" affinity |
+
+## Axes
+
+Six independent axes drive feed selection. Each axis exposes one or more
+**feed configs**, each config a `{ id, label, terms[], activeWhen() }` tuple.
+
+1. **Seasonal** — calendar-driven (month, holiday, weather)
+2. **Regional** — geography-driven (canton, landscape feature, country)
+3. **Moral / Tugend** — virtue / vice / archetype-of-conduct
+4. **Motif (preference)** — characters, animals, objects, settings
+5. **Mood** — emotional state (per `mood-recommendations.md`)
+6. **Reading context** — length, age, dialect, time-of-day
+
+Search terms are matched **case-insensitively** with German diacritic
+folding (ä→ae, ö→oe, ü→ue, ß→ss) against `slug + " " + title` for v1.
+A v2 pass adds body-token matching once frontmatter tags are enriched.
+
+---
+
+## 1. Seasonal feeds
+
+| Feed id | Active window | Search terms (slug/title substrings) |
+|---|---|---|
+| `winter-weihnachten` | Nov 15 – Jan 6 | `schnee`, `eis`, `frost`, `weihn`, `christ`, `tann`, `stern`, `engel`, `nikol`, `advent`, `krippe`, `koenig` (drei) |
+| `silvester-neujahr` | Dec 28 – Jan 2 | `jahr`, `neujahr`, `silvester`, `wunsch`, `glueck` |
+| `fasnacht-karneval` | Jan 6 – Ash Wed | `narr`, `maske`, `verkleid`, `lustig`, `bruder lustig`, `tanz` |
+| `fruehling-ostern` | Mar 1 – Apr 30 | `oster`, `lamm`, `hase`, `ei`, `frueh`, `bluete`, `knosp`, `auferstehung`, `gaensebluemchen` |
+| `mai-pfingsten` | May | `mai`, `wiese`, `blume`, `pfingst`, `taube` |
+| `sommer-licht` | Jun – Aug | `sommer`, `sonne`, `wald`, `see`, `meer`, `quelle`, `aussersten meer` |
+| `erntezeit` | Aug – Sep | `ernte`, `korn`, `muhl`, `mueller`, `brot`, `garbe` |
+| `herbst-nebel` | Oct | `herbst`, `nebel`, `blatt`, `kuerbis` |
+| `martinstag` | Nov 5 – 15 | `martin`, `latern`, `gans`, `bettler`, `mantel` |
+| `allerheiligen-tod` | Oct 28 – Nov 5 | `tod`, `gevatter`, `bote`, `friedhof`, `grab`, `geist`, `gespenst` |
+| `nationalfeiertag-ch` | Aug 1 ± 3 | every story under `swiss/`, plus `eidg`, `tell`, `bund` |
+| `valentinstag` | Feb 10 – 16 | `lieb`, `treu`, `braut`, `hochzeit`, `frosch`, `rapunzel`, `kuess` |
+| `muttertag` | 2nd Sun May ± 3 | `mutter`, `stiefmutter`, `kind`, `wiege`, `frau holle` |
+
+## 2. Regional feeds
+
+The `swiss/` source is already organised by canton. Each canton can be
+exposed as a feed without further enrichment:
+
+| Feed id | Source filter |
+|---|---|
+| `region-bern` | `swiss/bern/*` |
+| `region-zuerich` | `swiss/zuerich/*` |
+| `region-graubuenden` | `swiss/graubuenden/*` |
+| ...one per canton |  |
+
+**Cross-source landscape feeds** (search terms across all sources):
+
+| Feed id | Terms |
+|---|---|
+| `landschaft-berge` | `berg`, `alp`, `gipfel`, `gletsch`, `pass`, `fels`, `drachenloch` |
+| `landschaft-wasser` | `see`, `bach`, `fluss`, `quell`, `meer`, `brunnen`, `aar` |
+| `landschaft-wald` | `wald`, `forst`, `tann`, `lichtung`, `holz` |
+| `landschaft-burg` | `burg`, `schloss`, `turm`, `kapell`, `kloster`, `kirch` |
+| `dialekt-schweiz` | source ∈ {`hohler`, `swiss`, `idiotikon`} |
+| `dialekt-baerndeutsch` | source = `hohler` |
+
+## 3. Moral / Tugend feeds
+
+| Feed id | Label | Terms |
+|---|---|---|
+| `tugend-fleiss` | Fleiß belohnt | `fleiss`, `arbeit`, `frau holle`, `sterntal`, `aschen`, `brave` |
+| `tugend-mut` | Mut & Tapferkeit | `tapfer`, `furcht`, `mutig`, `kuehn`, `held`, `nichts fuerchtet` |
+| `tugend-demut` | Demut & Bescheidenheit | `demut`, `bescheid`, `armut`, `arm`, `bettler` |
+| `tugend-treue` | Treue & Freundschaft | `treu`, `freund`, `bruder`, `gefaehrt`, `kamerad`, `reisekamerad` |
+| `tugend-mitleid` | Mitleid & Barmherzigkeit | `mitleid`, `barm`, `helf`, `teil`, `geben`, `gans` (Sterntaler-Motiv) |
+| `tugend-klugheit` | List & Klugheit | `klug`, `list`, `schlau`, `raetsel`, `aufgabe`, `kluges grethel` |
+| `warnung-habgier` | Habgier bestraft | `gier`, `geiz`, `gold`, `goldene gans`, `fischer und seine frau` |
+| `warnung-hochmut` | Hochmut kommt vor dem Fall | `stolz`, `hochmut`, `eitel`, `koenig drosselbart`, `spiegel` |
+| `warnung-luege` | Lüge & Verrat | `luege`, `betrug`, `verrat`, `stiefmutter`, `falsche braut` |
+| `warnung-faulheit` | Faulheit | `faul`, `traeg`, `siebenschlaefer` |
+| `motiv-erloesung` | Erlösung | `erloesung`, `verwunsch`, `verzaubert`, `frosch`, `dornroes`, `schwan` |
+| `motiv-gerechtigkeit` | Gerechte Strafe | `strafe`, `gericht`, `gerechtig`, `teufel` |
+| `motiv-vergebung` | Vergebung & Versöhnung | `vergeb`, `versoehn`, `reue`, `bereu` |
+
+## 4. Motif (preference) feeds
+
+User picks favourite motifs in onboarding; each becomes a feed.
+
+### Characters / archetypes
+- `chars-koenigshaus` — `koenig`, `koenigin`, `prinz`, `prinzess`
+- `chars-handwerk` — `schneider`, `schuster`, `mueller`, `schmied`, `tischler`
+- `chars-bauer-hirte` — `bauer`, `hirte`, `magd`, `knecht`
+- `chars-uebernatuerlich` — `hexe`, `zauber`, `fee`, `riese`, `zwerg`, `drache`, `kobold`, `unhold`, `teufel`, `engel`, `tod`, `geist`
+- `chars-familie` — `mutter`, `vater`, `bruder`, `schwester`, `kind`, `waise`, `stiefmutter`, `juengster`, `sieben`
+
+### Animals (maps to `grimm-tiere` collection)
+- `tiere-wolf-fuchs` — `wolf`, `fuchs`
+- `tiere-vogel` — `vogel`, `gans`, `huhn`, `sperling`, `eule`, `nachtigall`, `zaunkoenig`, `taube`, `rohrdommel`
+- `tiere-haustier` — `katze`, `hund`, `pferd`, `esel`, `ziege`, `schaf`
+- `tiere-wild` — `baer`, `hase`, `igel`, `loewe`, `hirsch`, `reh`, `wild`
+- `tiere-klein` — `frosch`, `maus`, `biene`, `fisch`, `scholle`, `schlange`
+- `bremer-stadtmusikanten` — explicit slug match
+
+### Objects / magic items
+- `obj-magisch` — `ring`, `spiegel`, `spinn`, `apfel`, `goldener`, `silber`, `mantel`, `kappe`, `horn`, `harfe`, `topf`, `tisch deck`, `lebenswasser`
+- `obj-kleidung` — `schuh`, `kleid`, `hut`, `mantel`, `pantoffel`
+- `obj-essen` — `brot`, `apfel`, `kuchen`, `suppe`, `wein`
+
+### Settings
+- `setting-schloss` — `schloss`, `burg`, `turm`, `palast`
+- `setting-wald-huette` — `wald`, `huette`, `hexenhaus`, `lichtung`
+- `setting-jenseits` — `himmel`, `hoelle`, `unterwelt`, `paradies`, `engel`
+
+### Story patterns
+- `pattern-aufgabe` — `aufgabe`, `pruefung`, `wette`, `raetsel`
+- `pattern-wunsch` — `wunsch`, `drei wuensche`, `fee`
+- `pattern-fluch` — `fluch`, `verwunsch`, `verzaubert`, `bann`
+
+## 5. Mood feeds (per `mood-recommendations.md`)
+
+| Mood | Search direction |
+|---|---|
+| `mood-anxious` | "calming, resolved endings": `aschenputtel`, `dornroes`, `sterntal`, `frau holle` |
+| `mood-sad` | "transformative, hopeful": `haessl`, `entlein`, `frosch`, `sterntal`, `aschen` |
+| `mood-angry` | "trickster satisfaction": `rumpel`, `tapfere schneider`, `kluges grethel`, `bremer` |
+| `mood-curious` | "adventure, discovery": `reisekamerad`, `abenteuer`, `nichts fuerchtet`, `tell` |
+| `mood-nostalgic` | "canon": `collection-grimm-klassiker` membership |
+| `mood-cosy` | "kurze warme Geschichten": short word count + `winter`, `tee`, `kachel`, `huette` |
+| `mood-thrill` | "düstere Stoffe": `blaubart`, `hexe`, `teufel`, `tod`, `geist`, `gespenst` |
+
+## 6. Reading-context feeds
+
+Filter on existing frontmatter (no enrichment needed for v1).
+
+| Feed id | Filter |
+|---|---|
+| `dauer-3min` | `wordCount < 500` |
+| `dauer-mittag` | `500 ≤ wordCount < 2000` |
+| `dauer-wochenend` | `wordCount ≥ 2000` |
+| `bedtime-kurz` | `wordCount < 800` AND `ageMax ≤ 8` |
+| `alter-3-6` | `ageMin ≤ 6 AND (ageMax == null OR ageMax ≥ 4)` |
+| `alter-6-9` | overlap with [6,9] |
+| `alter-9-12` | overlap with [9,12] |
+| `alter-erwachsen` | `ageMax == null OR ageMax ≥ 14`; or known dark slugs (`blaubart`, `gevatter_tod`, `boten_des_todes`) |
+| `dialekt-schweiz` | sources `hohler`, `swiss`, `idiotikon` |
+| `kanon-grimm` | collection `grimm-klassiker` |
+| `tier-collection` | collection `grimm-tiere` |
+| `quickstart` | collection `grimm-top5` |
+
+## Composition: today's daily feed
+
+The runtime composes the daily feed as an ordered list of feed bundles:
+
+1. **Always-on personal feeds** — user-toggled motif / mood / region selections
+2. **Calendar feeds** active today (window check)
+3. **Surprise feed** — a random low-frequency motif feed (cycled daily by date seed)
+4. **Quickstart fallback** — if any feed yields fewer than `N` matches, fall back to `grimm-klassiker`
+
+Within each feed, stories are ranked by:
+- term-match score (number of terms hit, weighted by slug > title > body)
+- novelty boost (not in user's `readHistory`)
+- favourites affinity (sources with prior favourites get +1)
+- a stable per-day seed so the same date returns the same order
+
+## Data-enrichment gaps (blocking v2)
+
+Current frontmatter exposes only `title`, `source`, `wordCount`,
+`ageMin`, `ageMax`. To reach v2 quality, add per-story sidecar:
+
+```yaml
+# stories/{source}/{slug}/tags.json
+motifs: [wolf, wald, list, juengster_sohn]
+virtues: [klugheit, mut]
+warnings: [habgier]
+seasons: [herbst]
+moods: [angry, curious]
+landscape: [wald]
+characters: [koenig, prinz, fuchs]
+objects: [goldener_apfel]
+patterns: [aufgabe, drei_wuensche]
+darkness: 2  # 0=heiter, 5=dunkel
+ageBand: 6-12
+```
+
+Generation strategy: AI tagging pass via the Claude API over each
+`content.md`, written by a new `npm run enrich` task that parallels
+`npm run crawl`. Tags become the primary feed-matching surface; raw
+search terms remain as a fallback.
+
+## Implementation hooks
+
+- **Module:** `src/lib/suggestionFeeds.js` — feed configs, matcher, builder
+- **Glue:** consume `getStoryIndex()` from `src/lib/storyLibrary.js`
+- **UI:** new home screen in `AppLayout` with one carousel per active feed
+- **Flag:** `suggestion-feeds` (off by default)
+- **Test ids:** `feed-row`, `feed-label`, `feed-card`, `feed-empty`
+
+## Links
+
+- [Mood Recommendations](mood-recommendations.md) — mood axis source
+- [Age Filter](age-filter.md) — context-axis precedent
+- [Story Directories](story-directories.md) — regional axis precedent
+- [Deep Search](deep-search.md) — body-text matching engine for v2
+- [Favorites](favorites.md) — affinity signal for ranking

--- a/docs/features/suggestion-feeds.md
+++ b/docs/features/suggestion-feeds.md
@@ -1,8 +1,10 @@
 ---
 id: "suggestion-feeds"
 name: "Suggestion Feeds"
-type: "strategic"
-status: "vision"
+type: "app"
+flag_key: "suggestion-feeds"
+lifecycle: "EXPERIMENT"
+flag_default: "off"
 category: "discovery"
 personas:
   - "02-parents"

--- a/flags.json
+++ b/flags.json
@@ -125,6 +125,13 @@
       "off": false
     }
   },
+  "suggestion-feeds": {
+    "defaultVariant": "off",
+    "variants": {
+      "on": true,
+      "off": false
+    }
+  },
   "theme": {
     "defaultVariant": "light",
     "variants": {

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -62,7 +62,7 @@ const GrimmMarchenApp = () => {
     showSpeedReader, showSpeedreaderOrp, showWordBlacklist, showDeepSearch, showStoryDirectories, showCollections, showDebugBadges, showSubscriberFonts, showErrorPageSimulator, showAppAnimation,
     showAbTesting, showAbTestingAdmin,
     showVoiceControl, showVoiceResume, showVoiceNavigation, showVoiceReadingControl, showVoiceDiscovery, showVoiceHandsFree,
-    showAgeFilter, showChildProfile, showIllustrations: rawShowIllustrations,
+    showAgeFilter, showChildProfile, showIllustrations: rawShowIllustrations, showSuggestionFeeds,
     _rawFlagValues,
     userFeatureOverrides, setUserFeatureOverrides, _o,
     flagTheme, bigFontsVariant,
@@ -997,6 +997,8 @@ const GrimmMarchenApp = () => {
               completedStories={completedStories}
               showFavorites={showFavorites}
               showWordCount={showWordCount}
+              showSuggestionFeeds={showSuggestionFeeds}
+              storyIndex={stories}
               onSelectStory={handleSelectStory}
               onToggleFavorite={toggleFavorite}
             />

--- a/src/lib/featureRegistry.jsx
+++ b/src/lib/featureRegistry.jsx
@@ -277,6 +277,16 @@ export const FEATURE_REGISTRY = [
     retireBy: '2026-12-31',
     roles: ALL_USERS,
   },
+  {
+    key: 'suggestion-feeds',
+    kind: 'boolean',
+    label: 'Vorschlags-Feeds',
+    description: 'Zeigt auf der Startseite tägliche Empfehlungs-Feeds nach Jahreszeit, Region, Moral, Motiv und Stimmung.',
+    Icon: () => <LayoutGrid size={20} strokeWidth={1.75} />,
+    flag: bool('off'),
+    status: 'experimental',
+    roles: ALL_USERS,
+  },
 
   // -------- Released but hidden (variant / infra flags) --------
   {

--- a/src/lib/suggestionFeeds.js
+++ b/src/lib/suggestionFeeds.js
@@ -1,0 +1,384 @@
+// Configurable suggestion feeds — search-term landscape sourced from
+// docs/features/suggestion-feeds.md. The matcher operates on the slug+title
+// surface (frontmatter is sparse today); body-text and tag matching land in
+// v2 once the enrichment pass is in place.
+
+const COLLECTION_SOURCES = {
+  klassiker: 'grimm-klassiker',
+  tiere: 'grimm-tiere',
+  top5: 'grimm-top5',
+};
+
+const SWISS_DIALECT_SOURCES = new Set(['hohler', 'swiss', 'idiotikon']);
+
+const KNOWN_DARK_SLUGS = new Set([
+  'blaubart',
+  'der_gevatter_tod',
+  'die_boten_des_todes',
+  'von_dem_tode_des_huenchens',
+  'der_tod_und_der_gansehirt',
+]);
+
+// Calendar windows are inclusive on both ends. Months are 1-indexed.
+const SEASONAL_WINDOWS = {
+  winterWeihnachten: { from: [11, 15], to: [1, 6] },
+  silvester: { from: [12, 28], to: [1, 2] },
+  fruehlingOstern: { from: [3, 1], to: [4, 30] },
+  mai: { from: [5, 1], to: [5, 31] },
+  sommerLicht: { from: [6, 1], to: [8, 31] },
+  ernte: { from: [8, 1], to: [9, 30] },
+  herbstNebel: { from: [10, 1], to: [10, 31] },
+  martinstag: { from: [11, 5], to: [11, 15] },
+  allerheiligen: { from: [10, 28], to: [11, 5] },
+  nationalfeiertagCh: { from: [7, 29], to: [8, 4] },
+  valentin: { from: [2, 10], to: [2, 16] },
+};
+
+export const FEEDS = [
+  // 1. SEASONAL
+  {
+    id: 'winter-weihnachten',
+    label: 'Winterzauber & Weihnachten',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.winterWeihnachten,
+    terms: ['schnee', 'eis', 'frost', 'weihn', 'christ', 'tann', 'stern', 'engel', 'nikol', 'advent', 'krippe'],
+  },
+  {
+    id: 'silvester-neujahr',
+    label: 'Silvester & Neujahr',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.silvester,
+    terms: ['neujahr', 'silvester', 'wunsch', 'glueck'],
+  },
+  {
+    id: 'fruehling-ostern',
+    label: 'Frühling & Ostern',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.fruehlingOstern,
+    terms: ['oster', 'lamm', 'hase', 'ei', 'frueh', 'bluet', 'knosp', 'gaensebluemchen'],
+  },
+  {
+    id: 'mai-pfingsten',
+    label: 'Mai & Pfingsten',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.mai,
+    terms: ['mai', 'wiese', 'blume', 'pfingst', 'taube'],
+  },
+  {
+    id: 'sommer-licht',
+    label: 'Sommer & Licht',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.sommerLicht,
+    terms: ['sommer', 'sonne', 'wald', 'see', 'meer', 'quell'],
+  },
+  {
+    id: 'erntezeit',
+    label: 'Erntezeit',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.ernte,
+    terms: ['ernte', 'korn', 'muehl', 'mueller', 'brot', 'garbe'],
+  },
+  {
+    id: 'herbst-nebel',
+    label: 'Herbst & Nebel',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.herbstNebel,
+    terms: ['herbst', 'nebel', 'blatt', 'kuerbis'],
+  },
+  {
+    id: 'martinstag',
+    label: 'Martinstag',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.martinstag,
+    terms: ['martin', 'latern', 'gans', 'bettler', 'mantel'],
+  },
+  {
+    id: 'allerheiligen-tod',
+    label: 'Allerheiligen — Geschichten vom Tod',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.allerheiligen,
+    terms: ['tod', 'gevatter', 'bote', 'grab', 'geist', 'gespenst'],
+  },
+  {
+    id: 'nationalfeiertag-ch',
+    label: '1. August — Schweizer Sagen',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.nationalfeiertagCh,
+    sourceFilter: (s) => s === 'swiss',
+    terms: ['tell', 'eidg', 'bund'],
+  },
+  {
+    id: 'valentinstag',
+    label: 'Valentinstag — Liebe & Treue',
+    axis: 'seasonal',
+    window: SEASONAL_WINDOWS.valentin,
+    terms: ['lieb', 'treu', 'braut', 'hochzeit', 'frosch', 'rapunzel'],
+  },
+
+  // 2. REGIONAL — landscape across all sources
+  {
+    id: 'landschaft-berge',
+    label: 'Berge & Gipfel',
+    axis: 'regional',
+    terms: ['berg', 'alp', 'gipfel', 'gletsch', 'pass', 'fels', 'drachenloch'],
+  },
+  {
+    id: 'landschaft-wasser',
+    label: 'Seen, Bäche & Quellen',
+    axis: 'regional',
+    terms: ['see', 'bach', 'fluss', 'quell', 'meer', 'brunnen', 'aar'],
+  },
+  {
+    id: 'landschaft-wald',
+    label: 'Wald & Lichtung',
+    axis: 'regional',
+    terms: ['wald', 'forst', 'tann', 'lichtung', 'holz'],
+  },
+  {
+    id: 'landschaft-burg',
+    label: 'Burgen, Schlösser & Klöster',
+    axis: 'regional',
+    terms: ['burg', 'schloss', 'turm', 'kapell', 'kloster', 'kirch'],
+  },
+  {
+    id: 'dialekt-schweiz',
+    label: 'Schweizer Dialekt & Sagen',
+    axis: 'regional',
+    sourceFilter: (s) => SWISS_DIALECT_SOURCES.has(s),
+  },
+
+  // 3. MORAL / TUGEND
+  { id: 'tugend-fleiss', label: 'Fleiß belohnt', axis: 'moral',
+    terms: ['fleiss', 'arbeit', 'frau holle', 'sterntal', 'aschen', 'brave'] },
+  { id: 'tugend-mut', label: 'Mut & Tapferkeit', axis: 'moral',
+    terms: ['tapfer', 'furcht', 'mutig', 'kuehn', 'held', 'nichts fuerchtet'] },
+  { id: 'tugend-demut', label: 'Demut & Bescheidenheit', axis: 'moral',
+    terms: ['demut', 'bescheid', 'armut', 'arm', 'bettler'] },
+  { id: 'tugend-treue', label: 'Treue & Freundschaft', axis: 'moral',
+    terms: ['treu', 'freund', 'bruder', 'kamerad', 'reisekamerad'] },
+  { id: 'tugend-mitleid', label: 'Mitleid & Barmherzigkeit', axis: 'moral',
+    terms: ['mitleid', 'barm', 'helf', 'teil', 'sterntal'] },
+  { id: 'tugend-klugheit', label: 'List & Klugheit', axis: 'moral',
+    terms: ['klug', 'list', 'schlau', 'raetsel', 'kluges grethel'] },
+  { id: 'warnung-habgier', label: 'Habgier bestraft', axis: 'moral',
+    terms: ['gier', 'geiz', 'gold', 'goldene gans', 'fischer'] },
+  { id: 'warnung-hochmut', label: 'Hochmut kommt vor dem Fall', axis: 'moral',
+    terms: ['stolz', 'hochmut', 'eitel', 'drosselbart', 'spiegel'] },
+  { id: 'warnung-luege', label: 'Lüge & Verrat', axis: 'moral',
+    terms: ['luege', 'betrug', 'verrat', 'falsche braut'] },
+  { id: 'motiv-erloesung', label: 'Erlösung', axis: 'moral',
+    terms: ['erloesung', 'verwunsch', 'verzaubert', 'frosch', 'dornroes', 'schwan'] },
+
+  // 4. MOTIF (preference) — characters, animals, objects, settings, patterns
+  { id: 'chars-koenigshaus', label: 'Königshaus', axis: 'motif',
+    terms: ['koenig', 'koenigin', 'prinz', 'prinzess'] },
+  { id: 'chars-handwerk', label: 'Handwerker', axis: 'motif',
+    terms: ['schneider', 'schuster', 'mueller', 'schmied', 'tischler'] },
+  { id: 'chars-bauer-hirte', label: 'Bauern & Hirten', axis: 'motif',
+    terms: ['bauer', 'hirte', 'magd', 'knecht', 'buerle'] },
+  { id: 'chars-uebernatuerlich', label: 'Hexen, Riesen & Drachen', axis: 'motif',
+    terms: ['hexe', 'zauber', 'fee', 'riese', 'zwerg', 'drache', 'kobold', 'unhold', 'teufel', 'engel', 'geist'] },
+  { id: 'chars-familie', label: 'Familiengeschichten', axis: 'motif',
+    terms: ['mutter', 'vater', 'bruder', 'schwester', 'waise', 'stiefmutter', 'juengst', 'sieben'] },
+
+  { id: 'tiere-wolf-fuchs', label: 'Wolf & Fuchs', axis: 'motif',
+    terms: ['wolf', 'fuchs'] },
+  { id: 'tiere-vogel', label: 'Vögel', axis: 'motif',
+    terms: ['vogel', 'gans', 'huhn', 'sperling', 'eule', 'nachtigall', 'zaunkoenig', 'taube', 'rohrdommel'] },
+  { id: 'tiere-haustier', label: 'Haustiere', axis: 'motif',
+    terms: ['katze', 'hund', 'pferd', 'esel', 'ziege', 'schaf', 'geiss'] },
+  { id: 'tiere-wild', label: 'Wildtiere', axis: 'motif',
+    terms: ['baer', 'hase', 'igel', 'loewe', 'hirsch', 'reh'] },
+  { id: 'tiere-klein', label: 'Kleine Tiere', axis: 'motif',
+    terms: ['frosch', 'maus', 'biene', 'fisch', 'scholle', 'schlange'] },
+
+  { id: 'obj-magisch', label: 'Magische Gegenstände', axis: 'motif',
+    terms: ['ring', 'spiegel', 'spinn', 'apfel', 'goldener', 'silber', 'mantel', 'kappe', 'horn', 'harfe', 'lebenswasser'] },
+  { id: 'obj-kleidung', label: 'Kleidung & Schuhe', axis: 'motif',
+    terms: ['schuh', 'kleid', 'hut', 'pantoffel'] },
+
+  { id: 'setting-schloss', label: 'Schloss & Turm', axis: 'motif',
+    terms: ['schloss', 'burg', 'turm', 'palast'] },
+  { id: 'setting-wald-huette', label: 'Hütten im Wald', axis: 'motif',
+    terms: ['waldhaus', 'huette', 'hexenhaus'] },
+  { id: 'setting-jenseits', label: 'Himmel & Hölle', axis: 'motif',
+    terms: ['himmel', 'hoelle', 'paradies'] },
+
+  { id: 'pattern-aufgabe', label: 'Prüfungen & Rätsel', axis: 'motif',
+    terms: ['aufgabe', 'pruefung', 'wette', 'raetsel'] },
+  { id: 'pattern-wunsch', label: 'Drei Wünsche', axis: 'motif',
+    terms: ['wunsch', 'drei wuensche'] },
+  { id: 'pattern-fluch', label: 'Fluch & Verwünschung', axis: 'motif',
+    terms: ['fluch', 'verwunsch', 'verzaubert', 'bann'] },
+
+  // 5. MOOD (per docs/features/mood-recommendations.md)
+  { id: 'mood-anxious', label: 'Beruhigend', axis: 'mood',
+    terms: ['aschen', 'dornroes', 'sterntal', 'frau holle'] },
+  { id: 'mood-sad', label: 'Hoffnungsvoll & wandelnd', axis: 'mood',
+    terms: ['haessl', 'entlein', 'frosch', 'sterntal', 'aschen'] },
+  { id: 'mood-angry', label: 'Trickster & Genugtuung', axis: 'mood',
+    terms: ['rumpel', 'tapfere schneider', 'kluges grethel', 'bremer'] },
+  { id: 'mood-curious', label: 'Abenteuer & Entdeckung', axis: 'mood',
+    terms: ['reisekamerad', 'abenteuer', 'nichts fuerchtet'] },
+  { id: 'mood-thrill', label: 'Düstere Stoffe', axis: 'mood',
+    custom: (s) => KNOWN_DARK_SLUGS.has(s.slug),
+    terms: ['blaubart', 'hexe', 'teufel', 'tod', 'geist', 'gespenst'] },
+
+  // 6. READING-CONTEXT
+  { id: 'dauer-3min', label: '3-Minuten-Geschichten', axis: 'context',
+    custom: (s) => typeof s.wordCount === 'number' && s.wordCount > 0 && s.wordCount < 500 },
+  { id: 'dauer-mittag', label: 'Mittagspause (5-15 Min)', axis: 'context',
+    custom: (s) => typeof s.wordCount === 'number' && s.wordCount >= 500 && s.wordCount < 2000 },
+  { id: 'dauer-wochenend', label: 'Lange Geschichten', axis: 'context',
+    custom: (s) => typeof s.wordCount === 'number' && s.wordCount >= 2000 },
+  { id: 'bedtime-kurz', label: 'Gute-Nacht-Geschichten', axis: 'context',
+    custom: (s) =>
+      typeof s.wordCount === 'number' && s.wordCount < 800 &&
+      typeof s.ageMax === 'number' && s.ageMax <= 8 },
+  { id: 'alter-3-6', label: 'Für die Kleinsten (3-6)', axis: 'context',
+    custom: (s) => ageBandOverlaps(s, 3, 6) },
+  { id: 'alter-6-9', label: 'Schulkinder (6-9)', axis: 'context',
+    custom: (s) => ageBandOverlaps(s, 6, 9) },
+  { id: 'alter-9-12', label: 'Tweens (9-12)', axis: 'context',
+    custom: (s) => ageBandOverlaps(s, 9, 12) },
+  { id: 'kanon-grimm', label: 'Grimm-Klassiker', axis: 'context',
+    sourceFilter: (s) => s === COLLECTION_SOURCES.klassiker },
+  { id: 'tier-collection', label: 'Tiermärchen', axis: 'context',
+    sourceFilter: (s) => s === COLLECTION_SOURCES.tiere },
+  { id: 'quickstart', label: 'Quickstart — Top 5', axis: 'context',
+    sourceFilter: (s) => s === COLLECTION_SOURCES.top5 },
+];
+
+function foldGerman(input) {
+  return String(input || '')
+    .toLowerCase()
+    .replace(/ä/g, 'ae')
+    .replace(/ö/g, 'oe')
+    .replace(/ü/g, 'ue')
+    .replace(/ß/g, 'ss');
+}
+
+function ageBandOverlaps(story, min, max) {
+  const sMin = typeof story.ageMin === 'number' ? story.ageMin : null;
+  const sMax = typeof story.ageMax === 'number' ? story.ageMax : null;
+  if (sMin == null && sMax == null) return false;
+  const lo = sMin ?? sMax;
+  const hi = sMax ?? sMin;
+  return lo <= max && hi >= min;
+}
+
+function storyHaystack(story) {
+  return foldGerman(`${story.slug || ''} ${story.title || ''}`.replace(/[_-]+/g, ' '));
+}
+
+function scoreTerms(story, terms) {
+  if (!terms || terms.length === 0) return 0;
+  const hay = storyHaystack(story);
+  let hits = 0;
+  for (const term of terms) {
+    if (hay.includes(foldGerman(term))) hits += 1;
+  }
+  return hits;
+}
+
+export function matchStory(story, feed) {
+  if (feed.sourceFilter && !feed.sourceFilter(story.source)) return 0;
+  if (feed.custom && feed.custom(story)) return 1;
+  const score = scoreTerms(story, feed.terms);
+  if (score > 0) return score;
+  // sourceFilter alone (no terms, no custom) is a pass-through filter
+  if (feed.sourceFilter && !feed.terms && !feed.custom) return 1;
+  return 0;
+}
+
+function inWindow({ from, to }, date) {
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  const cmp = (a, b) => a[0] * 100 + a[1] - (b[0] * 100 + b[1]);
+  const today = [m, d];
+  if (cmp(from, to) <= 0) {
+    return cmp(today, from) >= 0 && cmp(today, to) <= 0;
+  }
+  // wrap-around (e.g. Nov 15 → Jan 6)
+  return cmp(today, from) >= 0 || cmp(today, to) <= 0;
+}
+
+export function isFeedActive(feed, date = new Date()) {
+  if (!feed.window) return true;
+  return inWindow(feed.window, date);
+}
+
+export function getActiveFeeds(date = new Date()) {
+  return FEEDS.filter((f) => isFeedActive(f, date));
+}
+
+// Stable per-day shuffle so the same date returns the same order.
+function dateSeed(date) {
+  return date.getFullYear() * 10000 + (date.getMonth() + 1) * 100 + date.getDate();
+}
+
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function tieBreakStable(stories, seed) {
+  const rng = mulberry32(seed);
+  return stories
+    .map((s) => ({ s, k: rng() }))
+    .sort((a, b) => a.k - b.k)
+    .map((x) => x.s);
+}
+
+export function buildFeed(feed, storyIndex, { limit = 12, date = new Date() } = {}) {
+  const scored = [];
+  for (const story of storyIndex) {
+    const score = matchStory(story, feed);
+    if (score > 0) scored.push({ story, score });
+  }
+  // Sort by score desc, then stable-shuffle ties by date seed.
+  const seed = dateSeed(date) ^ hashString(feed.id);
+  const buckets = new Map();
+  for (const e of scored) {
+    if (!buckets.has(e.score)) buckets.set(e.score, []);
+    buckets.get(e.score).push(e.story);
+  }
+  const ordered = [...buckets.keys()]
+    .sort((a, b) => b - a)
+    .flatMap((s) => tieBreakStable(buckets.get(s), seed + s));
+  return {
+    id: feed.id,
+    label: feed.label,
+    axis: feed.axis,
+    stories: ordered.slice(0, limit),
+    total: ordered.length,
+  };
+}
+
+function hashString(str) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+export function buildDailyFeeds(storyIndex, {
+  date = new Date(),
+  limitPerFeed = 12,
+  enabledFeedIds = null,
+} = {}) {
+  const active = getActiveFeeds(date).filter(
+    (f) => !enabledFeedIds || enabledFeedIds.includes(f.id),
+  );
+  return active
+    .map((feed) => buildFeed(feed, storyIndex, { limit: limitPerFeed, date }))
+    .filter((row) => row.stories.length > 0);
+}

--- a/src/lib/suggestionFeeds.js
+++ b/src/lib/suggestionFeeds.js
@@ -221,7 +221,7 @@ export const FEEDS = [
   { id: 'mood-curious', label: 'Abenteuer & Entdeckung', axis: 'mood',
     terms: ['reisekamerad', 'abenteuer', 'nichts fuerchtet'] },
   { id: 'mood-thrill', label: 'Düstere Stoffe', axis: 'mood',
-    custom: (s) => KNOWN_DARK_SLUGS.has(s.slug),
+    custom: (s) => KNOWN_DARK_SLUGS.has(storySlug(s)),
     terms: ['blaubart', 'hexe', 'teufel', 'tod', 'geist', 'gespenst'] },
 
   // 6. READING-CONTEXT
@@ -267,8 +267,19 @@ function ageBandOverlaps(story, min, max) {
   return lo <= max && hi >= min;
 }
 
+function storySlug(story) {
+  if (story.slug) return story.slug;
+  // id is `${source}/${slug}` or `${source}/${directory}/${slug}`
+  if (typeof story.id === 'string') {
+    const parts = story.id.split('/');
+    return parts[parts.length - 1] || '';
+  }
+  return '';
+}
+
 function storyHaystack(story) {
-  return foldGerman(`${story.slug || ''} ${story.title || ''}`.replace(/[_-]+/g, ' '));
+  const slug = storySlug(story);
+  return foldGerman(`${slug} ${story.title || ''}`.replace(/[_-]+/g, ' '));
 }
 
 function scoreTerms(story, terms) {


### PR DESCRIPTION
Adds the search-term landscape doc (docs/features/suggestion-feeds.md)
covering six axes — seasonal, regional, moral, motif, mood, reading
context — grounded in the current corpus (grimm, andersen, swiss
cantons, hohler, maerchenstiftung, idiotikon, curated collections).

Adds src/lib/suggestionFeeds.js, a pure module that defines 59 feed
configs and exposes matchStory / buildFeed / buildDailyFeeds with
diacritic-folded substring matching, per-day stable shuffling, and
calendar-window activation.

https://claude.ai/code/session_01DrAYmFPnvp7RhZHn6LXUA8