### PR TITLE
docs: improve developer onboarding and persona documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,18 +5,28 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run dev          # Start dev server (http://localhost:5173)
-npm run build        # Production build → dist/
-npm run crawl        # Crawl all sources and write to stories/
-npm run crawl grimm  # Crawl a single source by id
-npm run test         # Run Playwright E2E tests (starts dev server automatically)
-npm run test:ui      # Playwright interactive UI mode
+npm run dev                  # Start dev server (http://localhost:5173)
+npm run build                # Production build → dist/ (runs docs:check first)
+npm run test:unit            # Vitest unit tests — fastest loop, no browser
+npm run test:unit:watch      # Vitest in watch mode
+npm run test                 # Playwright E2E (starts the dev server itself)
+npm run test:ui              # Playwright interactive UI
+npm run docs:check           # Assert every flag has a docs/features/ file
+npm run format               # Prettier write (format:check for CI read-only)
+npm run crawl                # Crawl every source into stories/
+npm run crawl grimm          # Crawl a single source by id
+npm run crawl -- --limit 10  # Cap stories per source (useful for debugging)
+npm run content:report       # Story counts + health report
+npm run content:duplicates   # Detect duplicate slugs across sources
+npm run content:orphans      # Detect orphaned files under stories/
 ```
 
 Run a single test file or grep pattern:
 ```bash
 npx playwright test pagination.spec.js
 npx playwright test -g "dead space"
+npx vitest run tests/unit/useReader.test.jsx
+npm run test:unit -- guidelines   # only the guideline-enforcement tests
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
 # webreader
+
+A paginated fairy-tale reader for the web. Content is crawled from public-domain
+sources (Grimm, Andersen, Swiss Sagen, Maerchenstiftung) into
+`stories/{source}/{slug}/content.md`, then rendered by a DOM-measurement
+word-packing pager — no scrolling, no CSS columns.
+
+- **App:** React 18 · Vite 8 · Tailwind v4 · OpenFeature
+- **Content:** YAML-frontmatter markdown under `stories/`
+- **Tests:** Vitest (unit) + Playwright (E2E)
+
+## Quickstart
+
+```bash
+npm install
+npm run dev          # http://localhost:5173
+```
+
+That is enough to boot the reader against the committed story set. No API
+keys, no `.env` required for development — feature flags resolve from
+`flags.json` via the OpenFeature `InMemoryProvider`.
+
+## Common commands
+
+```bash
+npm run dev                   # Dev server (http://localhost:5173)
+npm run build                 # Production build → dist/ (runs docs:check first)
+npm run test:unit             # Vitest — fast, no browser
+npm run test:unit:watch       # Vitest in watch mode
+npm run test                  # Playwright E2E (starts the dev server itself)
+npm run test:ui               # Playwright interactive UI
+npm run format                # Prettier write
+npm run crawl                 # Re-crawl every source into stories/
+npm run crawl grimm           # Crawl a single source by id
+npm run crawl -- --limit 10   # Crawl at most 10 stories per source (debugging)
+npm run docs:check            # Assert every flag has a feature doc
+npm run content:report        # Story counts, duplicates, orphan detection
+```
+
+Single-test filters:
+
+```bash
+npx playwright test pagination.spec.js
+npx playwright test -g "dead space"
+npx vitest run tests/unit/useReader.test.jsx
+```
+
+## Where to start reading
+
+| You want to… | Read this |
+|---|---|
+| Understand the codebase at a glance | [`CLAUDE.md`](CLAUDE.md) |
+| Follow the coding rules (enforced by tests) | [`CODING_GUIDELINES.md`](CODING_GUIDELINES.md) |
+| See the product picture + roadmap | [`docs/product-strategy.md`](docs/product-strategy.md) |
+| Browse features per-persona | [`docs/personas.md`](docs/personas.md) |
+| Add a curated story collection (npm package) | [`docs/collections.md`](docs/collections.md) |
+| Find the highest-value refactors | [`docs/refactoring-targets.md`](docs/refactoring-targets.md) |
+| Know what belongs to the developer persona | [`docs/personas/08-developers.md`](docs/personas/08-developers.md) |
+
+## Architecture in one screen
+
+```
+stories/{source}/{slug}/content.md   ← YAML frontmatter + markdown
+        │
+        ▼  (import.meta.glob at build time, 2- or 3-level)
+src/lib/storyLibrary.js              ← merges file-based + collection packages
+        │
+        ▼
+grimm-reader.jsx                     ← root composition (feature flags, modals)
+        │
+        ▼
+hooks/useReader.js + components/PageContent.jsx
+                                     ← DOM-measurement word-packing pager
+```
+
+- **New source:** implement `SourceAdapter` in `crawlers/sources/` and register in `crawlers/index.ts`.
+- **New flag:** add to `flags.json` + `src/lib/featureRegistry.jsx`. `useFeatureFlags` exposes it as `show<CamelCase>`.
+- **New feature doc:** add `docs/features/<flag>.md` — `npm run docs:check` (and the build) fails otherwise.
+- **New curated collection:** copy `packages/collection-grimm-top5/`; see [`docs/collections.md`](docs/collections.md).
+
+## Deployment
+
+Deploys to Vercel. The build runs `npm run docs:check && vite build`. The
+Vercel Toolbar Flags panel is wired to `api/.well-known/vercel/flags.js`, which
+reads the same `flags.json` the app uses — gated by a `FLAGS_SECRET` env var.

