### PR TITLE
feat(stories): add age 4+ contemporary adaptions for top 5 Grimm tales

### DIFF
--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -299,6 +299,12 @@ const GrimmMarchenApp = () => {
     return list;
   }, [stories, blacklist, ageFilterActive, childAge]);
 
+  const visibleAdaptionsByParent = React.useMemo(() => {
+    if (!ageFilterActive || typeof childAge !== 'number') return adaptionsByParent;
+    const fits = a => (a.ageMin == null || childAge >= a.ageMin) && (a.ageMax == null || childAge <= a.ageMax);
+    return Object.fromEntries(Object.entries(adaptionsByParent).map(([id, list]) => [id, list.filter(fits)]));
+  }, [adaptionsByParent, ageFilterActive, childAge]);
+
   const normalizedSearchTerm = searchTerm.trim().toLowerCase();
 
   const titleMatchedStoryIds = React.useMemo(() => {
@@ -975,7 +981,7 @@ const GrimmMarchenApp = () => {
               controlsVisible={controlsVisible}
               onToggleControls={setControlsVisible}
               showAdaptionSwitcher={showAdaptionSwitcher}
-              adaptionsByParent={adaptionsByParent}
+              adaptionsByParent={visibleAdaptionsByParent}
               onSelectVariant={selectVariant}
               showTypographyPanel={showTypographyPanel}
               typoPanelOpen={typoPanelOpen}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "jsdom": "^29.0.1",
         "node-html-parser": "^7.0.0",
         "postcss": "8.5.8",
+        "prettier": "^3.3.3",
         "tailwindcss": "4.2.2",
         "tsx": "^4.19.4",
         "vite": "8.0.8",
@@ -3973,6 +3974,22 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",

--- a/packages/collection-grimm-top5/collection.json
+++ b/packages/collection-grimm-top5/collection.json
@@ -14,7 +14,8 @@
       "atuType": "510A",
       "coverImage": "cover.svg",
       "adaptions": [
-        { "name": "schweizerdeutsch", "label": "Schweizer Fassung" }
+        { "name": "schweizerdeutsch", "label": "Schweizer Fassung" },
+        { "name": "contemporary", "label": "Moderne Fassung" }
       ]
     },
     {
@@ -22,28 +23,40 @@
       "title": "Hänsel und Gretel",
       "khmNumber": 15,
       "atuType": "327A",
-      "coverImage": "cover.svg"
+      "coverImage": "cover.svg",
+      "adaptions": [
+        { "name": "contemporary", "label": "Moderne Fassung" }
+      ]
     },
     {
       "slug": "rapunzel",
       "title": "Rapunzel",
       "khmNumber": 12,
       "atuType": "310",
-      "coverImage": "cover.svg"
+      "coverImage": "cover.svg",
+      "adaptions": [
+        { "name": "contemporary", "label": "Moderne Fassung" }
+      ]
     },
     {
       "slug": "rotkaeppchen",
       "title": "Rotkäppchen",
       "khmNumber": 26,
       "atuType": "333",
-      "coverImage": "cover.svg"
+      "coverImage": "cover.svg",
+      "adaptions": [
+        { "name": "contemporary", "label": "Moderne Fassung" }
+      ]
     },
     {
       "slug": "schneewittchen",
       "title": "Schneewittchen",
       "khmNumber": 53,
       "atuType": "709",
-      "coverImage": "cover.svg"
+      "coverImage": "cover.svg",
+      "adaptions": [
+        { "name": "contemporary", "label": "Moderne Fassung" }
+      ]
     }
   ]
 }

--- a/packages/collection-grimm-top5/index.js
+++ b/packages/collection-grimm-top5/index.js
@@ -13,6 +13,12 @@ import schneewittchenCover from './stories/schneewittchen/cover.svg?url';
 
 import aschenputtelSchweizerdeutsch from './stories/aschenputtel/adaptions/schweizerdeutsch/content.md?raw';
 
+import aschenputtelContemporary from './stories/aschenputtel/adaptions/contemporary/content.md?raw';
+import hansel_und_gretelContemporary from './stories/hansel_und_gretel/adaptions/contemporary/content.md?raw';
+import rapunzelContemporary from './stories/rapunzel/adaptions/contemporary/content.md?raw';
+import rotkaeppchenContemporary from './stories/rotkaeppchen/adaptions/contemporary/content.md?raw';
+import schneewittchenContemporary from './stories/schneewittchen/adaptions/contemporary/content.md?raw';
+
 import openingIllustration from './assets/opening.svg?url';
 import endingIllustration from './assets/ending.svg?url';
 import ornamentIllustration from './assets/ornament.svg?url';
