### PR TITLE
feat(gestures): responsive drag-follow drawers with unified coordination

### DIFF
--- a/components/DrawerIndicators.jsx
+++ b/components/DrawerIndicators.jsx
@@ -1,0 +1,90 @@
+import { cn } from '../ui/cn';
+import { useTheme } from '../ui/ThemeContext';
+
+/**
+ * Four subtle edge affordances that advertise the drawer gestures to the
+ * reader. Each edge hosts a thin tab (dot-pull shape). When the user drags
+ * from that edge, the matching tab brightens in proportion to the gesture
+ * progress so they feel the connection between the hint and the drawer.
+ *
+ * Hidden on large viewports where the static sidebar already makes the
+ * navigation affordance obvious, and hidden while any drawer is open.
+ */
+export default function DrawerIndicators({ anyDrawerOpen, activeEdge, progress = 0 }) {
+  const { tc } = useTheme();
+  if (anyDrawerOpen) return null;
+
+  const activeLeft   = activeEdge === 'left';
+  const activeRight  = activeEdge === 'right';
+  const activeTop    = activeEdge === 'top';
+  const activeBottom = activeEdge === 'bottom';
+
+  const base = tc({
+    light:   'bg-amber-400/30',
+    dark:    'bg-amber-500/25',
+    hcLight: 'bg-black',
+    hcDark:  'bg-white',
+  });
+  const activeCls = tc({
+    light:   'bg-amber-700',
+    dark:    'bg-amber-300',
+    hcLight: 'bg-black',
+    hcDark:  'bg-white',
+  });
+
+  const vertStyle = (active) => ({
+    opacity: active ? 0.5 + progress * 0.5 : 0.35,
+    height: active ? `${48 + progress * 36}px` : '48px',
+    transition: active ? 'none' : 'opacity 200ms ease-out, height 200ms ease-out',
+  });
+  const horizStyle = (active) => ({
+    opacity: active ? 0.5 + progress * 0.5 : 0.35,
+    width: active ? `${64 + progress * 48}px` : '64px',
+    transition: active ? 'none' : 'opacity 200ms ease-out, width 200ms ease-out',
+  });
+
+  return (
+    <div
+      aria-hidden
+      data-testid="drawer-indicators"
+      className="pointer-events-none fixed inset-0 z-30 lg:hidden"
+    >
+      <div
+        data-testid="drawer-indicator-left"
+        data-active={activeLeft || undefined}
+        style={vertStyle(activeLeft)}
+        className={cn(
+          'absolute left-0 top-1/2 -translate-y-1/2 w-1 rounded-r-full',
+          activeLeft ? activeCls : base,
+        )}
+      />
+      <div
+        data-testid="drawer-indicator-right"
+        data-active={activeRight || undefined}
+        style={vertStyle(activeRight)}
+        className={cn(
+          'absolute right-0 top-1/2 -translate-y-1/2 w-1 rounded-l-full',
+          activeRight ? activeCls : base,
+        )}
+      />
+      <div
+        data-testid="drawer-indicator-top"
+        data-active={activeTop || undefined}
+        style={horizStyle(activeTop)}
+        className={cn(
+          'absolute top-0 left-1/2 -translate-x-1/2 h-1 rounded-b-full',
+          activeTop ? activeCls : base,
+        )}
+      />
+      <div
+        data-testid="drawer-indicator-bottom"
+        data-active={activeBottom || undefined}
+        style={horizStyle(activeBottom)}
+        className={cn(
+          'absolute bottom-0 left-1/2 -translate-x-1/2 h-1 rounded-t-full',
+          activeBottom ? activeCls : base,
+        )}
+      />
+    </div>
+  );
+}

--- a/components/GestureDrawers.jsx
+++ b/components/GestureDrawers.jsx
@@ -20,14 +20,17 @@ function useEscClose(open, onClose) {
   }, [open, onClose]);
 }
 