--- a/docs/features/debug-badges.md
+++ b/docs/features/debug-badges.md
@@ -39,6 +39,20 @@ The control panel is opened from the bug icon in the bottom-right corner
 (`debug-panel-toggle`). Clicking a badge still opens the modal with
 `data-testid`, element tag, size, `aria-label`, and `role`.
 
+## How to enable
+
+Three common paths:
+
+- **Profile panel** → the feature overrides list flips `debug-badges` per-browser
+  (persisted to `localStorage` under `wr-feature-overrides`).
+- **Vercel Toolbar** → on a deployed preview, the Flags panel lists every flag
+  from `flags.json` via `api/.well-known/vercel/flags.js`.
+- **Default change** → edit `flags.json` → `debug-badges.defaultVariant` to
+  `"on"` (affects every visitor; only do this in an experiment branch).
+
+The `localStorage` override is a browser-local boolean — clear
+`wr-feature-overrides` to reset.
+
 ## Behavior
 
 - `DebugOverlay` is rendered once at the root when the flag is on.

--- a/docs/features/story-api.md
+++ b/docs/features/story-api.md
@@ -41,6 +41,12 @@ Public REST/GraphQL API exposing story content, metadata, and semantic graph dat
 - Authentication: API key per developer account
 - Rate limiting: standard tiered by plan
 
+### Today's foothold
+
+The repo already exposes one public endpoint at `api/.well-known/vercel/flags.js` (Vercel Functions, reads `flags.json`, gated by `FLAGS_SECRET`). Any REST surface can live alongside it under `api/` — the Vercel deployment model already routes `api/**.js` as serverless functions, no extra wiring required.
+
+Curated [collections](../collections.md) (`@tweakch/collection-*` npm packages) are a complementary distribution channel: stories as installable packages rather than fetched over HTTP.
+
 ## Embeddable Reader
 
 A `<story-reader src="story-id">` web component that developers can drop into any page — same reader engine, zero dependencies.
@@ -51,3 +57,4 @@ A `<story-reader src="story-id">` web component that developers can drop into an
 - [Story Remix](story-remix.md)
 - [Story Directories](story-directories.md) — existing app flag (structural foundation)
 - [Deep Search](deep-search.md) — existing app flag (search layer)
+- [Curated Collections](../collections.md) — complementary npm-package distribution

--- a/docs/personas/08-developers.md
+++ b/docs/personas/08-developers.md
@@ -12,6 +12,7 @@ app_features:
   - debug-badges
   - deep-search
   - attribution
+  - error-page-simulator
 related_personas:
   - "06-creatives"
 opportunity: "Platform play — graphify-out/ knowledge graph is a direct head start. Transitioning from product to platform unlocks a developer ecosystem."
@@ -20,6 +21,13 @@ opportunity: "Platform play — graphify-out/ knowledge graph is a direct head s
 # 🧑‍💻 Developers / API Users
 
 **Job-to-be-done:** "I want to use fairy tales programmatically."
+
+Two audiences share this persona:
+
+- **External developers** who want webreader as a platform — API, embeddable reader, structured story data.
+- **Internal contributors** working on the app itself — the person who clones the repo and runs `npm install`.
+
+The strategic features below serve the first group; the "Developer surfaces today" section below serves the second.
 
 ## Use Cases
 