@@ -44,6 +50,19 @@ export const illustrations = {
 export const adaptions = {
   aschenputtel: {
     schweizerdeutsch: aschenputtelSchweizerdeutsch,
+    contemporary: aschenputtelContemporary,
+  },
+  hansel_und_gretel: {
+    contemporary: hansel_und_gretelContemporary,
+  },
+  rapunzel: {
+    contemporary: rapunzelContemporary,
+  },
+  rotkaeppchen: {
+    contemporary: rotkaeppchenContemporary,
+  },
+  schneewittchen: {
+    contemporary: schneewittchenContemporary,
   },
 };
 

--- a/packages/collection-grimm-top5/stories/aschenputtel/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/aschenputtel/adaptions/contemporary/content.md
@@ -1,0 +1,32 @@
+---
+title: "Aschenputtel"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal ein freundliches Mädchen namens Ella. Sie wohnte mit ihrem Papa, seiner neuen Frau und deren zwei Töchtern in einem grossen Haus. Die neue Frau war nicht nett zu Ella. Ihre Töchter auch nicht. Sie nannten Ella "Aschenputtel", weil sie den ganzen Tag putzen musste und ihre Kleider staubig waren.
+
+Am Abend legte Aschenputtel sich müde neben den warmen Ofen. Aber sie blieb immer freundlich, auch wenn die anderen gemein waren.
+
+Eines Tages hörten alle eine grosse Neuigkeit. Der Prinz machte ein Fest! Alle Mädchen im ganzen Land durften kommen. Die Stiefschwestern freuten sich sehr. "Wir gehen hin!" riefen sie. "Aber du, Aschenputtel, du bleibst zu Hause."
+
+Aschenputtel war traurig. Sie ging in den Garten zu einem kleinen Baum, den sie selber gepflanzt hatte. Oben im Baum sass ein weisses Vögelchen. "Warum weinst du?" fragte das Vögelchen.
+
+"Ich möchte auch zum Fest", sagte Aschenputtel.
+
+Das Vögelchen zwitscherte fröhlich. Plötzlich lag vor Aschenputtel ein wunderschönes Kleid aus Gold und Silber, und daneben zwei glitzernde Schuhe. Sie zog alles an und lief zum Schloss.
+
+Als Aschenputtel im Saal stand, schaute der Prinz sie an. Er war verzaubert. "Darf ich mit dir tanzen?" fragte er. Sie tanzten den ganzen Abend. Der Prinz wollte mit keinem anderen Mädchen tanzen, nur mit ihr.
+
+Als die Uhr spät war, musste Aschenputtel schnell nach Hause. Sie rannte so schnell, dass ein Schuh von ihrem Fuss rutschte und auf der Treppe liegen blieb. Der Prinz fand den Schuh und hob ihn auf.
+
+"Wem dieser Schuh passt, das ist meine Freundin", sagte der Prinz. Er ging von Haus zu Haus. Jedes Mädchen probierte den Schuh. Aber er passte niemandem.
+
+Endlich kam der Prinz auch zu Aschenputtels Haus. Die Stiefschwestern drängten ihre Füsse in den Schuh, doch er war zu klein. "Gibt es hier noch ein Mädchen?" fragte der Prinz.
+
+Aschenputtel trat leise aus der Küche. Sie streifte den Schuh über den Fuss – und er passte genau! Der Prinz lachte vor Freude.
+
+"Komm mit mir ins Schloss", sagte er. "Dort musst du nie mehr putzen."
+
+Und so ging Aschenputtel mit dem Prinzen ins Schloss. Sie lebten glücklich zusammen und blieben Freunde für immer.

--- a/packages/collection-grimm-top5/stories/hansel_und_gretel/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/hansel_und_gretel/adaptions/contemporary/content.md
@@ -1,0 +1,32 @@
+---
+title: "Hänsel und Gretel"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Hänsel und Gretel waren Geschwister. Sie wohnten in einem kleinen Haus am Rand eines grossen Waldes. Manchmal hatten sie nicht viel zu essen, aber sie hatten sich lieb.
+
+Eines Tages gingen Hänsel und Gretel in den Wald, um Beeren zu suchen. Hänsel steckte vorsichtig Brotkrumen in seine Tasche. "Damit wir wieder nach Hause finden", sagte er klug. Unterwegs streute er die Krumen auf den Weg.
+
+Sie pflückten Beeren, lachten und spielten zwischen den Bäumen. Doch als sie zurück wollten, waren die Brotkrumen weg. Ein paar hungrige Vögel hatten sie aufgepickt!
+
+"Wir haben uns verirrt", sagte Gretel. Der Wald wurde dunkel. Hänsel nahm die Hand seiner Schwester.
+
+Plötzlich sahen sie etwas Merkwürdiges zwischen den Bäumen. Ein Haus! Aber was für ein Haus! Die Wände waren aus Lebkuchen. Das Dach bestand aus Schokolade. Die Fenster glitzerten wie Zuckerguss.
+
+Hänsel und Gretel waren hungrig. Ganz vorsichtig brachen sie ein kleines Stück vom Dach ab und probierten. "Mmm, süss!" riefen sie.
+
+Die Tür öffnete sich. Eine alte Frau kam heraus. Sie schaute ein bisschen streng. "Kommt mit rein", sagte sie. "Ich habe Milch und Kuchen für euch."
+
+Die Kinder gingen hinein. Die Frau gab ihnen Essen, aber sie sagte komisch: "Bleibt nur hier, ich brauche Hilfe im Haus."
+
+Gretel merkte schnell, dass die Frau sie gar nicht mehr gehen lassen wollte. "Wir müssen doch nach Hause zum Papa!", sagte sie mutig.
+
+Die Frau murmelte und wollte sie nicht ziehen lassen. Da hatte Gretel eine Idee. "Können Sie mir bitte zeigen, wo der Backofen ist?" fragte sie höflich. Als die Frau sich bückte, um den Ofen zu zeigen, sprangen Hänsel und Gretel durch die Tür und rannten weg, so schnell sie konnten.
+
+Sie liefen und liefen, bis sie einen Bach fanden. Auf dem Bach schwamm eine weisse Ente. "Liebe Ente, hilfst du uns über das Wasser?" fragte Gretel. Die Ente nickte und brachte sie sicher ans andere Ufer.
+
+Am Waldrand stand ihr Papa. Er hatte sie lange gesucht und rief: "Meine Kinder!" Er nahm beide in die Arme und drückte sie fest.
+
+Hänsel und Gretel zeigten ihm Nüsse und Beeren, die sie im Wald gefunden hatten. Von nun an hatten sie immer genug zu essen. Und nie mehr gingen sie ohne den Papa in den Wald.

--- a/packages/collection-grimm-top5/stories/rapunzel/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/rapunzel/adaptions/contemporary/content.md
@@ -1,0 +1,36 @@
+---
+title: "Rapunzel"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal ein Mädchen mit Haaren so lang und gold wie Sonnenstrahlen. Sein Name war Rapunzel. Rapunzel wohnte in einem hohen Turm mitten im Wald. Eine strenge Fee hatte sie vor langer Zeit dorthin gebracht und passte auf sie auf.
+
+Der Turm hatte keine Tür. Nur ein kleines Fenster ganz oben. Wenn die Fee Rapunzel besuchen wollte, rief sie:
+
+"Rapunzel, Rapunzel, lass dein Haar herunter!"
+
+Dann liess Rapunzel ihre goldenen Zöpfe aus dem Fenster fallen, und die Fee kletterte hinauf.
+
+Rapunzel war oft einsam im Turm. Sie sang jeden Tag aus dem Fenster. Die Vögel kamen und sangen mit ihr. Ihre Stimme war so schön wie Musik.
+
+Eines Tages ritt ein junger Prinz durch den Wald. Er hörte Rapunzels Lied und blieb stehen. Noch nie hatte er so etwas Schönes gehört! Er suchte und suchte und fand endlich den hohen Turm.
+
+"Wie kommt man dort hinauf?" fragte er sich. Da versteckte er sich hinter einem Busch und wartete.
+
+Bald kam die Fee und rief: "Rapunzel, Rapunzel, lass dein Haar herunter!" Der Prinz sah, wie die Fee an den Zöpfen hinaufkletterte.
+
+Am nächsten Tag stellte der Prinz sich selbst vor den Turm. Mit freundlicher Stimme rief er:
+
+"Rapunzel, Rapunzel, lass dein Haar herunter!"
+
+Rapunzel liess ihr Haar fallen, und der Prinz stieg hinauf. Sie erschrak ein wenig, doch der Prinz lächelte und sagte: "Ich wollte deine schöne Stimme kennen lernen. Möchtest du mein Freund sein?"
+
+Rapunzel freute sich sehr. Endlich hatte sie jemanden zum Sprechen. Jeden Tag kam der Prinz heimlich vorbei, und die beiden lachten und erzählten sich Geschichten.
+
+Als die Fee davon hörte, wurde sie böse. Sie schnitt Rapunzels lange Zöpfe ab und schickte sie weit weg in einen einsamen Wald. Der Prinz suchte Rapunzel überall. Lange, lange irrte er durch die Wälder.
+
+Eines Morgens hörte er wieder eine Stimme singen. Es war Rapunzel! Er folgte der Stimme und fand sie auf einer Lichtung.
+
+"Da bist du ja!" riefen sie beide. Sie nahmen sich bei der Hand und gingen zusammen zum Schloss des Prinzen. Dort wohnten sie glücklich zusammen, und Rapunzel sang jeden Tag ihr schönstes Lied.

--- a/packages/collection-grimm-top5/stories/rotkaeppchen/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/rotkaeppchen/adaptions/contemporary/content.md
@@ -1,0 +1,46 @@
+---
+title: "Rotkäppchen"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal ein kleines Mädchen, das immer eine rote Mütze trug. Alle nannten es Rotkäppchen.
+
+Eines Morgens sagte die Mama zu Rotkäppchen: "Die Oma ist krank. Bitte bring ihr diesen Korb mit Kuchen und Saft. Aber bleib auf dem Weg, und sprich mit niemand Fremdem."
+
+Rotkäppchen versprach es. Fröhlich lief es los. Die Sonne schien, die Vögel zwitscherten, und am Wegrand blühten bunte Blumen.
+
+Mitten im Wald traf Rotkäppchen einen grossen Wolf. Der Wolf zeigte ein breites Lächeln.
+
+"Guten Tag, kleines Mädchen", sagte der Wolf freundlich. "Wohin gehst du denn?"
+
+Rotkäppchen hatte noch nie einen Wolf gesehen und erschrak nicht. "Ich besuche meine Oma", antwortete es.
+
+"Oh, wie schön", sagte der Wolf. "Schau, dort auf der Wiese, wie bunt die Blumen sind. Warum pflückst du nicht ein paar für die Oma?"
+
+Rotkäppchen dachte: "Ein Blumenstrauss würde Oma freuen!" So ging es von Blume zu Blume und kam immer weiter vom Weg ab.
+
+Der Wolf aber rannte schnell zu Omas Haus. Er klopfte an die Tür. "Oma, mach auf!" Doch die Oma wusste gleich: Das ist nicht Rotkäppchen! Flink versteckte sie sich im Schrank und schloss ihn fest von innen.
+
+Da kam der Wolf herein. Er schaute ins Bett – leer. Er schaute unter den Tisch – leer. "Die Oma muss im Wald sein", brummte er und legte sich wartend ins Bett.
+
+Bald klopfte Rotkäppchen an der Tür. "Ich bin's!" Es trat ein und sah das komische Bild: Etwas Haariges lag unter Omas Decke.
+
+"Oma, warum hast du so grosse Ohren?"
+
+"Damit ich dich besser hören kann!"
+
+"Oma, warum hast du so grosse Augen?"
+
+"Damit ich dich besser sehen kann!"
+
+"Oma, warum hast du so einen grossen Mund?"
+
+"Damit ich—" Und da sprang der Wolf aus dem Bett!
+
+Rotkäppchen schrie laut. Zum Glück kam gerade der Jäger vorbei. Er hörte den Schrei und lief schnell ins Haus. Der Wolf erschrak so sehr, dass er aus dem Fenster sprang und weit, weit weg in den Wald rannte. Dort blieb er.
+
+"Oma! Wo bist du?" rief Rotkäppchen. Ein kleines Klopfen kam aus dem Schrank. Die Oma öffnete die Tür und umarmte Rotkäppchen ganz fest.
+
+Zusammen assen sie den Kuchen und tranken den Saft. Und Rotkäppchen versprach: "Nie mehr gehe ich vom Weg ab, und nie mehr spreche ich mit Fremden im Wald."

--- a/packages/collection-grimm-top5/stories/schneewittchen/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/schneewittchen/adaptions/contemporary/content.md
@@ -1,0 +1,40 @@
+---
+title: "Schneewittchen"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal eine Prinzessin mit Haaren schwarz wie die Nacht, Lippen rot wie eine Erdbeere und Haut weiss wie Schnee. Alle nannten sie Schneewittchen. Sie war freundlich zu allen Menschen und auch zu allen Tieren.
+
+Schneewittchens Stiefmutter, die Königin, war sehr stolz. Jeden Morgen schaute sie in ihren Zauberspiegel und fragte:
+
+"Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
+
+Viele Jahre antwortete der Spiegel: "Du, meine Königin." Doch eines Tages sagte der Spiegel:
+
+"Schneewittchen ist tausendmal schöner als Ihr."
+
+Da wurde die Königin sehr neidisch. Sie wollte Schneewittchen fortschicken. Schneewittchen lief in den Wald und lief und lief, bis es müde wurde.
+
+Plötzlich sah es ein winziges Häuschen. Schneewittchen klopfte. Niemand antwortete, also ging es hinein. Im Zimmer standen sieben kleine Stühle, auf dem Tisch sieben kleine Teller, und im Schlafzimmer waren sieben kleine Betten. Schneewittchen ass ein bisschen, trank ein bisschen und legte sich auf das letzte Bett. Schon schlief es fest.
+
+Am Abend kamen die sieben Zwerge von der Arbeit nach Hause. Sie arbeiteten in einem Bergwerk und sammelten funkelnde Steine. "Wer hat auf unseren Stühlen gesessen? Wer hat von unseren Tellern gegessen? Wer liegt in meinem Bett?" fragte der siebte, kleinste Zwerg staunend.
+
+Da wachte Schneewittchen auf. Es erzählte alles. Die Zwerge waren gute Kerle und sagten: "Du darfst bei uns bleiben. Wir passen auf dich auf."
+
+Schneewittchen wohnte nun bei den Zwergen. Sie kochte Suppe, putzte das Häuschen und sang mit den Vögeln.
+
+Die Königin aber hörte vom Spiegel, dass Schneewittchen noch lebte. Sie verkleidete sich als alte Frau und kam mit einem roten Apfel zum Häuschen. "Guten Tag, möchtest du einen süssen Apfel?"
+
+Schneewittchen biss vorsichtig hinein. Im Apfel war ein Zaubertrank. Schneewittchen wurde so müde, dass es in einen tiefen Zauberschlaf fiel.
+
+Als die Zwerge heimkamen, fanden sie Schneewittchen schlafend. Sie bauten für sie ein Bett aus Glas, damit alle Vögel und Tiere sie sehen konnten.
+
+Eines Tages ritt ein Prinz vorbei. Er sah Schneewittchen und die sieben Zwerge, die traurig dabeistanden. Vorsichtig berührte der Prinz das Glas.
+
+Da rutschte ein Stück vom Zauberapfel aus Schneewittchens Mund. Es öffnete die Augen und lächelte!
+
+"Willst du mit mir kommen?" fragte der Prinz.
+
+Schneewittchen umarmte die Zwerge zum Abschied. "Ich besuche euch bald wieder, versprochen!" Und so tat es. Sie lebten alle glücklich, und der Zauberspiegel flüsterte nie wieder böse Dinge.

--- a/src/lib/storyLibrary.js
+++ b/src/lib/storyLibrary.js
@@ -79,11 +79,15 @@ for (const pkg of collections) {
           const fmBlock = fmMatch ? fmMatch[1] : '';
           const adaptionNameMatch = fmBlock.match(/^adaption:\s*"(.+)"$/m);
           const titleMatch = fmBlock.match(/^title:\s*"(.+)"$/m);
+          const ageMinMatch = fmBlock.match(/^ageMin:\s*(\d+)$/m);
+          const ageMaxMatch = fmBlock.match(/^ageMax:\s*(\d+)$/m);
           const afterFm = fmMatch ? adaptionRaw.slice(fmMatch[0].length) : adaptionRaw;
           const content = afterFm.replace(/^\*\*[^\n]*\*\*\n\n/, '').trimEnd();
           return {
             adaptionName: labelByName.get(name) || (adaptionNameMatch ? adaptionNameMatch[1] : name),
             title: titleMatch ? titleMatch[1] : null,
+            ageMin: ageMinMatch ? parseInt(ageMinMatch[1], 10) : null,
+            ageMax: ageMaxMatch ? parseInt(ageMaxMatch[1], 10) : null,
             content,
           };
         });
