### PR TITLE
fix(reader): bold first letter only at real paragraph starts

### DIFF
--- a/components/PageContent.jsx
+++ b/components/PageContent.jsx
@@ -109,14 +109,21 @@ export default function PageContent({
               paras.push({ text: currentPara.join(' '), isComplete: false });
             }
 
+            // The first paragraph on a page is a continuation (not a real start)
+            // when the previous page ended mid-paragraph.
+            const prevPage = currentPage > 0 ? pages[currentPage - 1] : null;
+            const prevLastToken = prevPage?.tokens?.[prevPage.tokens.length - 1];
+            const firstParaIsContinuation = !!prevLastToken && !prevLastToken.isPara;
+
             const ornamentUrl = showIllustrations && illustrations?.ornament;
 
             return paras.map((para, idx) => {
               const isLastOnPage = idx === paras.length - 1;
               const showOrnament = ornamentUrl && para.isComplete && !isLastOnPage;
+              const isParagraphStart = idx > 0 || !firstParaIsContinuation;
               return (
                 <div key={idx}>
-                  <p className="mb-6 first-letter:font-bold">{para.text}</p>
+                  <p className={isParagraphStart ? 'mb-6 first-letter:font-bold' : 'mb-6'}>{para.text}</p>
                   {showOrnament && (
                     <div
                       data-testid="paragraph-ornament"

--- a/tests/unit/PageContent.test.jsx
+++ b/tests/unit/PageContent.test.jsx
@@ -54,6 +54,52 @@ describe('PageContent', () => {
     expect(screen.getByText('Es war einmal.')).toBeInTheDocument();
   });
 
+  it('bolds first letter on paragraph starts', () => {
+    render();
+    const p = screen.getByText('Es war einmal.');
+    expect(p.className).toContain('first-letter:font-bold');
+  });
+
+  it('does not bold first letter when page starts mid-paragraph', () => {
+    // Page 1 ends mid-paragraph (last token isPara=false), so page 2's first
+    // paragraph is a continuation and its first letter must not be bolded.
+    const page1 = {
+      hasTitle: true,
+      tokens: [
+        { word: 'Es', isPara: false },
+        { word: 'war', isPara: false },
+      ],
+    };
+    const page2 = {
+      hasTitle: false,
+      tokens: [
+        { word: 'einmal.', isPara: true },
+        { word: 'Dann', isPara: false },
+        { word: 'geschah', isPara: false },
+        { word: 'etwas.', isPara: true },
+      ],
+    };
+    render({ pages: [page1, page2], currentPage: 1, totalPages: 2 });
+    const continuation = screen.getByText('einmal.');
+    expect(continuation.className).not.toContain('first-letter:font-bold');
+    const newPara = screen.getByText('Dann geschah etwas.');
+    expect(newPara.className).toContain('first-letter:font-bold');
+  });
+
+  it('bolds first letter when previous page ended on a paragraph boundary', () => {
+    const page1 = {
+      hasTitle: true,
+      tokens: [{ word: 'Ende.', isPara: true }],
+    };
+    const page2 = {
+      hasTitle: false,
+      tokens: [{ word: 'Neuer', isPara: false }, { word: 'Absatz.', isPara: true }],
+    };
+    render({ pages: [page1, page2], currentPage: 1, totalPages: 2 });
+    const p = screen.getByText('Neuer Absatz.');
+    expect(p.className).toContain('first-letter:font-bold');
+  });
+
   it('returns null when the current page does not exist', () => {
     const { container } = render({ pages: [], currentPage: 0 });
     expect(container).toBeEmptyDOMElement();


### PR DESCRIPTION
The first <p> on every page was bolded regardless of whether it was a
true paragraph start or a continuation from the previous page. Detect
continuations by inspecting the previous page's last token — when it
doesn't end a paragraph, skip the first-letter:font-bold class on the
current page's first paragraph.

https://claude.ai/code/session_0154s9LCDASv1sjZUoKQZdgS