@@ -35,18 +43,44 @@ opportunity: "Platform play — graphify-out/ knowledge graph is a direct head s
 | [Story Directories](../features/story-directories.md) | Structured multi-level content hierarchy |
 | [Deep Search](../features/deep-search.md) | Full-text search across all story content |
 | [Attribution](../features/attribution.md) | Source metadata for downstream use |
-| [Debug Badges](../features/debug-badges.md) | `data-testid` labels on all UI elements |
+| [Debug Badges](../features/debug-badges.md) | Debug overlay: testid badges, FPS, viewport, flags, build info |
+| [Error Page Simulator](../features/error-page-simulator.md) | Trigger 404/500 pages on demand to verify error UX |
 
 ## Strategic Opportunity
 
 Platform play — the project's existing `graphify-out/` knowledge graph is a direct head start. Transitioning from product to platform unlocks a developer ecosystem.
 
+## Developer surfaces today
+
+Existing concrete hooks a developer (internal or external) can build on right now:
+
+| Surface | Entry point | Status |
+|---|---|---|
+| Story crawler | `crawlers/core.ts` + `crawlers/types.ts` — implement `SourceAdapter`, register in `crawlers/index.ts` | stable |
+| Curated collections | npm packages under `packages/collection-*`, published as `@tweakch/collection-*` — see [`docs/collections.md`](../collections.md) | stable |
+| Feature flags | `flags.json` + `src/lib/featureRegistry.jsx`; `useFeatureFlags` hook exposes `show<CamelCase>` | stable |
+| Vercel Flags discovery | `api/.well-known/vercel/flags.js` — auto-serves every flag to the Vercel Toolbar | stable |
+| Knowledge graph | `graphify-out/graph.json` + `GRAPH_REPORT.md` | experimental |
+| Debug overlay | `debug-badges` flag — testids, FPS, viewport, grid, resolved flags, build SHA | experiment |
+
+## Contributor onboarding
+
+Read these in order:
+
+1. [`README.md`](../../README.md) — quickstart + command cheat sheet
+2. [`CLAUDE.md`](../../CLAUDE.md) — architecture: story pipeline, pagination algorithm, sidebar state, curated collections, testid conventions
+3. [`CODING_GUIDELINES.md`](../../CODING_GUIDELINES.md) — six rules enforced by `tests/unit/guidelines/`
+4. [`docs/refactoring-targets.md`](../refactoring-targets.md) — known god files, A/B variants awaiting resolution, quick wins
+5. [`docs/collections.md`](../collections.md) — the curated-collection npm package spec
+
 ## Implementation Note
 
-The crawler architecture (`SourceAdapter` interface, `crawlers/sources/`) already provides a clean abstraction that maps naturally to a public API surface.
+The crawler architecture (`SourceAdapter` interface, `crawlers/sources/`) already provides a clean abstraction that maps naturally to a public API surface. `api/.well-known/vercel/flags.js` is the first public `api/` endpoint — any future REST surface can live next to it.
 
 ## Links
 
 - [Back to Feature Matrix](../personas.md)
 - [Creatives →](06-creatives.md)
 - [Product Strategy](../product-strategy.md)
+- [Refactoring Targets](../refactoring-targets.md)
+- [Coding Guidelines](../../CODING_GUIDELINES.md)


### PR DESCRIPTION
- Populate README.md (was a single-line stub) with quickstart, command
  cheat sheet, and a map of where to read next.
- Extend CLAUDE.md commands with test:unit, docs:check, content health
  scripts, and crawl --limit — the ones a contributor reaches for daily.
- Rewrite docs/personas/08-developers.md: add the missing
  error-page-simulator flag, separate external vs. internal developer
  audiences, add "Developer surfaces today" and contributor-onboarding
  sections pointing to CODING_GUIDELINES and refactoring-targets.
- docs/features/debug-badges.md: document the three ways to enable the
  flag (profile panel, Vercel Toolbar, flags.json) since the previous
  doc explained what it does but not how to turn it on.
- docs/features/story-api.md: reference the existing api/ endpoint so
  the "vision" status doesn't obscure the concrete foothold already in
  the repo; link the curated collections spec as a complementary
  distribution channel.