@@ -304,9 +308,17 @@ export async function loadAdaptionsByStoryId(storyId) {
         const adaptionName = adaptionNameMatch ? adaptionNameMatch[1] : parts[parts.length - 2];
         const titleMatch = fmBlock.match(/^title:\s*"(.+)"$/m);
         const title = titleMatch ? titleMatch[1] : null;
+        const ageMinMatch = fmBlock.match(/^ageMin:\s*(\d+)$/m);
+        const ageMaxMatch = fmBlock.match(/^ageMax:\s*(\d+)$/m);
         const afterFm = fmMatch ? raw.slice(fmMatch[0].length) : raw;
         const content = afterFm.replace(/^\*\*[^\n]*\*\*\n\n/, '').trimEnd();
-        return { adaptionName, title, content };
+        return {
+          adaptionName,
+          title,
+          ageMin: ageMinMatch ? parseInt(ageMinMatch[1], 10) : null,
+          ageMax: ageMaxMatch ? parseInt(ageMaxMatch[1], 10) : null,
+          content,
+        };
       }),
   );
 

--- a/stories/grimm/aschenputtel/adaptions/contemporary/content.md
+++ b/stories/grimm/aschenputtel/adaptions/contemporary/content.md
@@ -1,0 +1,32 @@
+---
+title: "Aschenputtel"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal ein freundliches Mädchen namens Ella. Sie wohnte mit ihrem Papa, seiner neuen Frau und deren zwei Töchtern in einem grossen Haus. Die neue Frau war nicht nett zu Ella. Ihre Töchter auch nicht. Sie nannten Ella "Aschenputtel", weil sie den ganzen Tag putzen musste und ihre Kleider staubig waren.
+
+Am Abend legte Aschenputtel sich müde neben den warmen Ofen. Aber sie blieb immer freundlich, auch wenn die anderen gemein waren.
+
+Eines Tages hörten alle eine grosse Neuigkeit. Der Prinz machte ein Fest! Alle Mädchen im ganzen Land durften kommen. Die Stiefschwestern freuten sich sehr. "Wir gehen hin!" riefen sie. "Aber du, Aschenputtel, du bleibst zu Hause."
+
+Aschenputtel war traurig. Sie ging in den Garten zu einem kleinen Baum, den sie selber gepflanzt hatte. Oben im Baum sass ein weisses Vögelchen. "Warum weinst du?" fragte das Vögelchen.
+
+"Ich möchte auch zum Fest", sagte Aschenputtel.
+
+Das Vögelchen zwitscherte fröhlich. Plötzlich lag vor Aschenputtel ein wunderschönes Kleid aus Gold und Silber, und daneben zwei glitzernde Schuhe. Sie zog alles an und lief zum Schloss.
+
+Als Aschenputtel im Saal stand, schaute der Prinz sie an. Er war verzaubert. "Darf ich mit dir tanzen?" fragte er. Sie tanzten den ganzen Abend. Der Prinz wollte mit keinem anderen Mädchen tanzen, nur mit ihr.
+
+Als die Uhr spät war, musste Aschenputtel schnell nach Hause. Sie rannte so schnell, dass ein Schuh von ihrem Fuss rutschte und auf der Treppe liegen blieb. Der Prinz fand den Schuh und hob ihn auf.
+
+"Wem dieser Schuh passt, das ist meine Freundin", sagte der Prinz. Er ging von Haus zu Haus. Jedes Mädchen probierte den Schuh. Aber er passte niemandem.
+
+Endlich kam der Prinz auch zu Aschenputtels Haus. Die Stiefschwestern drängten ihre Füsse in den Schuh, doch er war zu klein. "Gibt es hier noch ein Mädchen?" fragte der Prinz.
+
+Aschenputtel trat leise aus der Küche. Sie streifte den Schuh über den Fuss – und er passte genau! Der Prinz lachte vor Freude.
+
+"Komm mit mir ins Schloss", sagte er. "Dort musst du nie mehr putzen."
+
+Und so ging Aschenputtel mit dem Prinzen ins Schloss. Sie lebten glücklich zusammen und blieben Freunde für immer.

