### PR TITLE
feat(leave-dialog): add restart button for testers and admins

### DIFF
--- a/components/LeaveAppDialog.jsx
+++ b/components/LeaveAppDialog.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useTheme } from '../ui/ThemeContext';
 
-export default function LeaveAppDialog({ open, onConfirm, onCancel }) {
+export default function LeaveAppDialog({ open, onConfirm, onCancel, onRestart }) {
   const { dark: darkMode, hc: highContrast } = useTheme();
   const confirmRef = useRef(null);
 
@@ -46,6 +46,19 @@ export default function LeaveAppDialog({ open, onConfirm, onCancel }) {
           Du bist an der Startseite der App angekommen. Möchtest du die App verlassen und zur Landing Page zurückkehren?
         </p>
         <div className="flex justify-end gap-2">
+          {onRestart && (
+            <button
+              data-testid="leave-app-restart"
+              onClick={onRestart}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                darkMode
+                  ? 'text-amber-200 hover:bg-slate-800 border border-amber-700/40'
+                  : 'text-amber-800 hover:bg-amber-50 border border-amber-200'
+              }`}
+            >
+              App neu starten
+            </button>
+          )}
           <button
             data-testid="leave-app-cancel"
             onClick={onCancel}

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -1045,6 +1045,11 @@ const GrimmMarchenApp = () => {
       open={leavePromptOpen}
       onConfirm={confirmLeave}
       onCancel={cancelLeave}
+      onRestart={
+        role === 'tester' || role === 'admin'
+          ? () => window.location.reload()
+          : undefined
+      }
     />
     {showDebugBadges && <DebugOverlay flagValues={_rawFlagValues} />}
     </GestureDrawerProvider>

--- a/tests/unit/guidelines/__fixtures__/data-testids.txt
+++ b/tests/unit/guidelines/__fixtures__/data-testids.txt
@@ -29,9 +29,7 @@ feed-label
 feed-row
 font-decrease
 font-increase
-gesture-footer-drawer
 gesture-footer-drawer-grid
-gesture-header-drawer
 gesture-header-open-profile
 gesture-header-open-typography
 gesture-home-focus-search
@@ -40,12 +38,11 @@ gesture-home-resume
 gesture-home-toggle-favorites
 gesture-reload-indicator
 gesture-right-bookmarks
-gesture-right-drawer
-gesture-right-drawer-close
 gesture-right-toc
 leave-app-cancel
 leave-app-confirm
 leave-app-dialog
+leave-app-restart
 lock-screen
 menu-toggle
 nav-bar


### PR DESCRIPTION
The leave-app dialog now shows an "App neu starten" button alongside
Bleiben/Verlassen when the current role is tester or admin, letting
them reload the app without leaving /app. Guests, subscribers, and
sales continue to see the standard two-button dialog.