-function DrawerBackdrop({ open, onClose }) {
-  if (!open) return null;
+function DrawerBackdrop({ open, onClose, dragProgress = 0 }) {
+  const visible = open || dragProgress > 0;
+  if (!visible) return null;
+  const opacity = open ? 0.3 : Math.min(0.3, dragProgress * 0.3);
   return (
     <button
       aria-label="Drawer schließen"
       data-testid="gesture-drawer-backdrop"
       onClick={onClose}
-      className="fixed inset-0 z-40 bg-black/30 backdrop-blur-[2px]"
+      className="fixed inset-0 z-40 bg-black backdrop-blur-[2px]"
+      style={{ opacity, transition: dragProgress > 0 && !open ? 'none' : 'opacity 200ms ease-out' }}
     />
   );
 }
@@ -79,18 +82,24 @@ export function ReloadIndicator({ progress }) {
  * Top drawer that hosts a quick-settings payload (typography, TTS, …)
  * passed as `children`. Slides in from the top edge.
  */
-export function HeaderDrawer({ open, onClose, children }) {
+export function HeaderDrawer({ open, onClose, children, dragProgress = 0 }) {
   const { tc } = useTheme();
   useEscClose(open, onClose);
+  const dragging = !open && dragProgress > 0;
+  const style = dragging
+    ? { transform: `translateY(${(dragProgress - 1) * 100}%)`, transition: 'none' }
+    : undefined;
   return (
     <>
-      <DrawerBackdrop open={open} onClose={onClose} />
+      <DrawerBackdrop open={open} onClose={onClose} dragProgress={dragProgress} />
       <div
         data-testid="gesture-header-drawer"
         data-open={open ? 'true' : 'false'}
-        aria-hidden={!open}
+        aria-hidden={!open && !dragging}
+        style={style}
         className={cn(
-          'fixed top-0 inset-x-0 z-50 border-b shadow-lg transition-transform duration-200 ease-out',
+          'fixed top-0 inset-x-0 z-50 border-b shadow-lg',
+          dragging ? '' : 'transition-transform duration-200 ease-out',
           open ? 'translate-y-0' : '-translate-y-full',
           tc({
             light:   'bg-white/95 border-amber-200 text-amber-900',
@@ -123,18 +132,24 @@ export function HeaderDrawer({ open, onClose, children }) {
  * Bottom drawer with a page-picker grid. Jumping to a page closes the
  * drawer; prev/next chevrons step without closing.
  */
-export function FooterDrawer({ open, onClose, totalPages, currentPage, onGoToPage, storyTitle }) {
+export function FooterDrawer({ open, onClose, totalPages, currentPage, onGoToPage, storyTitle, dragProgress = 0 }) {
   const { tc } = useTheme();
   useEscClose(open, onClose);
+  const dragging = !open && dragProgress > 0;
+  const style = dragging
+    ? { transform: `translateY(${(1 - dragProgress) * 100}%)`, transition: 'none' }
+    : undefined;
   return (
     <>
-      <DrawerBackdrop open={open} onClose={onClose} />
+      <DrawerBackdrop open={open} onClose={onClose} dragProgress={dragProgress} />
       <div
         data-testid="gesture-footer-drawer"
         data-open={open ? 'true' : 'false'}
-        aria-hidden={!open}
+        aria-hidden={!open && !dragging}
+        style={style}
         className={cn(
-          'fixed bottom-0 inset-x-0 z-50 border-t shadow-lg transition-transform duration-200 ease-out',
+          'fixed bottom-0 inset-x-0 z-50 border-t shadow-lg',
+          dragging ? '' : 'transition-transform duration-200 ease-out',
           open ? 'translate-y-0' : 'translate-y-full',
           tc({
             light:   'bg-white/95 border-amber-200 text-amber-900',

--- a/components/GestureLayer.jsx
+++ b/components/GestureLayer.jsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { SlidersHorizontal } from 'lucide-react';
 import { HeaderDrawer, FooterDrawer, RightDrawer, ReloadIndicator } from './GestureDrawers';
+import DrawerIndicators from './DrawerIndicators';
 import { useEnhancedGestures } from '../hooks/useEnhancedGestures';
 import { cn } from '../ui/cn';
 import { useTheme } from '../ui/ThemeContext';
@@ -43,10 +44,10 @@ function HeaderDrawerContent({ onOpenTypography, onClose }) {
 }
 
 /**
- * Composes `useEnhancedGestures` with the three drawers, the reload
- * indicator, and the stepped sidebar logic (closed → open → expanded).
- * Owns drawer + bookmark state internally; grimm-reader only threads its
- * reader state and the sidebar open/expanded controlled pair.
+ * Composes `useEnhancedGestures` with the three gesture drawers and coordinates
+ * them with the left sidebar so that only ever one drawer is active. Publishes
+ * a live drag offset back to the parent (for the sidebar) and down to the
+ * right/header/footer drawers so each one follows the finger during a gesture.
  */
 export default function GestureLayer({
   enabled,
@@ -62,20 +63,62 @@ export default function GestureLayer({
   sidebarExpanded,
   onSidebarExpandedChange,
   onOpenTypography,
+  onSidebarDragOffsetChange,
 }) {
   const [drawers, setDrawers] = useState({ header: false, footer: false, right: false });
   const [rightTab, setRightTab] = useState('toc');
   const [bookmarks, toggleBookmark] = useBookmarks();
-  useEffect(() => { if (!menuOpen && sidebarExpanded) onSidebarExpandedChange?.(false); }, [menuOpen, sidebarExpanded, onSidebarExpandedChange]);
-  const openOnly = (key) => setDrawers({ header: false, footer: false, right: false, [key]: true });
+  const [preview, setPreview] = useState(null);
+
+  const anyGestureDrawerOpen = drawers.header || drawers.footer || drawers.right;
+
+  // Mutual exclusion: if the sidebar opens, close any gesture drawer.
+  useEffect(() => {
+    if (menuOpen && anyGestureDrawerOpen) {
+      setDrawers({ header: false, footer: false, right: false });
+    }
+  }, [menuOpen, anyGestureDrawerOpen]);
+
+  // Cleanup side-effect for expanded sidebar.
+  useEffect(() => {
+    if (!menuOpen && sidebarExpanded) onSidebarExpandedChange?.(false);
+  }, [menuOpen, sidebarExpanded, onSidebarExpandedChange]);
+
+  const openOnly = (key) => {
+    if (menuOpen) onMenuOpenChange?.(false);
+    setDrawers({ header: false, footer: false, right: false, [key]: true });
+  };
   const closeAll = useCallback(() => setDrawers({ header: false, footer: false, right: false }), []);
   const closeHeader = () => setDrawers((d) => ({ ...d, header: false }));
   const closeFooter = () => setDrawers((d) => ({ ...d, footer: false }));
   const closeRight  = () => setDrawers((d) => ({ ...d, right: false }));
 
+  // Push sidebar drag offset up to the parent so SidebarV2 can render it.
+  const lastSidebarOffset = useRef(0);
+  useEffect(() => {
+    const edge = preview?.edge;
+    let offset = 0;
+    if (edge === 'left') offset = Math.min(1, preview.progress);
+    else if (edge === 'left-close') offset = -Math.min(1, preview.progress);
+    if (offset !== lastSidebarOffset.current) {
+      lastSidebarOffset.current = offset;
+      onSidebarDragOffsetChange?.(offset);
+    }
+  }, [preview, onSidebarDragOffsetChange]);
+
+  // Fire-and-forget clear when gesture ends.
+  useEffect(() => {
+    if (!preview && lastSidebarOffset.current !== 0) {
+      lastSidebarOffset.current = 0;
+      onSidebarDragOffsetChange?.(0);
+    }
+  }, [preview, onSidebarDragOffsetChange]);
+
   const { reloadProgress } = useEnhancedGestures({
     enabled,
     targetRef: readerAreaRef,
+    sidebarOpen: menuOpen,
+    onPreview: setPreview,
     onSwipeDownTop: () => openOnly('header'),
     onSwipeUpBottom: () => openOnly('footer'),
     onSwipeLeftRight: () => openOnly('right'),
@@ -92,16 +135,34 @@ export default function GestureLayer({
     onReload: () => { window.location.reload(); },
   });
 
+  // Live drag offsets for the three gesture drawers. Values are 0..1 progress.
+  const edge = preview?.edge;
+  const previewOffsets = {
+    right:  edge === 'right'  ? Math.min(1, preview.progress) : 0,
+    header: edge === 'top'    ? Math.min(1, preview.progress) : 0,
+    footer: edge === 'bottom' ? Math.min(1, preview.progress) : 0,
+  };
+
   return (
     <>
       <ReloadIndicator progress={reloadProgress} />
-      <HeaderDrawer open={drawers.header} onClose={closeHeader}>
+      <DrawerIndicators
+        anyDrawerOpen={menuOpen || anyGestureDrawerOpen}
+        activeEdge={edge}
+        progress={preview?.progress ?? 0}
+      />
+      <HeaderDrawer
+        open={drawers.header}
+        onClose={closeHeader}
+        dragProgress={!drawers.header ? previewOffsets.header : 0}
+      >
         <HeaderDrawerContent onOpenTypography={onOpenTypography} onClose={closeHeader} />
       </HeaderDrawer>
       <FooterDrawer
         open={drawers.footer} onClose={closeFooter}
         totalPages={totalPages} currentPage={currentPage}
         onGoToPage={onGoToPage} storyTitle={selectedStory?.title}
+        dragProgress={!drawers.footer ? previewOffsets.footer : 0}
       />
       <RightDrawer
         open={drawers.right} onClose={closeRight}
@@ -109,6 +170,7 @@ export default function GestureLayer({
         pages={pages} currentPage={currentPage} onGoToPage={onGoToPage}
         bookmarks={bookmarks} onToggleBookmark={toggleBookmark}
         storyTitle={selectedStory?.title} pageText={pageText}
+        dragProgress={!drawers.right ? previewOffsets.right : 0}
       />
     </>
   );

--- a/components/GestureRightDrawer.jsx
+++ b/components/GestureRightDrawer.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { X, List, Search, Bookmark, Activity } from 'lucide-react';
 import { cn } from '../ui/cn';
 import { useTheme } from '../ui/ThemeContext';
@@ -29,8 +30,9 @@ function previewPage(pages, i) {
 }
 
 /**
- * Right-side drawer hosting four research/analysis tabs: TOC, analysis,
- * bookmarks, and research shortcuts. Controlled by parent via `open`.
+ * Right-side drawer. Mirrors the sidebar interaction: edge swipe opens,
+ * swipe-away closes, backdrop dims the reader, and `dragProgress` (0..1)
+ * makes the drawer follow the finger during an in-flight gesture.
  */
 export default function RightDrawer({
   open,
@@ -44,28 +46,56 @@ export default function RightDrawer({
   onToggleBookmark,
   storyTitle,
   pageText,
+  dragProgress = 0,
 }) {
   const { tc } = useTheme();
   const tab = activeTab ?? 'toc';
   const paraStarts = pages ? pages.map((_, i) => previewPage(pages, i)) : [];
   const analysisStats = analyzeText(pageText);
 
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const dragging = !open && dragProgress > 0;
+  const style = dragging
+    ? { transform: `translateX(${(1 - dragProgress) * 100}%)`, transition: 'none' }
+    : undefined;
+
+  const backdropVisible = open || dragging;
+  const backdropOpacity = open ? 0.3 : Math.min(0.3, dragProgress * 0.3);
+
   return (
-    <div
-      data-testid="gesture-right-drawer"
-      data-open={open ? 'true' : 'false'}
-      aria-hidden={!open}
-      className={cn(
-        'fixed top-0 right-0 bottom-0 w-80 max-w-[85vw] z-50 border-l shadow-lg transition-transform duration-200 ease-out flex flex-col',
-        open ? 'translate-x-0' : 'translate-x-full',
-        tc({
-          light:   'bg-white/95 border-amber-200 text-amber-900',
-          dark:    'bg-slate-900/95 border-amber-700/40 text-amber-200',
-          hcLight: 'bg-white border-black text-black',
-          hcDark:  'bg-black border-white text-white',
-        })
+    <>
+      {backdropVisible && (
+        <button
+          aria-label="Drawer schließen"
+          data-testid="gesture-right-drawer-backdrop"
+          onClick={onClose}
+          className="fixed inset-0 z-40 bg-black backdrop-blur-[2px]"
+          style={{ opacity: backdropOpacity, transition: dragging ? 'none' : 'opacity 200ms ease-out' }}
+        />
       )}
-    >
+      <div
+        data-testid="gesture-right-drawer"
+        data-open={open ? 'true' : 'false'}
+        aria-hidden={!open && !dragging}
+        style={style}
+        className={cn(
+          'fixed top-0 right-0 bottom-0 w-80 max-w-[85vw] z-50 border-l shadow-lg flex flex-col',
+          dragging ? '' : 'transition-transform duration-200 ease-out',
+          open ? 'translate-x-0' : 'translate-x-full',
+          tc({
+            light:   'bg-white/95 border-amber-200 text-amber-900',
+            dark:    'bg-slate-900/95 border-amber-700/40 text-amber-200',
+            hcLight: 'bg-white border-black text-black',
+            hcDark:  'bg-black border-white text-white',
+          })
+        )}
+      >
       <div className={cn('flex items-center justify-between px-4 py-3 border-b', tc({
         light: 'border-amber-200', dark: 'border-amber-700/40', hcLight: 'border-black', hcDark: 'border-white',
       }))}>
@@ -202,6 +232,7 @@ export default function RightDrawer({
           </div>
         )}
       </div>
-    </div>
+      </div>
+    </>
   );
 }

--- a/components/SidebarV2.jsx
+++ b/components/SidebarV2.jsx
@@ -70,6 +70,8 @@ export default function SidebarV2({
   ab,
   expanded = false,
   onCollapseExpanded,
+  dragProgress = 0,
+  externalGestures = false,
 }) {
   const { dark: darkMode } = useTheme();
 
@@ -130,13 +132,15 @@ export default function SidebarV2({
 
   // Swipe gestures: swipe right from the left edge opens the sidebar;
   // swipe left while the sidebar is open closes it. Ignored on larger viewports
-  // where the sidebar is statically visible.
+  // where the sidebar is statically visible. When `externalGestures` is true,
+  // GestureLayer owns the gesture lifecycle and this hook is a no-op.
   useEffect(() => {
+    if (externalGestures) return undefined;
     if (typeof window === 'undefined') return;
-    const EDGE_PX = 32;
-    const MIN_DX = 60;
-    const MAX_DY = 60;
-    const MAX_DT = 500;
+    const EDGE_PX = 44;
+    const MIN_DX = 40;
+    const MAX_DY = 80;
+    const MAX_DT = 600;
     let startX = 0;
     let startY = 0;
     let startTime = 0;
@@ -185,7 +189,7 @@ export default function SidebarV2({
       window.removeEventListener('touchend', onEnd);
       window.removeEventListener('touchcancel', onCancel);
     };
-  }, [menuOpen, onMenuOpenChange]);
+  }, [menuOpen, onMenuOpenChange, externalGestures]);
 
   // Auto-open the profile group when the profile panel is open, so the active
   // tab indicator is visible in the sidebar.
@@ -400,11 +404,40 @@ export default function SidebarV2({
 
   const showFavShelf = !searchTerm && !favoritesOnly && showFavorites && favoriteStories.length > 0;
 
+  // Drag-follow: when opening (menuOpen=false, dragProgress>0) or closing
+  // (menuOpen=true, dragProgress<0), override the CSS translate so the sidebar
+  // tracks the finger. No transition during drag for 1:1 responsiveness.
+  const dragOpening = !menuOpen && dragProgress > 0;
+  const dragClosing = menuOpen && dragProgress < 0;
+  const dragging = dragOpening || dragClosing;
+  let dragStyle;
+  if (dragOpening) {
+    dragStyle = { transform: `translateX(${(dragProgress - 1) * 100}%)`, transition: 'none' };
+  } else if (dragClosing) {
+    dragStyle = { transform: `translateX(${dragProgress * 100}%)`, transition: 'none' };
+  }
+
+  const backdropVisible = menuOpen || dragOpening;
+  const backdropOpacity = menuOpen ? 0.3 : Math.min(0.3, dragProgress * 0.3);
+
   return (
+    <>
+    {backdropVisible && (
+      <button
+        aria-label="Menü schließen"
+        data-testid="sidebar-backdrop"
+        onClick={() => onMenuOpenChange?.(false)}
+        className="fixed inset-0 top-16 z-20 bg-black backdrop-blur-[2px] lg:hidden"
+        style={{ opacity: backdropOpacity, transition: dragging ? 'none' : 'opacity 200ms ease-out' }}
+      />
+    )}
     <aside
       ref={asideRef}
       data-testid="sidebar-v2"
-      className={`fixed lg:static top-16 bottom-0 left-0 ${expanded ? 'w-96 lg:w-96' : 'w-80 lg:w-72'} z-30 transform transition-all duration-300 flex flex-col ${
+      style={dragStyle}
+      className={`fixed lg:static top-16 bottom-0 left-0 ${expanded ? 'w-96 lg:w-96' : 'w-80 lg:w-72'} z-30 transform flex flex-col ${
+        dragging ? '' : 'transition-all duration-300'
+      } ${
         menuOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
       } ${
         darkMode
@@ -827,5 +860,6 @@ export default function SidebarV2({
         );
       })()}
     </aside>
+    </>
   );
 }

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -577,6 +577,7 @@ const GrimmMarchenApp = () => {
   }, [showPinchFontSize, selectedStory, speedReaderMode, maxFontSize, setFontSize]);
 
   const [sidebarExpanded, setSidebarExpanded] = useState(false);
+  const [sidebarDragProgress, setSidebarDragProgress] = useState(0);
 
   // When HC flag is toggled, map between normal and HC theme variants
   useEffect(() => {
@@ -781,6 +782,8 @@ const GrimmMarchenApp = () => {
           onMenuToggle={() => setMenuOpen(false)}
           onMenuOpenChange={setMenuOpen}
           expanded={showEnhancedGestures && sidebarExpanded} onCollapseExpanded={() => setSidebarExpanded(false)}
+          dragProgress={showEnhancedGestures ? sidebarDragProgress : 0}
+          externalGestures={showEnhancedGestures}
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}
           showDeepSearch={showDeepSearch}
@@ -1033,6 +1036,7 @@ const GrimmMarchenApp = () => {
         readerAreaRef={readerAreaRef} pages={pages} currentPage={currentPage} totalPages={totalPages} onGoToPage={goToPage}
         selectedStory={selectedStory} pageText={pageText} menuOpen={menuOpen} onMenuOpenChange={setMenuOpen}
         sidebarExpanded={sidebarExpanded} onSidebarExpandedChange={setSidebarExpanded}
+        onSidebarDragOffsetChange={setSidebarDragProgress}
         onOpenTypography={() => showTypographyPanel && setTypoPanelOpen(true)} />
     )}
 

--- a/hooks/useEnhancedGestures.js
+++ b/hooks/useEnhancedGestures.js
@@ -1,27 +1,32 @@
 import { useEffect, useRef, useState } from 'react';
 
-const EDGE_PX = 40;
-const MIN_DIST = 56;
-const MAX_DT = 650;
+const EDGE_PX = 44;
+const MIN_DIST = 40;
+const MIN_VELOCITY = 0.35; // px/ms — fast flicks commit on shorter travel
+const MIN_FLICK_DIST = 24;
+const MAX_DT = 600;
 const RELOAD_THRESHOLD = 0.6;
+const DRAG_GRACE = 10; // px — ignore tiny jitter before treating as a drag
 
 /**
  * Enhanced reader gestures.
  *
- * Detects single-finger swipes in four directions on a target element and
- * translates them into app-level intents. Pinch (2+ fingers) is ignored so
- * this coexists with `pinch-font-size`.
+ * Detects single-finger swipes from any of the four edges of a target element
+ * (or window) and dispatches app-level intents. Publishes a *live* preview of
+ * the in-flight gesture so the UI can animate drawers following the finger.
+ * Pinch (2+ fingers) is ignored so this coexists with `pinch-font-size`.
  *
  * Gesture vocabulary:
- *   swipe-down  from near the top edge   → open header drawer
+ *   swipe-down  from near the top edge    → open header drawer
  *   swipe-up    from near the bottom edge → open footer drawer
  *   swipe-down  long (>60% viewport)      → trigger reload
- *   swipe-left  from near the right edge → open right drawer
- *   swipe-right from near the left edge  → stepped sidebar open/expand
- *   swipe-left  anywhere (sidebar open)  → stepped sidebar collapse/close
+ *   swipe-left  from near the right edge  → open right drawer
+ *   swipe-right from near the left edge   → open sidebar / expand
+ *   swipe-left  anywhere (sidebar open)   → close sidebar
  *
- * Returns a live progress channel (`reloadProgress` 0..1) so UI can show a
- * long-swipe reload indicator during an in-flight gesture.
+ * Returns:
+ *   reloadProgress — 0..1 for the pull-to-reload indicator.
+ *   preview — live drag state: { edge, axis, dx, dy, distance, progress } or null.
  */
 export function useEnhancedGestures({
   enabled,
@@ -32,24 +37,47 @@ export function useEnhancedGestures({
   onSwipeRight,
   onSwipeLeft,
   onReload,
+  onPreview,
+  sidebarOpen,
 } = {}) {
   const [reloadProgress, setReloadProgress] = useState(0);
   const stateRef = useRef(null);
+  const onPreviewRef = useRef(onPreview);
+  const sidebarOpenRef = useRef(sidebarOpen);
+  useEffect(() => { onPreviewRef.current = onPreview; }, [onPreview]);
+  useEffect(() => { sidebarOpenRef.current = sidebarOpen; }, [sidebarOpen]);
 
   useEffect(() => {
-    if (!enabled) { setReloadProgress(0); return undefined; }
+    if (!enabled) {
+      setReloadProgress(0);
+      onPreviewRef.current?.(null);
+      return undefined;
+    }
     const target = targetRef?.current;
     if (!target) return undefined;
 
-    const resetReload = () => {
-      if (stateRef.current) stateRef.current.reloadArmed = false;
-      setReloadProgress(0);
+    const emitPreview = (p) => { onPreviewRef.current?.(p); };
+
+    const resolveEdge = (s, dx, dy, absDx, absDy) => {
+      // Only commit to an edge once we know the dominant axis.
+      if (absDx < DRAG_GRACE && absDy < DRAG_GRACE) return null;
+      const horizontal = absDx >= absDy;
+      if (horizontal) {
+        if (dx > 0 && s.fromLeft) return 'left';
+        if (dx < 0 && s.fromRight) return 'right';
+        if (dx < 0 && sidebarOpenRef.current) return 'left-close';
+        return null;
+      }
+      if (dy > 0 && s.fromTop) return 'top';
+      if (dy < 0 && s.fromBottom) return 'bottom';
+      return null;
     };
 
     const onTouchStart = (e) => {
       if (e.touches.length !== 1) {
         stateRef.current = null;
         setReloadProgress(0);
+        emitPreview(null);
         return;
       }
       const t = e.touches[0];
@@ -64,70 +92,108 @@ export function useEnhancedGestures({
         fromLeft: t.clientX - rect.left <= EDGE_PX,
         fromRight: rect.right - t.clientX <= EDGE_PX,
         reloadArmed: false,
+        committedEdge: null,
       };
     };
 
     const onTouchMove = (e) => {
       const s = stateRef.current;
       if (!s) return;
-      if (e.touches.length !== 1) { stateRef.current = null; setReloadProgress(0); return; }
+      if (e.touches.length !== 1) {
+        stateRef.current = null;
+        setReloadProgress(0);
+        emitPreview(null);
+        return;
+      }
       const t = e.touches[0];
       const dx = t.clientX - s.startX;
       const dy = t.clientY - s.startY;
+      const absDx = Math.abs(dx);
+      const absDy = Math.abs(dy);
 
-      // Track long swipe-down reload progress once the gesture looks vertical.
-      if (dy > MIN_DIST && Math.abs(dy) > Math.abs(dx) * 1.5 && s.fromTop === false) {
+      // Long swipe-down reload tracking.
+      if (dy > MIN_DIST && absDy > absDx * 1.5 && !s.fromTop) {
         const ratio = Math.max(0, Math.min(1, dy / s.rect.height));
         s.reloadArmed = ratio >= RELOAD_THRESHOLD;
         setReloadProgress(ratio);
       } else if (reloadProgress !== 0) {
         setReloadProgress(0);
       }
+
+      const edge = s.committedEdge ?? resolveEdge(s, dx, dy, absDx, absDy);
+      if (edge && !s.committedEdge) s.committedEdge = edge;
+
+      if (!edge) {
+        emitPreview(null);
+        return;
+      }
+
+      // Convert to a progress value per-edge in [0, 1].
+      const w = s.rect.width || 1;
+      const h = s.rect.height || 1;
+      let distance = 0;
+      let progress = 0;
+      let axis = 'x';
+      if (edge === 'left') { distance = Math.max(0, dx); progress = Math.min(1, distance / (w * 0.35)); }
+      else if (edge === 'right') { distance = Math.max(0, -dx); progress = Math.min(1, distance / (w * 0.35)); }
+      else if (edge === 'left-close') { distance = Math.max(0, -dx); progress = Math.min(1, distance / (w * 0.35)); }
+      else if (edge === 'top') { distance = Math.max(0, dy); progress = Math.min(1, distance / (h * 0.25)); axis = 'y'; }
+      else if (edge === 'bottom') { distance = Math.max(0, -dy); progress = Math.min(1, distance / (h * 0.25)); axis = 'y'; }
+
+      emitPreview({ edge, axis, dx, dy, distance, progress });
+    };
+
+    const dispatch = (s, dx, dy) => {
+      const absDx = Math.abs(dx);
+      const absDy = Math.abs(dy);
+      const dt = Math.max(1, Date.now() - s.startTime);
+      const velX = absDx / dt;
+      const velY = absDy / dt;
+
+      // Long-swipe reload takes priority.
+      if (s.reloadArmed && dy > 0 && absDy > absDx) {
+        s.reloadArmed = false;
+        setReloadProgress(0);
+        onReload?.();
+        return;
+      }
+
+      const horizontal = absDx > absDy;
+      const distGateH = absDx >= MIN_DIST || (absDx >= MIN_FLICK_DIST && velX >= MIN_VELOCITY);
+      const distGateV = absDy >= MIN_DIST || (absDy >= MIN_FLICK_DIST && velY >= MIN_VELOCITY);
+
+      if (horizontal) {
+        if (!distGateH) return;
+        if (dx > 0) onSwipeRight?.({ fromLeftEdge: s.fromLeft });
+        else if (s.fromRight) onSwipeLeftRight?.();
+        else onSwipeLeft?.();
+      } else {
+        if (!distGateV) return;
+        if (dy < 0 && s.fromBottom) onSwipeUpBottom?.();
+        else if (dy > 0 && s.fromTop) onSwipeDownTop?.();
+      }
     };
 
     const onTouchEnd = (e) => {
       const s = stateRef.current;
       stateRef.current = null;
+      emitPreview(null);
       if (!s) { setReloadProgress(0); return; }
       const t = (e.changedTouches && e.changedTouches[0]) || null;
       if (!t) { setReloadProgress(0); return; }
       const dx = t.clientX - s.startX;
       const dy = t.clientY - s.startY;
       const dt = Date.now() - s.startTime;
-      const absDx = Math.abs(dx);
-      const absDy = Math.abs(dy);
-
-      // Long-swipe reload — priority over the regular direction dispatch.
-      if (s.reloadArmed && dy > 0 && absDy > absDx) {
-        resetReload();
-        onReload?.();
-        return;
-      }
       setReloadProgress(0);
-
-      if (dt > MAX_DT && absDx < MIN_DIST * 2 && absDy < MIN_DIST * 2) return;
-      const horizontal = absDx > absDy;
-
-      if (horizontal) {
-        if (absDx < MIN_DIST) return;
-        if (dx > 0) {
-          // swipe right — always dispatch; parent handles edge preference.
-          onSwipeRight?.({ fromLeftEdge: s.fromLeft });
-        } else {
-          if (s.fromRight) onSwipeLeftRight?.();
-          else onSwipeLeft?.();
-        }
-      } else {
-        if (absDy < MIN_DIST) return;
-        if (dy < 0) {
-          if (s.fromBottom) onSwipeUpBottom?.();
-        } else {
-          if (s.fromTop) onSwipeDownTop?.();
-        }
-      }
+      if (dt > MAX_DT && Math.abs(dx) < MIN_DIST * 2 && Math.abs(dy) < MIN_DIST * 2) return;
+      dispatch(s, dx, dy);
     };
 
-    const onTouchCancel = () => { stateRef.current = null; setReloadProgress(0); };
+    const onTouchCancel = () => {
+      stateRef.current = null;
+      setReloadProgress(0);
+      emitPreview(null);
+    };
 
     target.addEventListener('touchstart', onTouchStart, { passive: true });
     target.addEventListener('touchmove', onTouchMove, { passive: true });

--- a/tests/enhanced-gestures.spec.js
+++ b/tests/enhanced-gestures.spec.js
@@ -29,7 +29,7 @@ async function dispatchSwipe(page, selector, from, to) {
   await page.evaluate(({ selector, from, to }) => {
     const el = document.querySelector(selector);
     if (!el) throw new Error(`No element: ${selector}`);
-    const mkTouch = (x, y) => ({
+    const mkTouch = (x, y) => new Touch({
       identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y,
     });
     const fire = (type, x, y) => {
@@ -100,7 +100,7 @@ test.describe('Enhanced gestures', () => {
     // Only dispatch start + move (no end) so the indicator is still visible.
     await page.evaluate(({ cx, yStart, yMove }) => {
       const el = document.querySelector('[data-testid="reader-viewport"]');
-      const mk = (x, y) => ({ identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y });
+      const mk = (x, y) => new Touch({ identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y });
       const start = new TouchEvent('touchstart', { bubbles: true, cancelable: true,
         touches: [mk(cx, yStart)], targetTouches: [mk(cx, yStart)], changedTouches: [mk(cx, yStart)] });
       const move = new TouchEvent('touchmove', { bubbles: true, cancelable: true,


### PR DESCRIPTION
Makes every edge drawer feel native: lower swipe thresholds, velocity-based
flicks, and live drag-follow so the sidebar and the three gesture drawers
track the finger instead of snapping open at the end of the gesture. The
right drawer now mirrors the left sidebar (matching backdrop + pan behaviour).
GestureLayer is the single source of truth for all four drawer slots and
enforces a one-open-at-a-time invariant. Adds subtle edge-indicator pulls so
the gesture affordances are discoverable, and fixes the test helper's
TouchEvent construction for modern Chromium.

https://claude.ai/code/session_012dHPxktnFBKBrYSi1yK9YL