--- a/stories/grimm/hansel_und_gretel/adaptions/contemporary/content.md
+++ b/stories/grimm/hansel_und_gretel/adaptions/contemporary/content.md
@@ -1,0 +1,32 @@
+---
+title: "Hänsel und Gretel"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Hänsel und Gretel waren Geschwister. Sie wohnten in einem kleinen Haus am Rand eines grossen Waldes. Manchmal hatten sie nicht viel zu essen, aber sie hatten sich lieb.
+
+Eines Tages gingen Hänsel und Gretel in den Wald, um Beeren zu suchen. Hänsel steckte vorsichtig Brotkrumen in seine Tasche. "Damit wir wieder nach Hause finden", sagte er klug. Unterwegs streute er die Krumen auf den Weg.
+
+Sie pflückten Beeren, lachten und spielten zwischen den Bäumen. Doch als sie zurück wollten, waren die Brotkrumen weg. Ein paar hungrige Vögel hatten sie aufgepickt!
+
+"Wir haben uns verirrt", sagte Gretel. Der Wald wurde dunkel. Hänsel nahm die Hand seiner Schwester.
+
+Plötzlich sahen sie etwas Merkwürdiges zwischen den Bäumen. Ein Haus! Aber was für ein Haus! Die Wände waren aus Lebkuchen. Das Dach bestand aus Schokolade. Die Fenster glitzerten wie Zuckerguss.
+
+Hänsel und Gretel waren hungrig. Ganz vorsichtig brachen sie ein kleines Stück vom Dach ab und probierten. "Mmm, süss!" riefen sie.
+
+Die Tür öffnete sich. Eine alte Frau kam heraus. Sie schaute ein bisschen streng. "Kommt mit rein", sagte sie. "Ich habe Milch und Kuchen für euch."
+
+Die Kinder gingen hinein. Die Frau gab ihnen Essen, aber sie sagte komisch: "Bleibt nur hier, ich brauche Hilfe im Haus."
+
+Gretel merkte schnell, dass die Frau sie gar nicht mehr gehen lassen wollte. "Wir müssen doch nach Hause zum Papa!", sagte sie mutig.
+
+Die Frau murmelte und wollte sie nicht ziehen lassen. Da hatte Gretel eine Idee. "Können Sie mir bitte zeigen, wo der Backofen ist?" fragte sie höflich. Als die Frau sich bückte, um den Ofen zu zeigen, sprangen Hänsel und Gretel durch die Tür und rannten weg, so schnell sie konnten.
+
+Sie liefen und liefen, bis sie einen Bach fanden. Auf dem Bach schwamm eine weisse Ente. "Liebe Ente, hilfst du uns über das Wasser?" fragte Gretel. Die Ente nickte und brachte sie sicher ans andere Ufer.
+
+Am Waldrand stand ihr Papa. Er hatte sie lange gesucht und rief: "Meine Kinder!" Er nahm beide in die Arme und drückte sie fest.
+
+Hänsel und Gretel zeigten ihm Nüsse und Beeren, die sie im Wald gefunden hatten. Von nun an hatten sie immer genug zu essen. Und nie mehr gingen sie ohne den Papa in den Wald.

--- a/stories/grimm/rapunzel/adaptions/contemporary/content.md
+++ b/stories/grimm/rapunzel/adaptions/contemporary/content.md
@@ -1,0 +1,36 @@
+---
+title: "Rapunzel"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal ein Mädchen mit Haaren so lang und gold wie Sonnenstrahlen. Sein Name war Rapunzel. Rapunzel wohnte in einem hohen Turm mitten im Wald. Eine strenge Fee hatte sie vor langer Zeit dorthin gebracht und passte auf sie auf.
+
+Der Turm hatte keine Tür. Nur ein kleines Fenster ganz oben. Wenn die Fee Rapunzel besuchen wollte, rief sie:
+
+"Rapunzel, Rapunzel, lass dein Haar herunter!"
+
+Dann liess Rapunzel ihre goldenen Zöpfe aus dem Fenster fallen, und die Fee kletterte hinauf.
+
+Rapunzel war oft einsam im Turm. Sie sang jeden Tag aus dem Fenster. Die Vögel kamen und sangen mit ihr. Ihre Stimme war so schön wie Musik.
+
+Eines Tages ritt ein junger Prinz durch den Wald. Er hörte Rapunzels Lied und blieb stehen. Noch nie hatte er so etwas Schönes gehört! Er suchte und suchte und fand endlich den hohen Turm.
+
+"Wie kommt man dort hinauf?" fragte er sich. Da versteckte er sich hinter einem Busch und wartete.
+
+Bald kam die Fee und rief: "Rapunzel, Rapunzel, lass dein Haar herunter!" Der Prinz sah, wie die Fee an den Zöpfen hinaufkletterte.
+
+Am nächsten Tag stellte der Prinz sich selbst vor den Turm. Mit freundlicher Stimme rief er:
+
+"Rapunzel, Rapunzel, lass dein Haar herunter!"
+
+Rapunzel liess ihr Haar fallen, und der Prinz stieg hinauf. Sie erschrak ein wenig, doch der Prinz lächelte und sagte: "Ich wollte deine schöne Stimme kennen lernen. Möchtest du mein Freund sein?"
+
+Rapunzel freute sich sehr. Endlich hatte sie jemanden zum Sprechen. Jeden Tag kam der Prinz heimlich vorbei, und die beiden lachten und erzählten sich Geschichten.
+
+Als die Fee davon hörte, wurde sie böse. Sie schnitt Rapunzels lange Zöpfe ab und schickte sie weit weg in einen einsamen Wald. Der Prinz suchte Rapunzel überall. Lange, lange irrte er durch die Wälder.
+
+Eines Morgens hörte er wieder eine Stimme singen. Es war Rapunzel! Er folgte der Stimme und fand sie auf einer Lichtung.
+
+"Da bist du ja!" riefen sie beide. Sie nahmen sich bei der Hand und gingen zusammen zum Schloss des Prinzen. Dort wohnten sie glücklich zusammen, und Rapunzel sang jeden Tag ihr schönstes Lied.

--- a/stories/grimm/rotkaeppchen/adaptions/contemporary/content.md
+++ b/stories/grimm/rotkaeppchen/adaptions/contemporary/content.md
@@ -1,0 +1,46 @@
+---
+title: "Rotkäppchen"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal ein kleines Mädchen, das immer eine rote Mütze trug. Alle nannten es Rotkäppchen.
+
+Eines Morgens sagte die Mama zu Rotkäppchen: "Die Oma ist krank. Bitte bring ihr diesen Korb mit Kuchen und Saft. Aber bleib auf dem Weg, und sprich mit niemand Fremdem."
+
+Rotkäppchen versprach es. Fröhlich lief es los. Die Sonne schien, die Vögel zwitscherten, und am Wegrand blühten bunte Blumen.
+
+Mitten im Wald traf Rotkäppchen einen grossen Wolf. Der Wolf zeigte ein breites Lächeln.
+
+"Guten Tag, kleines Mädchen", sagte der Wolf freundlich. "Wohin gehst du denn?"
+
+Rotkäppchen hatte noch nie einen Wolf gesehen und erschrak nicht. "Ich besuche meine Oma", antwortete es.
+
+"Oh, wie schön", sagte der Wolf. "Schau, dort auf der Wiese, wie bunt die Blumen sind. Warum pflückst du nicht ein paar für die Oma?"
+
+Rotkäppchen dachte: "Ein Blumenstrauss würde Oma freuen!" So ging es von Blume zu Blume und kam immer weiter vom Weg ab.
+
+Der Wolf aber rannte schnell zu Omas Haus. Er klopfte an die Tür. "Oma, mach auf!" Doch die Oma wusste gleich: Das ist nicht Rotkäppchen! Flink versteckte sie sich im Schrank und schloss ihn fest von innen.
+
+Da kam der Wolf herein. Er schaute ins Bett – leer. Er schaute unter den Tisch – leer. "Die Oma muss im Wald sein", brummte er und legte sich wartend ins Bett.
+
+Bald klopfte Rotkäppchen an der Tür. "Ich bin's!" Es trat ein und sah das komische Bild: Etwas Haariges lag unter Omas Decke.
+
+"Oma, warum hast du so grosse Ohren?"
+
+"Damit ich dich besser hören kann!"
+
+"Oma, warum hast du so grosse Augen?"
+
+"Damit ich dich besser sehen kann!"
+
+"Oma, warum hast du so einen grossen Mund?"
+
+"Damit ich—" Und da sprang der Wolf aus dem Bett!
+
+Rotkäppchen schrie laut. Zum Glück kam gerade der Jäger vorbei. Er hörte den Schrei und lief schnell ins Haus. Der Wolf erschrak so sehr, dass er aus dem Fenster sprang und weit, weit weg in den Wald rannte. Dort blieb er.
+
+"Oma! Wo bist du?" rief Rotkäppchen. Ein kleines Klopfen kam aus dem Schrank. Die Oma öffnete die Tür und umarmte Rotkäppchen ganz fest.
+
+Zusammen assen sie den Kuchen und tranken den Saft. Und Rotkäppchen versprach: "Nie mehr gehe ich vom Weg ab, und nie mehr spreche ich mit Fremden im Wald."

--- a/stories/grimm/schneewittchen/adaptions/contemporary/content.md
+++ b/stories/grimm/schneewittchen/adaptions/contemporary/content.md
@@ -1,0 +1,40 @@
+---
+title: "Schneewittchen"
+source: "Grimms Märchen"
+adaption: "Moderne Fassung"
+ageMin: 4
+---
+
+Es war einmal eine Prinzessin mit Haaren schwarz wie die Nacht, Lippen rot wie eine Erdbeere und Haut weiss wie Schnee. Alle nannten sie Schneewittchen. Sie war freundlich zu allen Menschen und auch zu allen Tieren.
+
+Schneewittchens Stiefmutter, die Königin, war sehr stolz. Jeden Morgen schaute sie in ihren Zauberspiegel und fragte:
+
+"Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
+
+Viele Jahre antwortete der Spiegel: "Du, meine Königin." Doch eines Tages sagte der Spiegel:
+
+"Schneewittchen ist tausendmal schöner als Ihr."
+
+Da wurde die Königin sehr neidisch. Sie wollte Schneewittchen fortschicken. Schneewittchen lief in den Wald und lief und lief, bis es müde wurde.
+
+Plötzlich sah es ein winziges Häuschen. Schneewittchen klopfte. Niemand antwortete, also ging es hinein. Im Zimmer standen sieben kleine Stühle, auf dem Tisch sieben kleine Teller, und im Schlafzimmer waren sieben kleine Betten. Schneewittchen ass ein bisschen, trank ein bisschen und legte sich auf das letzte Bett. Schon schlief es fest.
+
+Am Abend kamen die sieben Zwerge von der Arbeit nach Hause. Sie arbeiteten in einem Bergwerk und sammelten funkelnde Steine. "Wer hat auf unseren Stühlen gesessen? Wer hat von unseren Tellern gegessen? Wer liegt in meinem Bett?" fragte der siebte, kleinste Zwerg staunend.
+
+Da wachte Schneewittchen auf. Es erzählte alles. Die Zwerge waren gute Kerle und sagten: "Du darfst bei uns bleiben. Wir passen auf dich auf."
+
+Schneewittchen wohnte nun bei den Zwergen. Sie kochte Suppe, putzte das Häuschen und sang mit den Vögeln.
+
+Die Königin aber hörte vom Spiegel, dass Schneewittchen noch lebte. Sie verkleidete sich als alte Frau und kam mit einem roten Apfel zum Häuschen. "Guten Tag, möchtest du einen süssen Apfel?"
+
+Schneewittchen biss vorsichtig hinein. Im Apfel war ein Zaubertrank. Schneewittchen wurde so müde, dass es in einen tiefen Zauberschlaf fiel.
+
+Als die Zwerge heimkamen, fanden sie Schneewittchen schlafend. Sie bauten für sie ein Bett aus Glas, damit alle Vögel und Tiere sie sehen konnten.
+
+Eines Tages ritt ein Prinz vorbei. Er sah Schneewittchen und die sieben Zwerge, die traurig dabeistanden. Vorsichtig berührte der Prinz das Glas.
+
+Da rutschte ein Stück vom Zauberapfel aus Schneewittchens Mund. Es öffnete die Augen und lächelte!
+
+"Willst du mit mir kommen?" fragte der Prinz.
+
+Schneewittchen umarmte die Zwerge zum Abschied. "Ich besuche euch bald wieder, versprochen!" Und so tat es. Sie lebten alle glücklich, und der Zauberspiegel flüsterte nie wieder böse Dinge.


### PR DESCRIPTION
Adds a "Moderne Fassung" adaption to each of Aschenputtel, Hänsel und
Gretel, Rapunzel, Rotkäppchen, and Schneewittchen — gentle, short,
modern-German retellings suitable for pre-readers. Each adaption
carries `ageMin: 4` in frontmatter, and the variant switcher now hides
adaptions whose age range excludes the configured child age when the
age-filter flag is active.

- Mirrors the contemporary adaptions into the @tweakch/collection-grimm-top5
  workspace (index.js exports, collection.json declarations).
- Extends the adaption parser in src/lib/storyLibrary.js to read
  ageMin/ageMax from adaption frontmatter.
- Filters `adaptionsByParent` through age bounds before passing to
  ReaderView's VariantSwitcher.

https://claude.ai/code/session_01UTiVBZQ9DxYYqxESTPvdzq