### PR TITLE
feat(stories): expand modern adaptions to match original length

### DIFF
--- a/packages/collection-grimm-top5/stories/aschenputtel/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/aschenputtel/adaptions/contemporary/content.md
@@ -5,28 +5,114 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal ein freundliches Mädchen namens Ella. Sie wohnte mit ihrem Papa, seiner neuen Frau und deren zwei Töchtern in einem grossen Haus. Die neue Frau war nicht nett zu Ella. Ihre Töchter auch nicht. Sie nannten Ella "Aschenputtel", weil sie den ganzen Tag putzen musste und ihre Kleider staubig waren.
+Es war einmal ein freundliches Mädchen namens Ella. Sie wohnte mit ihrem Papa in einem grossen Haus am Rand der Stadt. Das Haus war hell, hatte viele Fenster und einen schönen Garten. Vor dem Haus stand ein alter Haselnussbaum. Unter diesem Baum war das Grab von Ellas Mama, die vor einigen Jahren krank geworden und gestorben war. Jeden Morgen ging Ella zu dem Baum, legte eine Hand auf die Rinde und erzählte ihrer Mama, was sie heute vorhatte. Dann lächelte sie, auch wenn sie manchmal ein bisschen weinen musste.
 
-Am Abend legte Aschenputtel sich müde neben den warmen Ofen. Aber sie blieb immer freundlich, auch wenn die anderen gemein waren.
+Ella hatte von klein auf gern Tiere beobachtet. Wenn ein Eichhörnchen über den Zaun sprang, konnte sie stundenlang zuschauen. Die Vögel im Haselnussbaum kannten sie, und wenn sie aus dem Fenster lehnte, flatterten sie manchmal ganz nahe an sie heran. Der Papa sagte oft mit einem Lächeln: "Unser Ellachen hat ein weiches Herz, das ist ein Geschenk."
 
-Eines Tages hörten alle eine grosse Neuigkeit. Der Prinz machte ein Fest! Alle Mädchen im ganzen Land durften kommen. Die Stiefschwestern freuten sich sehr. "Wir gehen hin!" riefen sie. "Aber du, Aschenputtel, du bleibst zu Hause."
+Ellas Mama hatte ihr kurz vor ihrem Tod etwas Wichtiges gesagt: "Bleib freundlich, liebes Kind. Dann wird alles gut. Und wenn du mich brauchst, dann schau hinauf in den Baum, dort werde ich bei dir sein." Ella hatte das nie vergessen.
 
-Aschenputtel war traurig. Sie ging in den Garten zu einem kleinen Baum, den sie selber gepflanzt hatte. Oben im Baum sass ein weisses Vögelchen. "Warum weinst du?" fragte das Vögelchen.
+Nach einer langen Zeit lernte Ellas Papa eine neue Frau kennen. Er wollte nicht, dass Ella so allein aufwuchs, und auch er selber fühlte sich manchmal einsam. Die neue Frau war ordentlich und elegant und konnte schöne Kuchen backen. "Ich werde mich gut um euch kümmern", sagte sie. Ella versuchte, sich zu freuen.
 
-"Ich möchte auch zum Fest", sagte Aschenputtel.
+Die Frau hatte zwei Töchter, die mit ihnen ins grosse Haus einzogen. Die eine hiess Gertrud, die andere Ines. Beide hatten schöne lockige Haare und teure Kleider, aber sie waren nicht sehr freundlich. Solange der Papa im Zimmer war, benahmen sie sich ganz brav. Aber sobald er das Haus verliess, fing das Ärgern an.
 
-Das Vögelchen zwitscherte fröhlich. Plötzlich lag vor Aschenputtel ein wunderschönes Kleid aus Gold und Silber, und daneben zwei glitzernde Schuhe. Sie zog alles an und lief zum Schloss.
+"Warum sitzt du in unserem Sessel?" sagte die eine. "Das ist jetzt unser Sessel, nicht deiner!"
 
-Als Aschenputtel im Saal stand, schaute der Prinz sie an. Er war verzaubert. "Darf ich mit dir tanzen?" fragte er. Sie tanzten den ganzen Abend. Der Prinz wollte mit keinem anderen Mädchen tanzen, nur mit ihr.
+"Und unsere Puppen sind jetzt auch unsere Puppen", sagte Ines. "Du kannst ja mit dem Besen spielen!"
 
-Als die Uhr spät war, musste Aschenputtel schnell nach Hause. Sie rannte so schnell, dass ein Schuh von ihrem Fuss rutschte und auf der Treppe liegen blieb. Der Prinz fand den Schuh und hob ihn auf.
+Sie lachten, und die Stiefmutter lachte leise mit. Ella sagte dem Papa nichts, denn sie wollte ihn nicht traurig machen. Und er bemerkte selber kaum etwas, weil er den ganzen Tag in der Werkstatt arbeitete.
 
-"Wem dieser Schuh passt, das ist meine Freundin", sagte der Prinz. Er ging von Haus zu Haus. Jedes Mädchen probierte den Schuh. Aber er passte niemandem.
+Von diesem Tag an musste Ella fast alles in Haus und Garten machen. Sie stand früh vor Tag auf. Sie trug Wasser vom Brunnen. Sie machte im Ofen Feuer. Sie wischte den Boden. Sie putzte die Fenster. Sie kochte Suppe und Brei. Sie schälte Kartoffeln. Sie hängte die Wäsche auf. Sie putzte die Schuhe der Stiefschwestern. Sie bürstete ihnen am Morgen die Haare, und am Abend machte sie ihnen heisse Milch mit Honig.
 
-Endlich kam der Prinz auch zu Aschenputtels Haus. Die Stiefschwestern drängten ihre Füsse in den Schuh, doch er war zu klein. "Gibt es hier noch ein Mädchen?" fragte der Prinz.
+Am Abend war sie so müde, dass sie keine Lust mehr hatte, in ihr richtiges Bett zu gehen. Sie setzte sich neben den warmen Ofen, und dort schlief sie dann ein. Weil sie jeden Morgen voller Asche aufwachte, riefen die Stiefschwestern lachend: "Das ist doch kein Mädchen, das ist ein Aschenputtel!" Der Name blieb, und bald nannten sie alle nur noch so. Manchmal schütteten die Stiefschwestern sogar eine Hand voll Linsen in die Asche und sagten gemein: "Les sie wieder raus, Aschenputtel, sonst wird's Ärger geben." Und Aschenputtel setzte sich dann geduldig auf den Boden und las Linsen aus der Asche, Körnchen für Körnchen.
 
-Aschenputtel trat leise aus der Küche. Sie streifte den Schuh über den Fuss – und er passte genau! Der Prinz lachte vor Freude.
+Aschenputtel trug ein graues Kleid und Holzschuhe, doch sie blieb freundlich. Jeden Morgen ging sie zu dem Haselnussbaum am Grab ihrer Mama. Manchmal kam ein weisses Vöglein auf einen Ast und schaute Aschenputtel mit glänzenden Augen an. "Sei gegrüsst, kleines Vöglein", sagte Aschenputtel. "Bitte sag meiner Mama, dass ich an sie denke." Das Vöglein zwitscherte leise und flog davon.
 
-"Komm mit mir ins Schloss", sagte er. "Dort musst du nie mehr putzen."
+Einmal sollte der Papa zu einem grossen Markt in der Nachbarstadt fahren. Er fragte alle drei Mädchen, was er ihnen mitbringen solle.
 
-Und so ging Aschenputtel mit dem Prinzen ins Schloss. Sie lebten glücklich zusammen und blieben Freunde für immer.
+"Ein schönes rosa Kleid!" rief Gertrud.
+
+"Goldene Ohrringe und eine Kette!" rief Ines.
+
+"Und du, Aschenputtel?" fragte der Papa.
+
+Aschenputtel überlegte kurz. "Bring mir bitte den ersten Zweig mit, der dir auf dem Heimweg an den Hut stösst."
+
+Der Papa lachte. "Das ist ja ein kleiner Wunsch." Auf dem Heimweg ritt er durch einen grünen Busch, und ein zarter Haselzweig streifte ihm den Hut. Er brach ihn vorsichtig ab und nahm ihn mit. Zu Hause verteilte er die Geschenke. Gertrud und Ines hüpften vor Freude. Aschenputtel nahm den Haselzweig in beide Hände und sagte leise: "Danke, Papa."
+
+Am selben Abend ging sie zum Grab ihrer Mama und pflanzte den Zweig in die weiche Erde. Sie weinte ein wenig, und ihre Tränen tropften auf die Erde. In der Nacht begann der Zweig zu wachsen. Aus dem kleinen Zweig wurde ein kleiner Busch, und aus dem Busch wurde mit der Zeit ein hoher Baum. Das weisse Vöglein, das Aschenputtel oft besucht hatte, liebte den neuen Baum sofort und nistete darin.
+
+Eines Tages kam eine grosse Neuigkeit in die Stadt. Der Prinz im Schloss wollte heiraten. Dazu machte der König ein grosses Fest. Alle jungen Mädchen im ganzen Land durften drei Abende lang ins Schloss kommen. Der Prinz wollte dort seine zukünftige Freundin finden.
+
+Die Stiefschwestern waren ausser sich vor Freude. "Schnell, Aschenputtel!" riefen sie. "Kämm uns die Haare! Putz uns die Schuhe! Wir müssen die schönsten Mädchen auf dem Fest sein!"
+
+Aschenputtel kämmte, bürstete und putzte. Dabei dachte sie leise: "Ich würde auch so gerne tanzen." Sie nahm all ihren Mut zusammen und fragte die Stiefmutter: "Darf ich auch mit aufs Schloss?"
+
+Die Stiefmutter schaute sie streng an. "Du? Mit deinem grauen Kleid und den Holzschuhen? Du würdest nur ausgelacht. Nein, Aschenputtel. Du bleibst zu Hause."
+
+Doch Aschenputtel bettelte so lieb, dass die Stiefmutter endlich sagte: "Also gut. Ich schütte dir eine Schüssel Linsen in die Asche. Wenn du sie in zwei Stunden wieder ausgelesen hast, darfst du mitkommen." Und schon leerte sie eine ganze Schüssel Linsen in den Kamin.
+
+Aschenputtel setzte sich auf den Boden und schaute in die Asche. "Das schaffe ich nie allein", flüsterte sie. Da lief sie schnell hinaus zum Haselnussbaum und rief: "Liebe Vöglein, bitte helft mir!"
+
+Im Nu flogen zwei Tauben, ein paar Spatzen und sogar ein rotes Rotkehlchen durchs Fenster. Sie pickten pick, pick, pick – die guten Linsen kamen in die Schüssel, die schlechten blieben in der Asche. Schon nach einer Stunde war alles sauber. "Danke, danke!" rief Aschenputtel. Die Vögel zwitscherten und flogen wieder hinaus.
+
+Voller Freude trug sie die Schüssel zu der Stiefmutter. "Ich habe alle Linsen ausgelesen!"
+
+Aber die Stiefmutter verzog das Gesicht. "Das geht viel zu schnell. Du musst geschummelt haben. Ich schütte dir noch zwei Schüsseln in die Asche, und wenn du die in einer Stunde auch ausgelesen hast, darfst du mit." Sie schüttete zwei volle Schüsseln in die Asche und lachte hämisch.
+
+Aschenputtel lief wieder in den Garten und rief die Vögel. Diesmal kamen noch mehr. Die ganze Küche war voller Flügel, Schnäbel und leisem Gurren. Pick, pick, pick – die Linsen flogen in die Schüsseln. In einer halben Stunde war alles fertig.
+
+"Fertig!" rief Aschenputtel und stellte die Schüsseln vor die Stiefmutter.
+
+Aber die Stiefmutter verzog das Gesicht erst recht. "Das gilt nicht. Du hast kein Kleid und keine Tanzschuhe. Du bleibst hier." Und schon eilte sie mit ihren zwei stolzen Töchtern zur Kutsche.
+
+Aschenputtel wischte sich eine Träne ab. Dann ging sie langsam in den Garten zu ihrem Haselnussbaum. Sie schaute hinauf und sprach leise: "Liebes Bäumchen, schüttel dich, wirf ein schönes Kleid für mich." Da raschelten die Blätter, und aus dem Baum fiel ein wunderschönes Kleid aus Gold und Silber. Daneben lagen zwei glitzernde Pantoffeln, fein wie gesponnen aus Sternenlicht.
+
+Aschenputtel zog das Kleid an. Dann lief sie zum Schloss. Im grossen Saal strahlten Kerzen und Lichter. Alle tanzten. Als Aschenputtel hereintrat, wurde es plötzlich ganz still. Sogar der Prinz blieb stehen.
+
+"Wer ist diese schöne Königstochter?" fragten die Leute. Keiner erkannte Aschenputtel, nicht einmal die Stiefschwestern. Der Prinz kam zu ihr, lachte und sagte: "Darf ich mit dir tanzen?"
+
+Sie tanzten den ganzen Abend miteinander. Kam ein anderes Mädchen und wollte den Prinzen auffordern, sagte er freundlich: "Entschuldige, ich tanze heute nur mit ihr."
+
+Als die grosse Uhr im Saal elfmal schlug, sagte Aschenputtel: "Ich muss nach Hause." Sie lief schnell aus dem Saal und verschwand im Dunkeln, bevor der Prinz fragen konnte, wer sie war. Zu Hause legte sie das Kleid und die Pantoffeln unter den Baum. Das Vöglein nahm sie mit. Da sass Aschenputtel wieder im grauen Kleid neben dem Ofen, und niemand ahnte etwas.
+
+Am zweiten Abend gab es wieder ein Fest. Wieder mussten die Stiefschwestern gekämmt und geputzt werden. Wieder beschwerte sich Gertrud, dass ihr Haar zu kraus sei, und Ines, dass die Schleife zu klein sei. Und wieder eilten sie endlich mit der Stiefmutter zur Kutsche.
+
+Als das Haus still war, ging Aschenputtel zum Haselnussbaum. "Liebes Bäumchen, schüttel dich, wirf ein noch schöneres Kleid für mich." Und schon fiel ein Kleid herab, das noch heller strahlte als das erste, mit kleinen silbernen Sternen darauf.
+
+Als Aschenputtel im Saal erschien, blieb dem Prinzen der Mund offen. "Du bist gekommen!" rief er. Den ganzen Abend tanzte er nur mit ihr. "Wer bist du? Woher kommst du?" fragte er. Aber Aschenputtel lächelte nur und drehte sich mit ihm im Kreis. Die Kerzen flackerten, die Geigen spielten, und Aschenputtel war so glücklich, dass sie für einen Moment ganz vergass, dass sie Aschenputtel hiess.
+
+Kurz bevor die Uhr wieder elf schlug, lief sie weg. Der Prinz rannte ihr nach, aber Aschenputtel sprang in den Schlossgarten und versteckte sich geschickt hinter einem grossen Birnbaum. Der Prinz lief an ihr vorbei, ohne sie zu sehen. Dann schlüpfte sie nach Hause, legte das Kleid und die Pantoffeln wieder zurück unter den Haselnussbaum, und als die Stiefmutter mit den Schwestern heimkam, sass Aschenputtel längst wieder im grauen Kittel am Ofen.
+
+Am dritten Abend war Aschenputtel wieder ganz allein im Haus. "Liebes Bäumchen, schüttel dich, wirf das allerschönste Kleid für mich." Und was vom Baum herabfiel, war so prächtig, dass Aschenputtel fast die Augen zukneifen musste. Die Pantoffeln waren aus reinem Gold.
+
+Im Schloss wartete der Prinz schon an der Tür. Diesmal hatte er eine List. Heimlich hatte er den Diener bitten lassen, die grosse Treppe mit ein bisschen klebrigem Honig zu bestreichen. "Wenn sie wegläuft", dachte der Prinz, "dann verliert sie vielleicht einen Schuh, und dann finde ich sie wieder."
+
+Sie tanzten und lachten. Aschenputtel hatte so viel Freude wie noch nie. Doch als die Uhr zu schlagen begann, sprang sie auf und lief zur Treppe. Der klebrige Honig hielt ihren linken Pantoffel fest – und der Schuh blieb auf der Stufe liegen! Aschenputtel rannte einfach weiter. Der Prinz hob den goldenen Pantoffel auf und drückte ihn an sein Herz.
+
+Am nächsten Morgen liess der Prinz in der ganzen Stadt ausrufen: "Das Mädchen, dem dieser goldene Schuh passt, das soll meine Freundin werden!"
+
+Die Leute lachten und staunten. Die Stiefmutter hörte den Ausruf und klatschte in die Hände. "Das ist unsere Chance!" rief sie.
+
+Der Prinz ritt von Haus zu Haus. Jedes Mädchen durfte den Schuh anprobieren. Eines hatte zu dicke Zehen, eines zu breite Fersen, und manchen rutschte der Schuh gleich wieder vom Fuss. Keinem passte der goldene Pantoffel.
+
+Endlich kam der Prinz auch zu Aschenputtels Haus. Die grosse Stiefschwester Gertrud setzte sich auf den Stuhl und drückte den Fuss in den Schuh. "Ich bin die Richtige, ich!" Aber ihr Fuss war zu gross. Die Zehe passte nicht hinein, egal wie sehr sie sich anstrengte. Die Stiefmutter flüsterte: "Drück stärker, mein Kind!" Doch es half nichts. Gertrud stand enttäuscht auf.
+
+Nun kam Ines. Sie zwängte und drückte, aber ihre Ferse war zu gross. Sie versuchte, auf den Zehen zu wackeln, aber der Schuh fiel wieder ab. Auch sie konnte den Schuh nicht anziehen. Sie warf ihn ärgerlich auf den Boden.
+
+Der Prinz fragte ernst: "Habt ihr noch eine andere Tochter?"
+
+Die Stiefmutter schüttelte schnell den Kopf. "Nein, nur ein kleines Aschenputtel, aber die ist ganz schmutzig und kann unmöglich gemeint sein."
+
+"Ich möchte sie trotzdem sehen", sagte der Prinz.
+
+Aschenputtel wurde aus der Küche gerufen. Sie wusch sich die Hände und kam leise herein. Sie setzte sich auf den Schemel, zog den Holzschuh aus und schlüpfte in den goldenen Pantoffel. Er passte genau, wie für sie gemacht.
+
+Als sie aufstand und dem Prinzen ins Gesicht schaute, lachte er vor Freude. "Das ist sie! Das ist die Tänzerin aus dem Schloss!"
+
+Die Stiefmutter und die zwei Schwestern wurden ganz blass. Aber niemand schimpfte mit ihnen. Aschenputtel sagte freundlich: "Heute ist ein schöner Tag. Bitte seid nicht mehr böse." Dann ging sie mit dem Prinzen zum Pferd. Als sie am Haselnussbaum vorbeikamen, setzten sich zwei weisse Tauben auf Aschenputtels Schultern. Sie gurrten leise, so als ob die Mama aus dem Himmel zurückgrüssen würde.
+
+Im Schloss wurde ein grosses Fest gefeiert. Es gab Musik, Tanz und viele Kinder aus der ganzen Stadt. Aschenputtel trug ihr goldenes Kleid, aber am liebsten zog sie später ein einfaches blaues an, in dem sie gut durch den Schlossgarten rennen konnte.
+
+Die Stiefschwestern wurden mit der Zeit etwas freundlicher, weil Aschenputtel ihnen immer wieder verzieh. Und wenn Aschenputtel zu Besuch bei ihrem alten Zuhause war, ging sie zuerst zum Haselnussbaum. Sie legte eine Hand auf die Rinde und sagte leise: "Danke, liebe Mama."
+
+Im Baum zwitscherte jedes Mal ein kleines weisses Vöglein.

--- a/packages/collection-grimm-top5/stories/hansel_und_gretel/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/hansel_und_gretel/adaptions/contemporary/content.md
@@ -5,28 +5,114 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Hänsel und Gretel waren Geschwister. Sie wohnten in einem kleinen Haus am Rand eines grossen Waldes. Manchmal hatten sie nicht viel zu essen, aber sie hatten sich lieb.
+Am Rand eines grossen, dunklen Waldes stand ein kleines Haus aus Holz. In diesem Haus wohnte ein Holzfäller mit seinen zwei Kindern. Der Junge hiess Hänsel, und seine Schwester hiess Gretel. Die beiden hatten sich sehr lieb. Wenn es regnete, sassen sie am Fenster und schauten den Tropfen zu. Wenn die Sonne schien, rannten sie zwischen die Bäume und suchten Tannzapfen. Im Sommer pflückten sie Himbeeren, im Herbst sammelten sie Pilze, und im Winter bauten sie kleine Schneemänner vor der Tür. Sie waren nicht reich, aber sie hatten einander.
 
-Eines Tages gingen Hänsel und Gretel in den Wald, um Beeren zu suchen. Hänsel steckte vorsichtig Brotkrumen in seine Tasche. "Damit wir wieder nach Hause finden", sagte er klug. Unterwegs streute er die Krumen auf den Weg.
+Ihre richtige Mama war schon vor langer Zeit gestorben. Der Papa hatte dann eine neue Frau geheiratet, damit Hänsel und Gretel nicht ganz ohne Mutter aufwuchsen. Die neue Frau war nicht gemein, aber sie war auch nicht besonders freundlich. Sie hatte keine Geduld mit Kindern und seufzte oft. Der Papa liebte seine Kinder über alles. Er war ein guter Mann, aber er war auch ein bisschen ängstlich, und manchmal wagte er es nicht, der Stiefmutter zu widersprechen.
 
-Sie pflückten Beeren, lachten und spielten zwischen den Bäumen. Doch als sie zurück wollten, waren die Brotkrumen weg. Ein paar hungrige Vögel hatten sie aufgepickt!
+Eines Tages wurde es im Dorf schwierig. Die Ernte war schlecht. Die Felder waren leer. Im Bach gab es fast keine Fische. In vielen Häusern fehlte das Brot. Auch beim Holzfäller stand bald nur noch ein kleiner trockener Laib auf dem Tisch. Die Stiefmutter machte ein sorgenvolles Gesicht. "Wir haben nicht genug für alle vier", sagte sie am Abend leise zum Vater. "Wir müssen etwas tun."
 
-"Wir haben uns verirrt", sagte Gretel. Der Wald wurde dunkel. Hänsel nahm die Hand seiner Schwester.
+Der Papa schwieg lange. "Was meinst du?"
 
-Plötzlich sahen sie etwas Merkwürdiges zwischen den Bäumen. Ein Haus! Aber was für ein Haus! Die Wände waren aus Lebkuchen. Das Dach bestand aus Schokolade. Die Fenster glitzerten wie Zuckerguss.
+"Wir bringen die Kinder morgen in den Wald", flüsterte die Stiefmutter. "Ganz tief hinein. Dort finden sie schon etwas zu essen. Besser, sie lernen selbst für sich zu sorgen, als dass wir alle vier hungern."
 
-Hänsel und Gretel waren hungrig. Ganz vorsichtig brachen sie ein kleines Stück vom Dach ab und probierten. "Mmm, süss!" riefen sie.
+"Aber sie sind doch noch so klein", sagte der Papa und rieb sich die Augen. Doch die Stiefmutter liess nicht locker, und am Ende gab der Papa ihr traurig nach.
 
-Die Tür öffnete sich. Eine alte Frau kam heraus. Sie schaute ein bisschen streng. "Kommt mit rein", sagte sie. "Ich habe Milch und Kuchen für euch."
+Hänsel und Gretel lagen hellwach in ihrem Bett und hörten alles. Gretel bekam feuchte Augen. "Hänsel, was sollen wir machen?"
 
-Die Kinder gingen hinein. Die Frau gab ihnen Essen, aber sie sagte komisch: "Bleibt nur hier, ich brauche Hilfe im Haus."
+"Keine Sorge, kleine Schwester", flüsterte Hänsel. "Ich habe eine Idee." Als die Erwachsenen endlich eingeschlafen waren, schlich Hänsel leise aus dem Haus. Der Mond schien hell wie eine grosse silberne Münze. Vor der Tür glitzerten weisse Kieselsteine wie kleine Sterne. Hänsel steckte sich die Taschen voll Kieselsteine. Er sammelte so viele, wie nur in seine beiden Hosentaschen und in die Jackentasche passten. Dann schlich er zurück, legte sich zu seiner Schwester und flüsterte: "Schlaf gut. Ich passe auf uns auf."
 
-Gretel merkte schnell, dass die Frau sie gar nicht mehr gehen lassen wollte. "Wir müssen doch nach Hause zum Papa!", sagte sie mutig.
+Am Morgen, noch bevor die Sonne ganz aufgegangen war, weckte die Stiefmutter sie. "Steht auf, ihr Faulpelze! Wir gehen in den Wald Holz holen." Sie gab jedem Kind ein kleines Stück Brot. "Das ist für den Mittag. Esst es nicht vorher auf."
 
-Die Frau murmelte und wollte sie nicht ziehen lassen. Da hatte Gretel eine Idee. "Können Sie mir bitte zeigen, wo der Backofen ist?" fragte sie höflich. Als die Frau sich bückte, um den Ofen zu zeigen, sprangen Hänsel und Gretel durch die Tür und rannten weg, so schnell sie konnten.
+Die Familie machte sich auf den Weg. Immer wieder blieb Hänsel stehen und schaute zurück zum Haus. "Was guckst du denn dauernd, Hänsel?" fragte der Vater.
 
-Sie liefen und liefen, bis sie einen Bach fanden. Auf dem Bach schwamm eine weisse Ente. "Liebe Ente, hilfst du uns über das Wasser?" fragte Gretel. Die Ente nickte und brachte sie sicher ans andere Ufer.
+"Ich schau nur zum weissen Kätzchen auf dem Dach, das mir Tschüss winkt", sagte Hänsel.
 
-Am Waldrand stand ihr Papa. Er hatte sie lange gesucht und rief: "Meine Kinder!" Er nahm beide in die Arme und drückte sie fest.
+"Ach Unsinn", sagte die Stiefmutter. "Das ist doch nur die Morgensonne auf dem Schornstein." Dabei warf Hänsel heimlich einen Kieselstein nach dem anderen auf den Weg. Klick. Klick. Klick. Immer wenn niemand schaute.
 
-Hänsel und Gretel zeigten ihm Nüsse und Beeren, die sie im Wald gefunden hatten. Von nun an hatten sie immer genug zu essen. Und nie mehr gingen sie ohne den Papa in den Wald.
+Im tiefen Wald machte der Vater ein kleines Feuer aus Ästen. "Bleibt hier sitzen und wärmt euch", sagte er leise, und seine Stimme zitterte ein wenig. "Wir gehen nur Holz hacken und kommen gleich zurück." Dann ging er mit der Stiefmutter weg.
+
+Hänsel und Gretel warteten. Sie assen ihr trockenes Brot in kleinen Bissen, damit es länger reichte. Die Sonne wanderte. In der Ferne hörten sie Schläge wie von einer Axt. Aber in Wirklichkeit war es nur ein loser Ast, den die Stiefmutter an einen Baum gebunden hatte, damit er im Wind hin- und herschlug. Vögel riefen. Schmetterlinge flatterten. Niemand kam zurück. Irgendwann fielen den Kindern die Augen zu, und sie schliefen am Feuer ein. Als sie aufwachten, war es schon dunkel.
+
+Gretel begann zu weinen. "Hänsel, wir sind allein!"
+
+"Hab keine Angst", sagte Hänsel und nahm ihre Hand. "Warte, bis der Mond aufgeht." Und wirklich, als der Mond durch die Baumkronen leuchtete, blitzten unten auf dem Waldboden die Kieselsteine. Sie schimmerten wie kleine Sterne. Hänsel und Gretel gingen von Stein zu Stein, Hand in Hand, die ganze Nacht hindurch. Als die Sonne wieder aufging, standen sie vor ihrem eigenen Haus.
+
+Der Vater erschrak fast vor Freude, als er sie sah. Er riss die Tür auf, lief ihnen entgegen und umarmte beide Kinder ganz fest. "Meine Kinder! Ich habe die ganze Nacht nicht geschlafen! Ich dachte schon, ich sehe euch nie wieder!" Er hatte Tränen in den Augen. Auch die Stiefmutter war überrascht – aber nicht ganz glücklich. Sie sagte nur spitz: "Da seid ihr ja endlich. Das nächste Mal bleibt ihr nicht so lange weg."
+
+Eine Weile ging es wieder. Das bisschen Brot reichte für einige Tage. Hänsel und Gretel halfen, wo sie konnten: Sie sammelten Tannzapfen für das Feuer, und Gretel flickte kleine Löcher im Hemd des Vaters. Aber das Essen wurde immer weniger. Wieder schmolzen die Vorräte zusammen. Eines Abends hörten die Kinder die Stiefmutter wieder leise reden: "Morgen müssen sie mit uns weiter in den Wald, noch tiefer diesmal. Diesmal sollen sie den Weg nicht mehr finden." Der Vater seufzte, aber er sagte nichts. Er wagte es nicht, ihr zu widersprechen.
+
+Hänsel wollte wieder Kieselsteine holen. Er stand leise auf und ging zur Tür. Doch die Tür war abgeschlossen! Hänsel drückte an der Klinke. Nichts. Er seufzte und kroch zurück ins Bett. "Keine Angst", sagte er zu Gretel. "Morgen denke ich mir etwas anderes aus."
+
+Am nächsten Morgen bekam jedes Kind ein kleines Stück Brot für den Weg. Das Brot war diesmal noch kleiner als beim letzten Mal. Hänsel steckte es in die Tasche, aber er ass es nicht. Stattdessen krümelte er es heimlich: er brach kleine Bröckchen ab und liess sie auf dem Weg fallen. Bröckchen um Bröckchen, sehr vorsichtig, damit niemand es sah.
+
+"Hänsel, was bleibst du denn immer stehen?" fragte der Vater.
+
+"Ich schau nur zu meinem Täubchen auf dem Dach", antwortete Hänsel.
+
+"Das ist dein Täubchen nicht", zischte die Stiefmutter. "Das ist die Morgensonne auf dem Schornstein. Geh weiter!"
+
+Es wurde diesmal viel länger gelaufen. Die Bäume wurden immer dicker, und der Pfad wurde immer schmaler. Schliesslich kamen sie an eine Stelle, an der Hänsel und Gretel noch nie gewesen waren. Hier machte der Vater wieder ein Feuer. "Ruht euch aus", sagte er leise. "Wir kommen bald zurück." Aber Hänsel merkte an seiner Stimme, dass er traurig war.
+
+Die Kinder warteten. Sie teilten sich das letzte Stück Brot, das Gretel noch hatte. Dann schliefen sie ein. Als sie aufwachten, war es dunkle Nacht. "Schnell", sagte Hänsel, "wir folgen den Brotkrumen." Aber – oh weh! Die Brotkrumen waren weg. Kleine Waldvögel hatten jeden Krümel aufgepickt. Auf dem Weg lag nur noch Erde.
+
+Gretel setzte sich auf einen Baumstamm. "Wir sind verloren, Hänsel."
+
+Hänsel setzte sich neben sie. "Wir finden einen Weg", sagte er. "Wir halten zusammen. Immer." Sie gingen los, einen Tag, dann noch einen Tag. Sie assen ein paar wilde Beeren. Sie tranken aus einem kleinen Bach. Ihre Füsse wurden müde, ihre Augen schwer. Manchmal hörte Gretel ein Rascheln und hatte Angst. Hänsel drückte dann ihre Hand.
+
+Am dritten Morgen sahen sie ein weisses Vögelchen auf einem Ast. Es sang ein so fröhliches Lied, dass Hänsel und Gretel stehen blieben, um zuzuhören. "Schau!" rief Gretel und zeigte mit dem Finger nach oben. Das Vögelchen schaute sie mit freundlichen Augen an, flog ein Stück, landete auf dem nächsten Ast und schaute wieder zurück, als ob es sagen wollte: "Kommt mit." Die Kinder liefen hinterher. Das Vögelchen hüpfte von Baum zu Baum, und Hänsel und Gretel folgten ihm immer tiefer in den Wald. Nach einer Weile kamen sie auf eine helle Lichtung. Und dort – ein kleines Haus! Aber was für ein Haus!
+
+Die Wände waren aus Lebkuchen. Das Dach war aus Schokolade. Die Fenster glitzerten wie Zuckerguss. An der Tür hingen Gummibärchen und Bonbons. Hänsel und Gretel schauten einander mit grossen Augen an.
+
+"Oh!" rief Hänsel. "Ich habe so Hunger!"
+
+"Ich auch!" rief Gretel.
+
+Sie brachen ganz vorsichtig ein kleines Stück vom Dach ab. Süss! Herrlich süss! Sie kauten und kauten. Hänsel griff nach einem Stück Schokoladenziegel, und Gretel knabberte an einer Fensterscheibe aus Zucker. Plötzlich hörten sie eine feine Stimme aus dem Haus rufen:
+
+"Knusper, knusper, knäuschen, wer knuspert an meinem Häuschen?"
+
+Hänsel und Gretel wussten keine Antwort und riefen einfach lustig: "Der Wind, der Wind, das himmlische Kind!" Sie assen weiter.
+
+Da öffnete sich die Tür, und eine alte Frau kam heraus. Sie stützte sich auf einen krummen Stock. Sie trug eine grosse Brille, ihre Haare waren weiss, und ihr Lächeln war ein wenig komisch. "Ei, ei, liebe Kinder", sagte sie mit süsser Stimme. "Habt ihr Hunger? Kommt herein, ich habe noch viel mehr zu essen."
+
+Hänsel und Gretel folgten ihr. Im Haus roch es wunderbar nach Pfannkuchen und Apfelmus. Auf dem Tisch standen Milch, Kekse und Obst. Die Kinder assen sich satt. Dann zeigte ihnen die Frau zwei kleine Betten. "Schlaft", sagte sie. "Hier seid ihr sicher."
+
+In der Nacht aber konnte Gretel nicht gut schlafen. Sie hatte ein komisches Gefühl. Die alte Frau murmelte im Nebenzimmer seltsame Worte. Am Morgen war plötzlich alles anders. Die freundliche Frau lachte gar nicht mehr. Sie schob Hänsel in ein kleines Zimmer mit einer Gittertür. "Du bleibst hier, Junge. Iss schön alles auf. Und du, Mädchen, du machst im Haus sauber. Hol Wasser, koch für deinen Bruder, damit er gross und satt wird!"
+
+Gretel begriff: Die Frau war eine Hexe. Sie wollte Hänsel nicht mehr gehen lassen. Gretels Herz schlug schnell. Aber sie zeigte es nicht. "Ja, ich helfe", sagte sie höflich und machte sich an die Arbeit.
+
+Jeden Morgen kam die Hexe zu Hänsels Türchen und rief: "Streck mal einen Finger raus. Ich will sehen, ob du schon kräftig bist."
+
+Hänsel war klug. Statt seines Fingers streckte er einen kleinen dünnen Zweig heraus, den er auf dem Boden gefunden hatte. Die Hexe sah nicht gut – Hexen haben oft schlechte Augen. Sie befühlte den Zweig und dachte: "Ach, der Junge ist ja immer noch so dünn! Das kann doch nicht sein." So ging Tag um Tag, dann Woche um Woche. Hänsel bekam jeden Morgen ein gutes Frühstück mit Milch, Pfannkuchen und Apfelkompott, und Gretel bekam nur harte Brotrinden und ein paar Krebsschalen. Gretel war manchmal so müde, dass sie sich beim Putzen hinsetzen und kurz ausruhen musste, aber sie dachte jeden Tag an Hänsel und machte weiter.
+
+Nach einigen Wochen wurde die Hexe ungeduldig. "Heute morgen", rief sie, "backe ich grosse Brote im Ofen. Und danach ist Schluss mit dem Warten!" Sie heizte den Backofen richtig ein. Flammen züngelten heraus.
+
+"Mädchen", sagte die Hexe, "geh mal hinein und schau nach, ob der Ofen heiss genug ist."
+
+Gretel schaute den Ofen an. Sie spürte: Das ist eine Falle. Die Hexe wollte sie in den Ofen schieben. Aber Gretel tat so, als wäre sie ganz dumm. "Oh, liebe Frau", sagte sie unschuldig, "ich weiss gar nicht, wie das geht. Wie kommt man da hinein? Zeig es mir bitte."
+
+"Dummes Mädchen!" schnaufte die Hexe. "Schau her, so!" Sie beugte sich weit vor, bis fast ihr ganzer Kopf im Ofen war.
+
+Gretel atmete tief durch. Dann gab sie der Hexe einen ganz kleinen Schubs, und die Hexe rutschte in den Ofen hinein. Gretel schlug die Ofentür zu und schob einen Riegel davor. Die Hexe konnte nicht mehr heraus. So etwas Böses hätte sie mit den Kindern tun wollen, und nun blieb sie dort.
+
+Gretel rannte zu Hänsels Türchen. "Hänsel, Hänsel, die Hexe ist weg, wir sind frei!" Sie öffnete die Gittertür, und Hänsel sprang heraus wie ein junger Vogel, der aus dem Käfig darf. Die beiden fielen sich in die Arme, lachten und weinten zugleich.
+
+Dann schauten sie sich im Haus der Hexe um. Überall standen kleine Kisten. In den Kisten waren Perlen, bunte Steine und sogar richtige Goldstücke. "Die nehmen wir mit", sagte Hänsel. "Die sind besser als Kieselsteine." Sie füllten sich die Taschen und Gretels Schürze.
+
+Dann machten sie sich auf den Weg nach Hause. Sie wanderten stundenlang durch den Wald. Am Mittag assen sie Beeren und tranken aus einem kleinen Bach. Gretel pflückte einen Strauss Wiesenblumen für den Papa. Nach einer Weile kamen sie an einen breiten Bach. "Wie kommen wir da hinüber?" fragte Hänsel. Es gab keine Brücke, keinen Steg und kein Boot.
+
+Da sahen sie eine weisse Ente auf dem Wasser. Sie hatte einen freundlichen Blick. "Liebes Entchen", sagte Gretel, "kannst du uns bitte über das Wasser tragen?"
+
+"Quak!" machte die Ente und schwamm ans Ufer. Hänsel setzte sich als Erster auf ihren Rücken, und die Ente brachte ihn sicher auf die andere Seite. Dann kam sie zurück und holte auch Gretel. "Danke, liebes Entchen", riefen die Kinder und winkten.
+
+Der Weg wurde wieder vertrauter. Bäume, die sie schon kannten. Pfade, die sie schon gegangen waren. Und endlich – da war es! Das kleine Holzhaus am Waldrand.
+
+Sie rannten auf die Tür zu. "Papa! Papa!"
+
+Der Vater öffnete und schrie fast vor Freude. Er umarmte Hänsel und Gretel ganz fest. "Meine Kinder! Ich habe jeden Tag an euch gedacht! Ich habe euch gesucht und gesucht!" Er hatte Tränen in den Augen. Die Stiefmutter war nicht mehr da. Sie war in der Zwischenzeit weggezogen.
+
+Gretel schüttelte die Schürze aus. Perlen und kleine Goldstücke rollten über den Boden. Hänsel leerte seine Taschen. "Jetzt haben wir genug", sagte er. "Jetzt müssen wir nie mehr hungern."
+
+Der Vater lachte und weinte zugleich. Er setzte die Kinder an den Tisch und kochte eine warme Suppe. Draussen ging die Sonne unter, und durch das Fenster kam ein leises Zwitschern. Auf dem Fensterbrett sass ein kleines weisses Vögelchen. Vielleicht war es dasselbe, das sie damals zu dem Lebkuchenhaus gebracht hatte. Oder ein anderes. Es zwitscherte fröhlich – so als würde es sagen: "Jetzt seid ihr daheim."
+
+Von da an gingen Hänsel und Gretel nie wieder allein in den tiefen Wald. Sie wanderten nur noch mit dem Papa, und wenn Gretel manchmal ein bisschen Angst bekam, nahm Hänsel ihre Hand und flüsterte: "Wir halten zusammen. Immer."

--- a/packages/collection-grimm-top5/stories/rapunzel/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/rapunzel/adaptions/contemporary/content.md
@@ -5,32 +5,94 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal ein Mädchen mit Haaren so lang und gold wie Sonnenstrahlen. Sein Name war Rapunzel. Rapunzel wohnte in einem hohen Turm mitten im Wald. Eine strenge Fee hatte sie vor langer Zeit dorthin gebracht und passte auf sie auf.
+Vor vielen Jahren lebten einmal ein Mann und eine Frau in einem kleinen Haus am Rand eines Dorfes. Sie hatten sich lieb, und sie wünschten sich nichts sehnlicher als ein Kind. Aber lange, lange blieb dieser Wunsch unerfüllt.
 
-Der Turm hatte keine Tür. Nur ein kleines Fenster ganz oben. Wenn die Fee Rapunzel besuchen wollte, rief sie:
+Hinter ihrem Haus stand eine hohe Mauer. Dahinter lag ein wunderschöner Garten. In diesem Garten wuchsen die buntesten Blumen und die saftigsten Kräuter. Der Garten gehörte einer alten Zauberin. Alle im Dorf hatten grossen Respekt vor ihr, denn sie konnte wirklich zaubern. Niemand ging freiwillig in ihren Garten.
+
+Eines Tages schaute die Frau aus dem Fenster und sah ein Beet voll frischer, grüner Rapunzelblätter. Die Blätter sahen so saftig und köstlich aus, dass die Frau plötzlich grossen Hunger darauf bekam. "Ich muss ein paar davon haben", sagte sie leise. "Sonst werde ich noch krank vor Sehnsucht."
+
+Der Mann hatte seine Frau sehr lieb. Er wollte nicht, dass sie traurig war. Also wartete er bis zum Abend, als es langsam dunkel wurde. Dann kletterte er ganz vorsichtig über die Mauer in den Garten. Er zupfte schnell eine Handvoll Rapunzelblätter ab und kletterte wieder zurück. Seine Frau machte sich einen Salat und ass ihn mit grossem Appetit. "Das ist das Beste, was ich je gegessen habe!" rief sie.
+
+Am nächsten Tag hatte sie schon wieder Hunger auf Rapunzeln. Also ging der Mann am Abend noch einmal los. Doch diesmal stand plötzlich die Zauberin vor ihm. Ihre Augen blitzten. "Was machst du in meinem Garten?" fragte sie streng. "Das sind meine Rapunzeln!"
+
+Der Mann zitterte vor Schreck. "Bitte verzeihen Sie mir! Meine Frau wollte so gern davon essen. Ich habe Angst gehabt, dass sie sonst krank wird."
+
+Die Zauberin schaute ihn lange an. Dann sagte sie: "Also gut. Du darfst so viele Rapunzeln haben, wie deine Frau möchte. Aber ich habe eine Bedingung. Wenn ihr eines Tages ein Kind bekommt, dann darf ich es bei mir aufnehmen. Ich werde gut auf es aufpassen, das verspreche ich."
+
+Der Mann war so erschrocken, dass er ohne nachzudenken "Ja" sagte. Er nahm ein paar Rapunzelblätter mit und ging nach Hause.
+
+Einige Monate später bekamen der Mann und die Frau tatsächlich ein kleines Mädchen. Sie freuten sich sehr. Aber gleich am nächsten Tag klopfte die Zauberin an die Tür. "Ich komme, um das Kind zu holen", sagte sie freundlich. "So wie ihr es versprochen habt."
+
+Der Mann und die Frau waren sehr traurig. Aber die Zauberin sagte: "Ich werde das Mädchen Rapunzel nennen, nach den Blättern aus meinem Garten. Und ich werde sie lieb haben wie eine eigene Tochter." Dann nahm sie das Baby und ging fort.
+
+Rapunzel wuchs heran. Sie hatte lange, goldene Haare, die immer länger wurden. Sie hatte eine fröhliche Stimme und lachte gerne. Die Zauberin passte gut auf sie auf, aber sie war auch ziemlich streng. "Die Welt draussen ist gefährlich", sagte sie oft. "Ich will nicht, dass dir etwas passiert."
+
+Als Rapunzel zwölf Jahre alt war, brachte die Zauberin sie in einen hohen Turm mitten im Wald. Der Turm hatte keine Treppe und keine Tür. Ganz oben gab es nur ein einziges Fenster. Im Turm war ein gemütliches Zimmer mit einem weichen Bett, einem Tisch, einem Stuhl und vielen Büchern.
+
+"Hier bist du sicher", sagte die Zauberin. "Hier kann dir nichts passieren." Und so blieb Rapunzel im Turm.
+
+Wenn die Zauberin ihre Pflegetochter besuchen wollte, stellte sie sich unten vor den Turm und rief hinauf:
 
 "Rapunzel, Rapunzel, lass dein Haar herunter!"
 
-Dann liess Rapunzel ihre goldenen Zöpfe aus dem Fenster fallen, und die Fee kletterte hinauf.
+Dann knüpfte Rapunzel ihre langen, goldenen Zöpfe an einen Haken am Fenster und liess sie lang herunterhängen. Sie waren so lang, dass sie bis auf den Boden reichten. Die Zauberin griff zu und kletterte daran hinauf, wie an einer goldenen Leiter. Sie brachte Essen, Bücher und manchmal auch neue Kleider.
 
-Rapunzel war oft einsam im Turm. Sie sang jeden Tag aus dem Fenster. Die Vögel kamen und sangen mit ihr. Ihre Stimme war so schön wie Musik.
+Rapunzel war oft allein. Aber sie war nicht traurig. Sie schaute aus dem Fenster und sah die Vögel, die Wolken, die Sterne. Und sie sang. Jeden Tag sang sie Lieder. Ihre Stimme war so klar und süss wie ein kleiner Bach, der über Steine plätschert. Die Vögel kamen und setzten sich auf das Fenster, um zuzuhören.
 
-Eines Tages ritt ein junger Prinz durch den Wald. Er hörte Rapunzels Lied und blieb stehen. Noch nie hatte er so etwas Schönes gehört! Er suchte und suchte und fand endlich den hohen Turm.
+Eines Tages ritt ein junger Prinz durch den Wald. Er hatte sich beim Reiten verirrt. Plötzlich hörte er eine Stimme, die so schön war, dass er sofort anhielt. "Was ist das für ein wunderbares Lied?" dachte er. Er stieg vom Pferd und folgte der Stimme. Endlich stand er vor einem hohen Turm. "Wer singt da drinnen?" fragte er sich. Er suchte eine Tür, aber er fand keine.
 
-"Wie kommt man dort hinauf?" fragte er sich. Da versteckte er sich hinter einem Busch und wartete.
+Der Prinz ritt nach Hause. Aber die Stimme ging ihm nicht aus dem Kopf. Am nächsten Tag kam er wieder. Und am übernächsten Tag auch. Jedes Mal stand er am Turm und hörte dem Gesang zu.
 
-Bald kam die Fee und rief: "Rapunzel, Rapunzel, lass dein Haar herunter!" Der Prinz sah, wie die Fee an den Zöpfen hinaufkletterte.
-
-Am nächsten Tag stellte der Prinz sich selbst vor den Turm. Mit freundlicher Stimme rief er:
+Einmal versteckte er sich hinter einem Busch. Da sah er, wie die Zauberin zum Turm kam und rief:
 
 "Rapunzel, Rapunzel, lass dein Haar herunter!"
 
-Rapunzel liess ihr Haar fallen, und der Prinz stieg hinauf. Sie erschrak ein wenig, doch der Prinz lächelte und sagte: "Ich wollte deine schöne Stimme kennen lernen. Möchtest du mein Freund sein?"
+Und er sah, wie lange goldene Zöpfe aus dem Fenster fielen, und wie die Zauberin daran hinaufkletterte. "Aha!" dachte der Prinz. "So kommt man hinauf."
 
-Rapunzel freute sich sehr. Endlich hatte sie jemanden zum Sprechen. Jeden Tag kam der Prinz heimlich vorbei, und die beiden lachten und erzählten sich Geschichten.
+Am nächsten Abend, als die Zauberin fort war, stellte sich der Prinz selbst an den Turm. Er räusperte sich und rief mit freundlicher Stimme:
 
-Als die Fee davon hörte, wurde sie böse. Sie schnitt Rapunzels lange Zöpfe ab und schickte sie weit weg in einen einsamen Wald. Der Prinz suchte Rapunzel überall. Lange, lange irrte er durch die Wälder.
+"Rapunzel, Rapunzel, lass dein Haar herunter!"
 
-Eines Morgens hörte er wieder eine Stimme singen. Es war Rapunzel! Er folgte der Stimme und fand sie auf einer Lichtung.
+Rapunzel dachte, es wäre die Zauberin. Sie liess ihre Zöpfe fallen, und der Prinz kletterte hinauf.
 
-"Da bist du ja!" riefen sie beide. Sie nahmen sich bei der Hand und gingen zusammen zum Schloss des Prinzen. Dort wohnten sie glücklich zusammen, und Rapunzel sang jeden Tag ihr schönstes Lied.
+Als er oben am Fenster erschien, erschrak Rapunzel zuerst. So einen Menschen hatte sie noch nie gesehen. "Bitte hab keine Angst", sagte der Prinz sanft. "Ich wollte nur deine wunderschöne Stimme kennenlernen. Jeden Tag höre ich dich singen. Du machst mich glücklich."
+
+Rapunzel schaute ihn lange an. Er hatte ein freundliches Gesicht und warme Augen. Langsam verlor sie ihre Angst. Sie zeigte ihm ihre Bücher. Sie erzählte ihm, wie es ist, den ganzen Tag oben im Turm zu sein. Der Prinz erzählte von der Welt draussen, vom Meer, von grossen Festen, von Pferden und Hunden.
+
+"Komm doch morgen wieder", sagte Rapunzel, als er ging. "Aber bitte, bitte, lass dich nicht von Frau Gothel sehen."
+
+Von da an kam der Prinz jeden Abend. Am Tag besuchte die Zauberin Rapunzel. Am Abend der Prinz. Rapunzel lachte und sang mehr als je zuvor. Die beiden wurden gute Freunde und machten zusammen Pläne: Rapunzel würde aus dem Turm herauskommen und die Welt sehen.
+
+Aber eines Tages, als die Zauberin gerade oben war, sagte Rapunzel aus Versehen: "Frau Gothel, warum sind Sie eigentlich immer so viel schwerer zu ziehen als der Prinz?"
+
+Die Zauberin wurde rot im Gesicht. "Was? Welcher Prinz? Du hast mich betrogen!" rief sie. Sie war so wütend, dass sie eine Schere nahm und, ritsch ratsch, Rapunzels lange goldene Zöpfe abschnitt. Die Zöpfe fielen auf den Boden.
+
+Dann brachte die Zauberin Rapunzel weit weg, in einen einsamen Wald am Rand eines Flusses. "Hier bleibst du jetzt", sagte sie traurig. "Ich wollte dich nur beschützen, und du bist mir weggelaufen." Dann verschwand die Zauberin.
+
+Rapunzel sass allein am Wasser und weinte. Aber nicht lange. Dann wischte sie sich die Tränen ab und dachte: "Ich finde einen Weg."
+
+Am Abend kam der Prinz wie immer zum Turm. Er rief: "Rapunzel, Rapunzel, lass dein Haar herunter!"
+
+Die Zauberin hatte die abgeschnittenen Zöpfe am Fensterhaken befestigt. Sie liess sie herunterfallen. Der Prinz kletterte hinauf. Aber oben am Fenster stand nicht Rapunzel, sondern die Zauberin. "Du willst Rapunzel sehen?" sagte sie. "Rapunzel ist weg, weit weg. Du wirst sie nie mehr finden!"
+
+Der Prinz war so traurig, dass er vor Schreck den Halt verlor und vom Fenster sprang. Zum Glück fiel er in einen grossen Dornenstrauch, der seinen Fall weich auffing. Aber ein paar Dornen kratzten seine Augen, und er konnte fast nichts mehr sehen.
+
+So wanderte der Prinz durch den Wald. Er konnte die Bäume nur noch schemenhaft erkennen. Er ass Beeren und Wurzeln. Er schlief unter Sternen. Monatelang war er unterwegs. Dabei dachte er die ganze Zeit nur an Rapunzel und ihr schönes Lied.
+
+Eines Morgens, als er ganz müde war, hörte er in der Ferne etwas Vertrautes. Eine Stimme, die sang. Ein Lied, das er kannte. Sein Herz sprang vor Freude. "Rapunzel!" rief er.
+
+Der Prinz tastete sich langsam weiter. Die Stimme wurde lauter. Endlich stand er vor einer kleinen Lichtung. Dort sass Rapunzel unter einem Apfelbaum.
+
+"Du?" rief Rapunzel. "Du bist es wirklich?" Sie sprang auf und rannte zu ihm. Sie umarmte ihn ganz fest, und dabei fielen zwei Tränen aus ihren Augen genau in seine verletzten Augen. Und in diesem Moment geschah etwas Wunderbares: Die Kratzer heilten. Der Prinz konnte wieder klar sehen. Er schaute Rapunzel an und lachte.
+
+"Ich habe dich gefunden", flüsterte er.
+
+"Ich wusste, dass du mich findest", sagte Rapunzel.
+
+Der Prinz und Rapunzel gingen zusammen in sein Schloss. Auf dem Weg sahen sie die Zauberin am Rand des Waldes stehen. Sie schaute die beiden lange an. Dann sagte sie leise: "Verzeih mir, Rapunzel. Ich wollte nur, dass dir nichts Schlimmes passiert. Aber ich habe dir die Welt weggenommen, und das war falsch."
+
+Rapunzel schaute sie an. Dann ging sie zu ihr und umarmte sie kurz. "Ich verzeihe dir", sagte sie. "Aber jetzt möchte ich selbst entscheiden, wo ich lebe."
+
+Von da an lebten Rapunzel und der Prinz zusammen im Schloss. Sie sang jeden Tag, und manchmal, wenn sie Lust hatte, besuchte sie die alte Zauberin. Die Zauberin hatte ein kleines Häuschen mit einem neuen Garten, und sie war freundlicher geworden. Sie schenkte Rapunzel jedes Mal einen kleinen Strauss frische Rapunzelblätter, und die beiden assen zusammen Salat und lachten.
+
+Und Rapunzels Haare? Die wuchsen wieder. Aber sie wurden nie mehr ganz so lang wie früher. Das war Rapunzel auch recht. Zöpfe sind praktisch – aber nicht, wenn man die Welt sehen will.

--- a/packages/collection-grimm-top5/stories/rotkaeppchen/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/rotkaeppchen/adaptions/contemporary/content.md
@@ -5,42 +5,102 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal ein kleines Mädchen, das immer eine rote Mütze trug. Alle nannten es Rotkäppchen.
+Es war einmal ein kleines Mädchen, das in einem Dorf am Rand eines Waldes wohnte. Alle Menschen im Dorf hatten das Mädchen lieb, denn es war fröhlich und freundlich. Am allerliebsten hatte es seine Grossmutter, die in einem kleinen Haus mitten im Wald wohnte. Die Grossmutter konnte nicht mehr gut laufen, aber sie kochte die beste Apfelsuppe der Welt, und sie konnte wunderbare Geschichten erzählen.
 
-Eines Morgens sagte die Mama zu Rotkäppchen: "Die Oma ist krank. Bitte bring ihr diesen Korb mit Kuchen und Saft. Aber bleib auf dem Weg, und sprich mit niemand Fremdem."
+Eines Tages schenkte die Grossmutter dem Mädchen eine Mütze aus weichem roten Samt. Das Mädchen war so begeistert davon, dass es die Mütze jeden Tag trug. Im Winter und im Sommer, zu Hause und auf der Strasse. So kam es, dass bald niemand mehr den richtigen Namen des Mädchens sagte. Alle nannten es einfach "Rotkäppchen".
 
-Rotkäppchen versprach es. Fröhlich lief es los. Die Sonne schien, die Vögel zwitscherten, und am Wegrand blühten bunte Blumen.
+Eines Morgens kam die Mama zu Rotkäppchen in die Küche. Sie hatte einen Korb in der Hand, und darin lagen ein frischer Kuchen, eine Flasche Apfelsaft und ein kleines Glas Honig.
 
-Mitten im Wald traf Rotkäppchen einen grossen Wolf. Der Wolf zeigte ein breites Lächeln.
+"Rotkäppchen", sagte die Mama, "die Oma ist ein bisschen krank. Sie hat Husten und bleibt im Bett. Bitte bring ihr diesen Korb. Der Kuchen und der Honig werden ihr gut tun."
 
-"Guten Tag, kleines Mädchen", sagte der Wolf freundlich. "Wohin gehst du denn?"
+"Ja, Mama, das mache ich gern", sagte Rotkäppchen und setzte ihre rote Mütze auf.
 
-Rotkäppchen hatte noch nie einen Wolf gesehen und erschrak nicht. "Ich besuche meine Oma", antwortete es.
+Die Mama schaute sie ernst an. "Aber hör gut zu: Bleib auf dem Weg. Geh nicht durch den Wald neben dem Weg. Renne nicht. Und vor allem – sprich nicht mit Fremden. Es gibt im Wald manchmal Tiere, die gefährlich sein können. Versprich mir das!"
 
-"Oh, wie schön", sagte der Wolf. "Schau, dort auf der Wiese, wie bunt die Blumen sind. Warum pflückst du nicht ein paar für die Oma?"
+Rotkäppchen nickte. "Ich verspreche es, Mama. Ich bleibe auf dem Weg." Sie nahm den Korb, winkte der Mama und lief fröhlich los.
 
-Rotkäppchen dachte: "Ein Blumenstrauss würde Oma freuen!" So ging es von Blume zu Blume und kam immer weiter vom Weg ab.
+Der Weg zur Grossmutter war schön. Die Sonne schien warm. Schmetterlinge flatterten zwischen den Blumen. Vögel zwitscherten in den Bäumen. Rotkäppchen sang ein Lied und hüpfte von Stein zu Stein.
 
-Der Wolf aber rannte schnell zu Omas Haus. Er klopfte an die Tür. "Oma, mach auf!" Doch die Oma wusste gleich: Das ist nicht Rotkäppchen! Flink versteckte sie sich im Schrank und schloss ihn fest von innen.
+Mitten im Wald, an einer Stelle, wo der Pfad zwischen hohen Bäumen lief, stand plötzlich ein grosser Wolf vor Rotkäppchen. Er hatte zottiges graues Fell und einen langen, buschigen Schwanz. Seine Zähne waren sehr spitz, aber er lachte so freundlich, dass Rotkäppchen gar keine Angst bekam. Sie hatte noch nie einen Wolf gesehen und wusste nicht, dass Wölfe gefährlich sein können.
 
-Da kam der Wolf herein. Er schaute ins Bett – leer. Er schaute unter den Tisch – leer. "Die Oma muss im Wald sein", brummte er und legte sich wartend ins Bett.
+"Guten Morgen, kleines Mädchen", sagte der Wolf mit honigsüsser Stimme. "Wohin gehst du denn so früh?"
 
-Bald klopfte Rotkäppchen an der Tür. "Ich bin's!" Es trat ein und sah das komische Bild: Etwas Haariges lag unter Omas Decke.
+"Guten Morgen", antwortete Rotkäppchen höflich. "Ich gehe zu meiner Grossmutter. Sie ist krank, und ich bringe ihr Kuchen und Honig."
 
-"Oma, warum hast du so grosse Ohren?"
+"Oh, wie lieb von dir!" sagte der Wolf. "Und wo wohnt deine Grossmutter denn?"
 
-"Damit ich dich besser hören kann!"
+"Sie wohnt mitten im Wald, unter den drei grossen Eichen. Das Haus hat grüne Fensterläden, und davor steht ein Zwetschgenbaum."
 
-"Oma, warum hast du so grosse Augen?"
+Der Wolf dachte heimlich: "Oh, wie fein! Das Mädchen ist zart und frisch, und die alte Grossmutter ist bestimmt auch ein feiner Bissen. Ich mache einen Plan, dann kann ich beide haben."
 
-"Damit ich dich besser sehen kann!"
+Laut aber sagte er nur ganz freundlich: "Schau, Rotkäppchen, schau doch einmal, wie schön die Blumen am Waldrand blühen! Gelbe Butterblumen, blaue Glockenblumen, rote Mohnblumen! Wäre es nicht wunderbar, wenn du deiner Grossmutter einen schönen Strauss mitbringen würdest? Hörst du auch, wie die Vögel singen? Warum rennst du so schnell? Ein bisschen spielen ist doch auch erlaubt."
 
-"Oma, warum hast du so einen grossen Mund?"
+Rotkäppchen schaute sich um. Und tatsächlich – die Blumen waren wirklich wunderschön. "Ein Blumenstrauss würde Oma bestimmt froh machen", dachte sie. "Und ich habe ja noch viel Zeit."
 
-"Damit ich—" Und da sprang der Wolf aus dem Bett!
+Sie vergass, was ihre Mama gesagt hatte. Sie lief vom Weg ab, tief in den Wald hinein, pflückte hier eine Blume und dort eine Blume. Jede schien schöner als die vorige. So geriet sie immer weiter weg vom Pfad.
 
-Rotkäppchen schrie laut. Zum Glück kam gerade der Jäger vorbei. Er hörte den Schrei und lief schnell ins Haus. Der Wolf erschrak so sehr, dass er aus dem Fenster sprang und weit, weit weg in den Wald rannte. Dort blieb er.
+Der Wolf aber lief, so schnell er konnte, geradewegs zum Haus der Grossmutter. An der Tür klopfte er an. Klopf, klopf, klopf.
 
-"Oma! Wo bist du?" rief Rotkäppchen. Ein kleines Klopfen kam aus dem Schrank. Die Oma öffnete die Tür und umarmte Rotkäppchen ganz fest.
+"Wer ist da?" fragte die Grossmutter mit müder Stimme aus dem Bett.
 
-Zusammen assen sie den Kuchen und tranken den Saft. Und Rotkäppchen versprach: "Nie mehr gehe ich vom Weg ab, und nie mehr spreche ich mit Fremden im Wald."
+Der Wolf machte seine Stimme so fein und hell wie er konnte: "Ich bin's, Rotkäppchen. Ich bringe dir Kuchen und Honig."
+
+"Drück nur die Klinke runter!" rief die Grossmutter. "Ich bin zu schwach, um aufzustehen."
+
+Der Wolf drückte die Klinke herunter, die Tür ging auf, und er kam in die Stube. Die Grossmutter sah gleich: Das ist kein kleines Mädchen! Das ist ein grosser Wolf! Sie erschrak fürchterlich und rutschte, so leise sie konnte, aus dem Bett. Flink, flink, flink – sie versteckte sich im grossen Schrank und zog die Tür von innen zu. "Hoffentlich findet mich der Wolf nicht", flüsterte sie und hielt den Atem an.
+
+Der Wolf rannte ins Schlafzimmer. Aber das Bett war leer. "Wo ist die alte Frau?" knurrte er. Er schaute unter den Tisch, hinter den Vorhang, sogar in den Küchenschrank. Aber die Grossmutter hatte sich so klein wie möglich in den grossen Kleiderschrank gedrückt. Der Wolf fand sie nicht.
+
+"Ach, was soll's", brummte er. "Die alte Frau kommt sicher bald nach Hause. Jetzt warte ich einfach auf das Mädchen." Er zog schnell Grossmutters weisse Nachthaube an, legte ihr geblümtes Nachthemd darüber und kroch ins Bett. Dann zog er die Bettdecke hoch bis unter die Nase und wartete.
+
+Unterdessen hatte Rotkäppchen einen riesigen Blumenstrauss gepflückt. Als der Strauss so gross war, dass sie kaum noch zwei Blumen dazu halten konnte, fiel ihr plötzlich ein: "Oh weh! Ich wollte doch schnell zur Grossmutter!" Sie rannte zurück auf den Weg und eilte zum Haus im Wald.
+
+Als sie ankam, war die Tür offen. Das war komisch. Rotkäppchen wurde ein bisschen mulmig. "Guten Morgen, Oma!" rief sie, aber niemand antwortete. Sie ging leise ins Schlafzimmer. Dort lag jemand im Bett, das Gesicht fast ganz unter der Decke. Nur die Augen, Ohren und Nase schauten heraus, und sie sahen heute sehr seltsam aus.
+
+"Ei, Oma", sagte Rotkäppchen, "was hast du für grosse Ohren?"
+
+"Damit ich dich besser hören kann", antwortete die tiefe Stimme aus dem Bett.
+
+"Ei, Oma, was hast du für grosse Augen?"
+
+"Damit ich dich besser sehen kann."
+
+"Ei, Oma, was hast du für grosse Hände?"
+
+"Damit ich dich besser halten kann."
+
+"Aber Oma, was hast du für einen ENTSETZLICH grossen Mund?"
+
+"Damit ich dich besser—"
+
+Da sprang der Wolf mit einem Satz aus dem Bett! Rotkäppchen schrie laut vor Schreck und rannte in die Ecke. Der Wolf war fast bei ihr.
+
+Zum Glück kam in diesem Moment ein Jäger am Fenster vorbei. Er hatte Rotkäppchens Schrei gehört. Er riss die Tür auf und stürmte hinein. "Halt! Was machst du da, du alter Sünder?"
+
+Der Wolf erschrak so furchtbar, dass er mitsamt Nachthaube und Nachthemd aus dem offenen Fenster sprang. Er rannte, so schnell er konnte, in den Wald hinein und wurde nie mehr gesehen. Vielleicht lebt er noch heute irgendwo ganz weit weg, wo er keine kleinen Mädchen und Grossmütter mehr ärgert.
+
+"Rotkäppchen! Bist du verletzt?" fragte der Jäger besorgt.
+
+"Nein", sagte Rotkäppchen, aber ihr Herz klopfte noch ganz laut. "Aber wo ist meine Oma?"
+
+Sie hörten ein leises Pochen aus dem grossen Schrank. Klopf, klopf. Rotkäppchen öffnete die Tür, und da sass die Oma ganz klein zusammengekauert drin. Sie war ein bisschen müde, aber sonst ging es ihr gut. Sie umarmte Rotkäppchen ganz fest.
+
+"Oh, mein Kind, ich bin so froh, dass du hier bist!" rief die Grossmutter.
+
+Der Jäger schaute freundlich zu. "Pass das nächste Mal besser auf, Rotkäppchen. Und bleib auf dem Weg."
+
+Rotkäppchen nickte. "Das werde ich, versprochen. Nie wieder spreche ich mit einem Fremden im Wald."
+
+Dann setzten sich alle zusammen an den Tisch. Rotkäppchen packte den Kuchen aus, schenkte Apfelsaft ein und stellte das Glas Honig neben die Grossmutter. Sie stellte auch den grossen Blumenstrauss in eine Vase. "Der ist für dich, Oma."
+
+"Oh, wie schön!" sagte die Grossmutter und lachte endlich wieder. "Meine Husten ist schon halb weg, einfach weil du da bist."
+
+Sie assen zusammen. Der Jäger erzählte lustige Geschichten vom Wald. Die Grossmutter erzählte von früher. Und Rotkäppchen versprach sich selbst ganz fest: Wenn ich das nächste Mal zur Oma gehe, dann bleibe ich auf dem Weg. Ich spreche nicht mit Fremden. Und ich renne, wenn ein Fremder mich vom Weg weglocken will, direkt zu einem Menschen, dem ich vertraue.
+
+Am Abend brachte der Jäger Rotkäppchen nach Hause. Die Mama umarmte sie ganz fest, als sie die Geschichte hörte.
+
+Und es wird erzählt, dass Rotkäppchen einige Zeit später wieder den Korb zur Oma bringen sollte. Da kam ihr tatsächlich noch ein anderer Wolf entgegen. Dieser Wolf tat auch ganz freundlich, aber Rotkäppchen war jetzt klüger. Sie schaute ihn gar nicht erst an, sie blieb auf dem Weg und rannte, so schnell sie konnte. Diesmal liess sie sich nicht weglocken.
+
+Als sie bei der Oma ankam, schlossen sie gleich die Tür ab. "Komm", sagte die Grossmutter, "heute bleiben wir schön drinnen." Der Wolf schlich ums Haus herum, aber er konnte nichts machen, denn die Tür war zu und die Fenster waren zu. Schliesslich gab er auf und trottete enttäuscht davon.
+
+Und Rotkäppchen? Sie wurde eine kluge, mutige junge Frau. Die rote Mütze trug sie noch viele Jahre lang, und wenn sie jemandem Kindern davon erzählte, dann fing sie immer so an: "Das Wichtigste, wenn ihr in den Wald geht, ist: Bleibt auf dem Weg und sprecht nicht mit Fremden."

--- a/packages/collection-grimm-top5/stories/schneewittchen/adaptions/contemporary/content.md
+++ b/packages/collection-grimm-top5/stories/schneewittchen/adaptions/contemporary/content.md
@@ -5,36 +5,168 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal eine Prinzessin mit Haaren schwarz wie die Nacht, Lippen rot wie eine Erdbeere und Haut weiss wie Schnee. Alle nannten sie Schneewittchen. Sie war freundlich zu allen Menschen und auch zu allen Tieren.
+Es war einmal ein strenger Winter. Die Schneeflocken fielen wie weisse Federn vom Himmel. Eine Königin sass an einem Fenster mit einem schwarzen Holzrahmen und nähte an einem feinen Kleid. Sie schaute immer wieder hinaus in den Schnee. Dabei stach sie sich mit der Nadel in den Finger, und drei kleine Tropfen Blut fielen in den weissen Schnee.
 
-Schneewittchens Stiefmutter, die Königin, war sehr stolz. Jeden Morgen schaute sie in ihren Zauberspiegel und fragte:
+"Wie schön das rot im weissen Schnee aussieht", dachte die Königin. "Wenn ich ein Kind hätte, dann sollte es Haut so weiss wie Schnee, Lippen so rot wie Blut und Haare so schwarz wie der Rahmen aus Ebenholz haben."
+
+Nicht lange danach bekam die Königin tatsächlich ein Töchterchen. Das Baby hatte Haut so weiss wie Schnee, Lippen so rot wie Himbeeren und Haare so schwarz wie die Nacht. Die Königin nannte es Schneewittchen. Alle im Schloss freuten sich.
+
+Aber kurz darauf wurde die Königin sehr krank. Sie hielt Schneewittchen noch einmal in den Armen und flüsterte: "Bleib immer gut und freundlich, mein Kind." Dann schlief sie für immer ein. Der König war sehr traurig, und das ganze Schloss war traurig mit ihm.
+
+Nach einem Jahr heiratete der König wieder. Seine neue Frau war auch schön. Sie hatte lange dunkle Haare, ein edles Gesicht und einen strengen Blick. Aber sie war sehr stolz und eitel. Sie konnte es nicht ertragen, wenn jemand schöner war als sie. In ihrem Zimmer hing ein grosser, verzauberter Spiegel. Vor diesem Spiegel stand sie jeden Morgen und jeden Abend. Sie sprach zu ihm:
 
 "Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
 
-Viele Jahre antwortete der Spiegel: "Du, meine Königin." Doch eines Tages sagte der Spiegel:
+Und der Spiegel antwortete jedes Mal:
 
-"Schneewittchen ist tausendmal schöner als Ihr."
+"Frau Königin, du bist die Schönste im Land."
 
-Da wurde die Königin sehr neidisch. Sie wollte Schneewittchen fortschicken. Schneewittchen lief in den Wald und lief und lief, bis es müde wurde.
+Darüber freute sich die Königin, denn sie wusste: Der Spiegel sagt immer die Wahrheit.
 
-Plötzlich sah es ein winziges Häuschen. Schneewittchen klopfte. Niemand antwortete, also ging es hinein. Im Zimmer standen sieben kleine Stühle, auf dem Tisch sieben kleine Teller, und im Schlafzimmer waren sieben kleine Betten. Schneewittchen ass ein bisschen, trank ein bisschen und legte sich auf das letzte Bett. Schon schlief es fest.
+So ging es eine Weile. Schneewittchen wuchs zu einem fröhlichen Mädchen heran. Sie war nicht nur schön, sondern auch sehr freundlich. Sie lachte viel. Sie sang im Schlossgarten. Sie streichelte die Pferde im Stall und fütterte die Vögel am Fenster. Alle im Schloss mochten Schneewittchen.
 
-Am Abend kamen die sieben Zwerge von der Arbeit nach Hause. Sie arbeiteten in einem Bergwerk und sammelten funkelnde Steine. "Wer hat auf unseren Stühlen gesessen? Wer hat von unseren Tellern gegessen? Wer liegt in meinem Bett?" fragte der siebte, kleinste Zwerg staunend.
+Als Schneewittchen sieben Jahre alt war, stand die Königin wieder vor ihrem Spiegel.
 
-Da wachte Schneewittchen auf. Es erzählte alles. Die Zwerge waren gute Kerle und sagten: "Du darfst bei uns bleiben. Wir passen auf dich auf."
+"Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
 
-Schneewittchen wohnte nun bei den Zwergen. Sie kochte Suppe, putzte das Häuschen und sang mit den Vögeln.
+Diesmal antwortete der Spiegel nicht wie sonst. Er sagte:
 
-Die Königin aber hörte vom Spiegel, dass Schneewittchen noch lebte. Sie verkleidete sich als alte Frau und kam mit einem roten Apfel zum Häuschen. "Guten Tag, möchtest du einen süssen Apfel?"
+"Frau Königin, du bist schön, aber Schneewittchen ist tausendmal schöner als du."
 
-Schneewittchen biss vorsichtig hinein. Im Apfel war ein Zaubertrank. Schneewittchen wurde so müde, dass es in einen tiefen Zauberschlaf fiel.
+Die Königin wurde gelb und grün vor Neid. "Ein Kind? Schöner als ich?" rief sie. Von diesem Tag an konnte sie Schneewittchen nicht mehr sehen. Jedes Mal, wenn sie Schneewittchen lachen hörte, bekam sie schlechte Laune. Sie schmiedete einen bösen Plan.
 
-Als die Zwerge heimkamen, fanden sie Schneewittchen schlafend. Sie bauten für sie ein Bett aus Glas, damit alle Vögel und Tiere sie sehen konnten.
+Die Königin rief einen jungen Jäger zu sich. "Nimm das Mädchen mit in den Wald", befahl sie. "Sie soll aus meinem Schloss verschwinden. Und bring mir ihre rote Mütze als Beweis, dass sie nicht mehr zurückkommt."
 
-Eines Tages ritt ein Prinz vorbei. Er sah Schneewittchen und die sieben Zwerge, die traurig dabeistanden. Vorsichtig berührte der Prinz das Glas.
+Der Jäger erschrak, aber er musste der Königin gehorchen. Er nahm Schneewittchen mit zu einem Spaziergang im Wald. Als sie tief zwischen den Bäumen waren, drehte sich der Jäger um und sagte traurig: "Schneewittchen, du musst weglaufen. Die Königin hat mir etwas Schlimmes befohlen. Aber ich kann dir das nicht antun. Lauf, und komm niemals mehr zurück zum Schloss!"
 
-Da rutschte ein Stück vom Zauberapfel aus Schneewittchens Mund. Es öffnete die Augen und lächelte!
+Schneewittchen erschrak fürchterlich. "Aber wohin soll ich laufen?"
 
-"Willst du mit mir kommen?" fragte der Prinz.
+"Irgendwohin, wo die Königin dich nicht findet. Vielleicht tiefer in den Wald. Und pass auf dich auf!" Dann legte der Jäger die rote Mütze auf den Boden und versteckte sich ein bisschen, um zu warten. Er wollte die Mütze schmutzig machen und so tun, als wäre alles erledigt.
 
-Schneewittchen umarmte die Zwerge zum Abschied. "Ich besuche euch bald wieder, versprochen!" Und so tat es. Sie lebten alle glücklich, und der Zauberspiegel flüsterte nie wieder böse Dinge.
+Schneewittchen rannte, so schnell sie konnte. Sie rannte durch Dornen und über Wurzeln. Vögel flogen auf. Rehe sprangen zur Seite. Die wilden Tiere taten ihr aber nichts, denn sie spürten, dass sie Angst hatte. Schneewittchen rannte den ganzen Tag, bis ihre Füsse wehtaten. Als die Sonne unterging, stand sie plötzlich auf einer kleinen Lichtung. Dort stand ein winziges Häuschen. Es war so klein, dass der Türgriff nur knapp bis an Schneewittchens Schulter reichte.
+
+Schneewittchen klopfte. Niemand antwortete. Die Tür war nicht abgeschlossen. Sie öffnete sie vorsichtig und ging hinein.
+
+Im Haus war alles klein, aber sehr sauber und gemütlich. Auf dem Tisch standen sieben kleine Teller, sieben kleine Löffel und sieben kleine Becher. An der Wand hingen sieben kleine Mützen an sieben kleinen Haken. Im Nebenzimmer standen sieben kleine Betten, alle hübsch mit weissen Laken zugedeckt.
+
+Schneewittchen hatte Hunger und Durst. Sie nahm von jedem Teller ein kleines bisschen, damit niemand etwas vermissen würde, und sie trank aus jedem Becher einen kleinen Schluck. Dann war sie so müde, dass sie sich in eines der Betten legte. Das erste war zu lang, das zweite zu kurz, das dritte zu hart. Erst das siebte Bett war genau richtig. Schneewittchen schlief schnell ein.
+
+Als es dunkel war, kamen die Besitzer des Häuschens heim. Es waren sieben Zwerge. Sie arbeiteten in einem Bergwerk und suchten im Berg nach glitzernden Steinen. Jeder trug einen kleinen Rucksack und eine kleine Lampe. Als sie ins Haus kamen, bemerkten sie gleich: Hier ist jemand gewesen!
+
+"Wer hat auf meinem Stuhl gesessen?" fragte der erste.
+
+"Wer hat von meinem Teller gegessen?" fragte der zweite.
+
+"Wer hat aus meinem Becher getrunken?" fragte der dritte.
+
+"Wer hat mein Kissen verschoben?" fragte der vierte.
+
+Die anderen schauten sich auch um. Schliesslich fand der siebte Zwerg Schneewittchen, die in seinem Bett schlief. "Seht mal hier!" rief er leise. Alle sieben Zwerge kamen mit ihren Lampen ans Bett und staunten. "Was für ein schönes Kind!" flüsterten sie. Sie weckten Schneewittchen nicht auf.
+
+Als Schneewittchen am Morgen die Augen öffnete, sah sie sieben kleine Gesichter, die sie freundlich anlachten. Zuerst erschrak sie ein bisschen. Aber dann sagte der kleinste Zwerg mit heller Stimme: "Hab keine Angst. Wir tun dir nichts. Wer bist du, und wie kommst du hierher?"
+
+Schneewittchen erzählte alles: Von der bösen Königin, vom Jäger, vom langen Lauf durch den Wald. Die Zwerge hörten mit grossen Augen zu.
+
+"Du kannst bei uns bleiben", sagte der älteste Zwerg. "Aber du musst uns dafür im Haushalt helfen. Kannst du kochen, waschen, nähen und Betten machen?"
+
+"Gern", sagte Schneewittchen. "Ich helfe, so gut ich kann."
+
+So wurde Schneewittchen die Freundin der sieben Zwerge. Jeden Morgen gingen die Zwerge mit ihren Lampen und Werkzeugen in den Berg. Schneewittchen blieb zu Hause, machte die Betten, fegte den Boden, kochte Suppe und sang dabei. Am Abend kamen die Zwerge heim. Sie setzten sich alle an den kleinen Tisch, erzählten Geschichten und lachten viel. Es war ein gutes Leben.
+
+Bevor die Zwerge jeden Morgen das Haus verliessen, sagten sie: "Pass auf dich auf, Schneewittchen. Lass niemand herein, egal wer klopft. Die böse Königin könnte dich hier finden."
+
+Im Schloss stand die Königin eines Tages wieder vor ihrem Spiegel. "Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
+
+Der Spiegel antwortete:
+
+"Frau Königin, du bist schön, aber über den Bergen, bei den sieben Zwergen, wohnt Schneewittchen, und sie ist tausendmal schöner als du."
+
+Die Königin bekam einen Schreck. "Was? Schneewittchen lebt noch?" Sie war ausser sich vor Wut. Sie dachte lange nach. Dann ging sie in ihre geheime Kammer und mischte einen Zaubertrank. Sie zog ein altes Kleid an, setzte einen grauen Schleier auf und nahm einen Korb mit Hübschmacher-Bändern mit. So verkleidet sah sie aus wie eine alte Hausiererin.
+
+Über sieben Berge und sieben Täler wanderte die Königin bis zum Haus der Zwerge. Sie klopfte an die Tür. "Schöne Bänder! Hübsche Schnüre! Feil, feil!"
+
+Schneewittchen schaute aus dem Fenster. "Guten Tag, liebe Frau!"
+
+"Oh, schau nur, was für wunderschöne Schnürsenkel ich habe", sagte die Hausiererin. "Darf ich dir einen zeigen?"
+
+Schneewittchen dachte: "Die alte Frau sieht doch ganz freundlich aus." Sie öffnete die Tür einen Spalt. Die Frau zeigte ihr einen schönen bunten Schnürsenkel. "Komm, ich schnüre dir das Kleid ganz schön. Dann siehst du noch hübscher aus."
+
+Schneewittchen liess sie herein. Aber die böse Königin zog die Schnur so fest, dass Schneewittchen fast keine Luft mehr bekam. Sie fiel in den Stuhl und konnte sich nicht mehr bewegen. Die Königin lachte leise und verschwand.
+
+Am Abend kamen die Zwerge heim. Sie fanden Schneewittchen reglos auf dem Stuhl. "Oh nein!" riefen sie. Zum Glück sahen sie die zu fest gebundene Schnur. Der kleinste Zwerg schnitt sie mit einer Schere durch. Schneewittchen holte tief Luft und kam langsam wieder zu sich.
+
+"Das war sicher die Königin!" sagten die Zwerge. "Nie, nie wieder lass jemanden herein, Schneewittchen. Egal, was er sagt oder zeigt!"
+
+Im Schloss stand die Königin wieder vor dem Spiegel. Sie war sicher, dass jetzt sie wieder die Schönste war. Aber der Spiegel sagte:
+
+"Frau Königin, du bist schön, aber über den Bergen, bei den sieben Zwergen, wohnt Schneewittchen, und sie ist tausendmal schöner als du."
+
+Die Königin wurde fuchsteufelswild. "Sie lebt? Schon wieder?" Sie machte einen neuen Plan. Sie bastelte einen hübschen Kamm und mischte einen Schlaftrank in den Kamm hinein. Dann verkleidete sie sich als eine andere alte Frau und wanderte wieder über die Berge.
+
+"Schöne Kämme! Hübsche Haarschmucke!" rief sie vor der Tür.
+
+Schneewittchen schaute vorsichtig hinaus. "Nein, danke. Ich darf niemanden hereinlassen."
+
+"Kein Problem, schau doch nur durchs Fenster", sagte die Frau. Sie hielt einen wunderhübschen bunten Kamm in die Höhe. Er glitzerte in der Sonne. Schneewittchen schaute ihn an, und der Wunsch, ihn in den Haaren zu tragen, wurde zu gross. Sie öffnete die Tür einen Spalt. Die Frau zog den Kamm schnell durch Schneewittchens Haare, und im selben Augenblick fiel Schneewittchen um und lag ganz still.
+
+Die Königin lachte höhnisch und eilte fort.
+
+Am Abend kamen die Zwerge nach Hause. Sie sahen Schneewittchen am Boden liegen und hatten gleich einen Verdacht. Sie suchten und fanden den Kamm in ihren Haaren. Kaum hatten sie ihn herausgezogen, da öffnete Schneewittchen die Augen. "Oh, wie mir schwindlig war", flüsterte sie.
+
+"Schneewittchen!" riefen die Zwerge. "Du musst wirklich sehr, sehr vorsichtig sein. Öffne niemand die Tür! Schau auch nicht durchs Fenster, wenn ein Fremder etwas zeigen will!"
+
+Im Schloss fragte die Königin zum dritten Mal den Spiegel. Und zum dritten Mal sagte er:
+
+"Frau Königin, du bist schön, aber über den Bergen, bei den sieben Zwergen, wohnt Schneewittchen, und sie ist tausendmal schöner als du."
+
+Jetzt wurde die Königin vor Zorn richtig krank. "Diesmal", flüsterte sie, "diesmal bin ich klüger." Sie ging in die dunkelste Kammer des Schlosses und machte einen grossen roten Apfel. Der Apfel war wunderschön – eine Hälfte war rot wie Glut, die andere weiss wie Sahne. Aber die rote Hälfte war mit einem Zaubertrank getränkt. Wer davon ass, würde in einen tiefen Zauberschlaf fallen.
+
+Die Königin verkleidete sich als Bauersfrau. Einen Korb voller Äpfel nahm sie mit, und mitten unter ihnen legte sie den verzauberten Apfel. Dann wanderte sie noch einmal über die sieben Berge.
+
+"Äpfel! Frische Äpfel!" rief sie vor dem Haus der Zwerge.
+
+Schneewittchen blickte vorsichtig aus dem Fenster. "Nein, ich darf keinen Fremden hereinlassen. Das haben mir die Zwerge gesagt."
+
+"Du sollst ja gar nichts hereinlassen!" sagte die Bauersfrau. "Schau, ich werfe dir einfach einen Apfel zum Probieren herein. Ich habe zu viele, und ich teile gern." Sie teilte den Apfel mit einem Messer in zwei Hälften. Die weisse Hälfte biss sie selber an. "Siehst du? Ganz köstlich und ungefährlich. Hier, die andere Hälfte ist für dich."
+
+Schneewittchen dachte: "Die Frau isst doch selbst davon. Der Apfel kann nicht schlecht sein." Sie streckte die Hand aus dem Fenster, nahm die rote Hälfte und biss hinein. Sofort spürte sie, wie ihr alles schwer wurde. Der Raum drehte sich. Sie fiel zu Boden und lag ganz still. Nur ein Stückchen Apfel war in ihrem Hals steckengeblieben.
+
+"Endlich!" lachte die Königin. "Jetzt bin ich wieder die Schönste." Sie eilte zurück ins Schloss und fragte sofort den Spiegel. Diesmal antwortete er:
+
+"Frau Königin, du bist die Schönste im Land."
+
+Am Abend kamen die Zwerge heim. Sie fanden Schneewittchen am Boden. Sie war ganz blass. "Schneewittchen, Schneewittchen, wach auf!" riefen sie. Sie rüttelten sie, schoben ihr Wasser an die Lippen, suchten nach einem Gift – nichts half. Schneewittchen wachte nicht auf.
+
+Die Zwerge weinten lange. Drei Tage hielten sie Trauer. Aber Schneewittchen sah nicht tot aus. Sie sah aus, als würde sie nur schlafen. Ihre Wangen waren noch rosa, ihre Haare noch schwarz, ihre Haut noch weiss.
+
+"Wir können sie nicht einfach in die Erde legen", sagte der älteste Zwerg. "Sie ist zu schön dafür."
+
+Die Zwerge bauten einen Sarg aus klarem Glas, damit man Schneewittchen von allen Seiten sehen konnte. Mit goldenen Buchstaben schrieben sie ihren Namen auf den Deckel: Schneewittchen, Königstochter. Sie stellten den Sarg auf einen kleinen Hügel im Wald. Rund um den Hügel sassen jeden Tag zwei oder drei Zwerge und wachten. Auch die Tiere kamen. Eine Eule sass auf einem Ast. Ein Rabe schaute vom Felsen herab. Eine weisse Taube flog um den Sarg. Alle trauerten um Schneewittchen.
+
+Viele Jahre vergingen. Schneewittchen lag immer noch im Glassarg, und sie sah immer noch aus, als würde sie nur schlafen.
+
+Eines Tages ritt ein junger Prinz durch den Wald. Er hatte sich verirrt und kam zum Häuschen der Zwerge. Er sah den Sarg auf dem Hügel und trat näher. Lange schaute er das schlafende Mädchen an. "Was für ein wunderschönes Kind", flüsterte er. "Was für eine traurige Geschichte."
+
+Der Prinz sprach mit den Zwergen. Er bat: "Darf ich den Sarg mit in mein Schloss nehmen? Ich möchte Schneewittchen in Ehren halten."
+
+Die Zwerge waren erst traurig. Aber dann dachten sie: "Vielleicht ist es gut für Schneewittchen, wenn sie nicht mehr allein im Wald liegt." Sie sagten ja.
+
+Der Prinz liess den Sarg auf ein Pferd laden und ritt langsam davon. Als das Pferd auf dem holprigen Waldweg einmal stolperte, rüttelte der Sarg heftig. Und dabei geschah das Wunder: Das Stückchen Apfel, das in Schneewittchens Hals steckengeblieben war, rutschte heraus. Schneewittchen holte tief Luft und öffnete langsam die Augen.
+
+"Wo bin ich?" fragte sie leise.
+
+"Du bist bei mir", sagte der Prinz. "Und du lebst." Er lachte vor Freude, und Schneewittchen lachte mit. Er erzählte ihr alles, was passiert war. Sie weinten und lachten zugleich.
+
+Der Prinz brachte Schneewittchen in sein Schloss. Es wurde ein grosses Fest gefeiert. Die sieben Zwerge kamen auch. Sie trugen ihre besten Mützen und tanzten, obwohl sie das sonst nie taten. Schneewittchen umarmte jeden einzelnen. "Ihr habt mich gerettet, und ich vergesse euch nie."
+
+Und was war mit der bösen Königin? Sie hörte im Schloss von einer neuen, wunderschönen Prinzessin. Sie fragte wie immer ihren Spiegel:
+
+"Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
+
+Der Spiegel sagte:
+
+"Frau Königin, du bist schön, aber die junge Königin ist tausendmal schöner als du."
+
+Da wurde die Königin blass. Sie ahnte, wer diese junge Königin war. Sie ritt zum Schloss, um es mit eigenen Augen zu sehen. Als sie Schneewittchen in einem weissen Kleid auf der Treppe stehen sah, bekam sie einen so grossen Schreck, dass sie am liebsten davongerannt wäre. Aber es war zu spät: Die Wachen erkannten sie, und sie musste das Schloss verlassen. Sie ging weit fort und kam nie mehr zurück.
+
+Schneewittchen aber lebte im Schloss mit dem Prinzen. Sie besuchte die Zwerge oft. Sie fütterte wieder die Vögel am Fenster. Und sie streichelte wieder die Pferde im Stall. Der Zauberspiegel wurde in eine dunkle Kammer gestellt, und niemand sprach mehr mit ihm. Im Schloss lachten und sangen die Menschen, und Schneewittchen blieb freundlich zu allen, so wie ihre Mama es sich gewünscht hatte.

--- a/stories/grimm/aschenputtel/adaptions/contemporary/content.md
+++ b/stories/grimm/aschenputtel/adaptions/contemporary/content.md
@@ -5,28 +5,114 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal ein freundliches Mädchen namens Ella. Sie wohnte mit ihrem Papa, seiner neuen Frau und deren zwei Töchtern in einem grossen Haus. Die neue Frau war nicht nett zu Ella. Ihre Töchter auch nicht. Sie nannten Ella "Aschenputtel", weil sie den ganzen Tag putzen musste und ihre Kleider staubig waren.
+Es war einmal ein freundliches Mädchen namens Ella. Sie wohnte mit ihrem Papa in einem grossen Haus am Rand der Stadt. Das Haus war hell, hatte viele Fenster und einen schönen Garten. Vor dem Haus stand ein alter Haselnussbaum. Unter diesem Baum war das Grab von Ellas Mama, die vor einigen Jahren krank geworden und gestorben war. Jeden Morgen ging Ella zu dem Baum, legte eine Hand auf die Rinde und erzählte ihrer Mama, was sie heute vorhatte. Dann lächelte sie, auch wenn sie manchmal ein bisschen weinen musste.
 
-Am Abend legte Aschenputtel sich müde neben den warmen Ofen. Aber sie blieb immer freundlich, auch wenn die anderen gemein waren.
+Ella hatte von klein auf gern Tiere beobachtet. Wenn ein Eichhörnchen über den Zaun sprang, konnte sie stundenlang zuschauen. Die Vögel im Haselnussbaum kannten sie, und wenn sie aus dem Fenster lehnte, flatterten sie manchmal ganz nahe an sie heran. Der Papa sagte oft mit einem Lächeln: "Unser Ellachen hat ein weiches Herz, das ist ein Geschenk."
 
-Eines Tages hörten alle eine grosse Neuigkeit. Der Prinz machte ein Fest! Alle Mädchen im ganzen Land durften kommen. Die Stiefschwestern freuten sich sehr. "Wir gehen hin!" riefen sie. "Aber du, Aschenputtel, du bleibst zu Hause."
+Ellas Mama hatte ihr kurz vor ihrem Tod etwas Wichtiges gesagt: "Bleib freundlich, liebes Kind. Dann wird alles gut. Und wenn du mich brauchst, dann schau hinauf in den Baum, dort werde ich bei dir sein." Ella hatte das nie vergessen.
 
-Aschenputtel war traurig. Sie ging in den Garten zu einem kleinen Baum, den sie selber gepflanzt hatte. Oben im Baum sass ein weisses Vögelchen. "Warum weinst du?" fragte das Vögelchen.
+Nach einer langen Zeit lernte Ellas Papa eine neue Frau kennen. Er wollte nicht, dass Ella so allein aufwuchs, und auch er selber fühlte sich manchmal einsam. Die neue Frau war ordentlich und elegant und konnte schöne Kuchen backen. "Ich werde mich gut um euch kümmern", sagte sie. Ella versuchte, sich zu freuen.
 
-"Ich möchte auch zum Fest", sagte Aschenputtel.
+Die Frau hatte zwei Töchter, die mit ihnen ins grosse Haus einzogen. Die eine hiess Gertrud, die andere Ines. Beide hatten schöne lockige Haare und teure Kleider, aber sie waren nicht sehr freundlich. Solange der Papa im Zimmer war, benahmen sie sich ganz brav. Aber sobald er das Haus verliess, fing das Ärgern an.
 
-Das Vögelchen zwitscherte fröhlich. Plötzlich lag vor Aschenputtel ein wunderschönes Kleid aus Gold und Silber, und daneben zwei glitzernde Schuhe. Sie zog alles an und lief zum Schloss.
+"Warum sitzt du in unserem Sessel?" sagte die eine. "Das ist jetzt unser Sessel, nicht deiner!"
 
-Als Aschenputtel im Saal stand, schaute der Prinz sie an. Er war verzaubert. "Darf ich mit dir tanzen?" fragte er. Sie tanzten den ganzen Abend. Der Prinz wollte mit keinem anderen Mädchen tanzen, nur mit ihr.
+"Und unsere Puppen sind jetzt auch unsere Puppen", sagte Ines. "Du kannst ja mit dem Besen spielen!"
 
-Als die Uhr spät war, musste Aschenputtel schnell nach Hause. Sie rannte so schnell, dass ein Schuh von ihrem Fuss rutschte und auf der Treppe liegen blieb. Der Prinz fand den Schuh und hob ihn auf.
+Sie lachten, und die Stiefmutter lachte leise mit. Ella sagte dem Papa nichts, denn sie wollte ihn nicht traurig machen. Und er bemerkte selber kaum etwas, weil er den ganzen Tag in der Werkstatt arbeitete.
 
-"Wem dieser Schuh passt, das ist meine Freundin", sagte der Prinz. Er ging von Haus zu Haus. Jedes Mädchen probierte den Schuh. Aber er passte niemandem.
+Von diesem Tag an musste Ella fast alles in Haus und Garten machen. Sie stand früh vor Tag auf. Sie trug Wasser vom Brunnen. Sie machte im Ofen Feuer. Sie wischte den Boden. Sie putzte die Fenster. Sie kochte Suppe und Brei. Sie schälte Kartoffeln. Sie hängte die Wäsche auf. Sie putzte die Schuhe der Stiefschwestern. Sie bürstete ihnen am Morgen die Haare, und am Abend machte sie ihnen heisse Milch mit Honig.
 
-Endlich kam der Prinz auch zu Aschenputtels Haus. Die Stiefschwestern drängten ihre Füsse in den Schuh, doch er war zu klein. "Gibt es hier noch ein Mädchen?" fragte der Prinz.
+Am Abend war sie so müde, dass sie keine Lust mehr hatte, in ihr richtiges Bett zu gehen. Sie setzte sich neben den warmen Ofen, und dort schlief sie dann ein. Weil sie jeden Morgen voller Asche aufwachte, riefen die Stiefschwestern lachend: "Das ist doch kein Mädchen, das ist ein Aschenputtel!" Der Name blieb, und bald nannten sie alle nur noch so. Manchmal schütteten die Stiefschwestern sogar eine Hand voll Linsen in die Asche und sagten gemein: "Les sie wieder raus, Aschenputtel, sonst wird's Ärger geben." Und Aschenputtel setzte sich dann geduldig auf den Boden und las Linsen aus der Asche, Körnchen für Körnchen.
 
-Aschenputtel trat leise aus der Küche. Sie streifte den Schuh über den Fuss – und er passte genau! Der Prinz lachte vor Freude.
+Aschenputtel trug ein graues Kleid und Holzschuhe, doch sie blieb freundlich. Jeden Morgen ging sie zu dem Haselnussbaum am Grab ihrer Mama. Manchmal kam ein weisses Vöglein auf einen Ast und schaute Aschenputtel mit glänzenden Augen an. "Sei gegrüsst, kleines Vöglein", sagte Aschenputtel. "Bitte sag meiner Mama, dass ich an sie denke." Das Vöglein zwitscherte leise und flog davon.
 
-"Komm mit mir ins Schloss", sagte er. "Dort musst du nie mehr putzen."
+Einmal sollte der Papa zu einem grossen Markt in der Nachbarstadt fahren. Er fragte alle drei Mädchen, was er ihnen mitbringen solle.
 
-Und so ging Aschenputtel mit dem Prinzen ins Schloss. Sie lebten glücklich zusammen und blieben Freunde für immer.
+"Ein schönes rosa Kleid!" rief Gertrud.
+
+"Goldene Ohrringe und eine Kette!" rief Ines.
+
+"Und du, Aschenputtel?" fragte der Papa.
+
+Aschenputtel überlegte kurz. "Bring mir bitte den ersten Zweig mit, der dir auf dem Heimweg an den Hut stösst."
+
+Der Papa lachte. "Das ist ja ein kleiner Wunsch." Auf dem Heimweg ritt er durch einen grünen Busch, und ein zarter Haselzweig streifte ihm den Hut. Er brach ihn vorsichtig ab und nahm ihn mit. Zu Hause verteilte er die Geschenke. Gertrud und Ines hüpften vor Freude. Aschenputtel nahm den Haselzweig in beide Hände und sagte leise: "Danke, Papa."
+
+Am selben Abend ging sie zum Grab ihrer Mama und pflanzte den Zweig in die weiche Erde. Sie weinte ein wenig, und ihre Tränen tropften auf die Erde. In der Nacht begann der Zweig zu wachsen. Aus dem kleinen Zweig wurde ein kleiner Busch, und aus dem Busch wurde mit der Zeit ein hoher Baum. Das weisse Vöglein, das Aschenputtel oft besucht hatte, liebte den neuen Baum sofort und nistete darin.
+
+Eines Tages kam eine grosse Neuigkeit in die Stadt. Der Prinz im Schloss wollte heiraten. Dazu machte der König ein grosses Fest. Alle jungen Mädchen im ganzen Land durften drei Abende lang ins Schloss kommen. Der Prinz wollte dort seine zukünftige Freundin finden.
+
+Die Stiefschwestern waren ausser sich vor Freude. "Schnell, Aschenputtel!" riefen sie. "Kämm uns die Haare! Putz uns die Schuhe! Wir müssen die schönsten Mädchen auf dem Fest sein!"
+
+Aschenputtel kämmte, bürstete und putzte. Dabei dachte sie leise: "Ich würde auch so gerne tanzen." Sie nahm all ihren Mut zusammen und fragte die Stiefmutter: "Darf ich auch mit aufs Schloss?"
+
+Die Stiefmutter schaute sie streng an. "Du? Mit deinem grauen Kleid und den Holzschuhen? Du würdest nur ausgelacht. Nein, Aschenputtel. Du bleibst zu Hause."
+
+Doch Aschenputtel bettelte so lieb, dass die Stiefmutter endlich sagte: "Also gut. Ich schütte dir eine Schüssel Linsen in die Asche. Wenn du sie in zwei Stunden wieder ausgelesen hast, darfst du mitkommen." Und schon leerte sie eine ganze Schüssel Linsen in den Kamin.
+
+Aschenputtel setzte sich auf den Boden und schaute in die Asche. "Das schaffe ich nie allein", flüsterte sie. Da lief sie schnell hinaus zum Haselnussbaum und rief: "Liebe Vöglein, bitte helft mir!"
+
+Im Nu flogen zwei Tauben, ein paar Spatzen und sogar ein rotes Rotkehlchen durchs Fenster. Sie pickten pick, pick, pick – die guten Linsen kamen in die Schüssel, die schlechten blieben in der Asche. Schon nach einer Stunde war alles sauber. "Danke, danke!" rief Aschenputtel. Die Vögel zwitscherten und flogen wieder hinaus.
+
+Voller Freude trug sie die Schüssel zu der Stiefmutter. "Ich habe alle Linsen ausgelesen!"
+
+Aber die Stiefmutter verzog das Gesicht. "Das geht viel zu schnell. Du musst geschummelt haben. Ich schütte dir noch zwei Schüsseln in die Asche, und wenn du die in einer Stunde auch ausgelesen hast, darfst du mit." Sie schüttete zwei volle Schüsseln in die Asche und lachte hämisch.
+
+Aschenputtel lief wieder in den Garten und rief die Vögel. Diesmal kamen noch mehr. Die ganze Küche war voller Flügel, Schnäbel und leisem Gurren. Pick, pick, pick – die Linsen flogen in die Schüsseln. In einer halben Stunde war alles fertig.
+
+"Fertig!" rief Aschenputtel und stellte die Schüsseln vor die Stiefmutter.
+
+Aber die Stiefmutter verzog das Gesicht erst recht. "Das gilt nicht. Du hast kein Kleid und keine Tanzschuhe. Du bleibst hier." Und schon eilte sie mit ihren zwei stolzen Töchtern zur Kutsche.
+
+Aschenputtel wischte sich eine Träne ab. Dann ging sie langsam in den Garten zu ihrem Haselnussbaum. Sie schaute hinauf und sprach leise: "Liebes Bäumchen, schüttel dich, wirf ein schönes Kleid für mich." Da raschelten die Blätter, und aus dem Baum fiel ein wunderschönes Kleid aus Gold und Silber. Daneben lagen zwei glitzernde Pantoffeln, fein wie gesponnen aus Sternenlicht.
+
+Aschenputtel zog das Kleid an. Dann lief sie zum Schloss. Im grossen Saal strahlten Kerzen und Lichter. Alle tanzten. Als Aschenputtel hereintrat, wurde es plötzlich ganz still. Sogar der Prinz blieb stehen.
+
+"Wer ist diese schöne Königstochter?" fragten die Leute. Keiner erkannte Aschenputtel, nicht einmal die Stiefschwestern. Der Prinz kam zu ihr, lachte und sagte: "Darf ich mit dir tanzen?"
+
+Sie tanzten den ganzen Abend miteinander. Kam ein anderes Mädchen und wollte den Prinzen auffordern, sagte er freundlich: "Entschuldige, ich tanze heute nur mit ihr."
+
+Als die grosse Uhr im Saal elfmal schlug, sagte Aschenputtel: "Ich muss nach Hause." Sie lief schnell aus dem Saal und verschwand im Dunkeln, bevor der Prinz fragen konnte, wer sie war. Zu Hause legte sie das Kleid und die Pantoffeln unter den Baum. Das Vöglein nahm sie mit. Da sass Aschenputtel wieder im grauen Kleid neben dem Ofen, und niemand ahnte etwas.
+
+Am zweiten Abend gab es wieder ein Fest. Wieder mussten die Stiefschwestern gekämmt und geputzt werden. Wieder beschwerte sich Gertrud, dass ihr Haar zu kraus sei, und Ines, dass die Schleife zu klein sei. Und wieder eilten sie endlich mit der Stiefmutter zur Kutsche.
+
+Als das Haus still war, ging Aschenputtel zum Haselnussbaum. "Liebes Bäumchen, schüttel dich, wirf ein noch schöneres Kleid für mich." Und schon fiel ein Kleid herab, das noch heller strahlte als das erste, mit kleinen silbernen Sternen darauf.
+
+Als Aschenputtel im Saal erschien, blieb dem Prinzen der Mund offen. "Du bist gekommen!" rief er. Den ganzen Abend tanzte er nur mit ihr. "Wer bist du? Woher kommst du?" fragte er. Aber Aschenputtel lächelte nur und drehte sich mit ihm im Kreis. Die Kerzen flackerten, die Geigen spielten, und Aschenputtel war so glücklich, dass sie für einen Moment ganz vergass, dass sie Aschenputtel hiess.
+
+Kurz bevor die Uhr wieder elf schlug, lief sie weg. Der Prinz rannte ihr nach, aber Aschenputtel sprang in den Schlossgarten und versteckte sich geschickt hinter einem grossen Birnbaum. Der Prinz lief an ihr vorbei, ohne sie zu sehen. Dann schlüpfte sie nach Hause, legte das Kleid und die Pantoffeln wieder zurück unter den Haselnussbaum, und als die Stiefmutter mit den Schwestern heimkam, sass Aschenputtel längst wieder im grauen Kittel am Ofen.
+
+Am dritten Abend war Aschenputtel wieder ganz allein im Haus. "Liebes Bäumchen, schüttel dich, wirf das allerschönste Kleid für mich." Und was vom Baum herabfiel, war so prächtig, dass Aschenputtel fast die Augen zukneifen musste. Die Pantoffeln waren aus reinem Gold.
+
+Im Schloss wartete der Prinz schon an der Tür. Diesmal hatte er eine List. Heimlich hatte er den Diener bitten lassen, die grosse Treppe mit ein bisschen klebrigem Honig zu bestreichen. "Wenn sie wegläuft", dachte der Prinz, "dann verliert sie vielleicht einen Schuh, und dann finde ich sie wieder."
+
+Sie tanzten und lachten. Aschenputtel hatte so viel Freude wie noch nie. Doch als die Uhr zu schlagen begann, sprang sie auf und lief zur Treppe. Der klebrige Honig hielt ihren linken Pantoffel fest – und der Schuh blieb auf der Stufe liegen! Aschenputtel rannte einfach weiter. Der Prinz hob den goldenen Pantoffel auf und drückte ihn an sein Herz.
+
+Am nächsten Morgen liess der Prinz in der ganzen Stadt ausrufen: "Das Mädchen, dem dieser goldene Schuh passt, das soll meine Freundin werden!"
+
+Die Leute lachten und staunten. Die Stiefmutter hörte den Ausruf und klatschte in die Hände. "Das ist unsere Chance!" rief sie.
+
+Der Prinz ritt von Haus zu Haus. Jedes Mädchen durfte den Schuh anprobieren. Eines hatte zu dicke Zehen, eines zu breite Fersen, und manchen rutschte der Schuh gleich wieder vom Fuss. Keinem passte der goldene Pantoffel.
+
+Endlich kam der Prinz auch zu Aschenputtels Haus. Die grosse Stiefschwester Gertrud setzte sich auf den Stuhl und drückte den Fuss in den Schuh. "Ich bin die Richtige, ich!" Aber ihr Fuss war zu gross. Die Zehe passte nicht hinein, egal wie sehr sie sich anstrengte. Die Stiefmutter flüsterte: "Drück stärker, mein Kind!" Doch es half nichts. Gertrud stand enttäuscht auf.
+
+Nun kam Ines. Sie zwängte und drückte, aber ihre Ferse war zu gross. Sie versuchte, auf den Zehen zu wackeln, aber der Schuh fiel wieder ab. Auch sie konnte den Schuh nicht anziehen. Sie warf ihn ärgerlich auf den Boden.
+
+Der Prinz fragte ernst: "Habt ihr noch eine andere Tochter?"
+
+Die Stiefmutter schüttelte schnell den Kopf. "Nein, nur ein kleines Aschenputtel, aber die ist ganz schmutzig und kann unmöglich gemeint sein."
+
+"Ich möchte sie trotzdem sehen", sagte der Prinz.
+
+Aschenputtel wurde aus der Küche gerufen. Sie wusch sich die Hände und kam leise herein. Sie setzte sich auf den Schemel, zog den Holzschuh aus und schlüpfte in den goldenen Pantoffel. Er passte genau, wie für sie gemacht.
+
+Als sie aufstand und dem Prinzen ins Gesicht schaute, lachte er vor Freude. "Das ist sie! Das ist die Tänzerin aus dem Schloss!"
+
+Die Stiefmutter und die zwei Schwestern wurden ganz blass. Aber niemand schimpfte mit ihnen. Aschenputtel sagte freundlich: "Heute ist ein schöner Tag. Bitte seid nicht mehr böse." Dann ging sie mit dem Prinzen zum Pferd. Als sie am Haselnussbaum vorbeikamen, setzten sich zwei weisse Tauben auf Aschenputtels Schultern. Sie gurrten leise, so als ob die Mama aus dem Himmel zurückgrüssen würde.
+
+Im Schloss wurde ein grosses Fest gefeiert. Es gab Musik, Tanz und viele Kinder aus der ganzen Stadt. Aschenputtel trug ihr goldenes Kleid, aber am liebsten zog sie später ein einfaches blaues an, in dem sie gut durch den Schlossgarten rennen konnte.
+
+Die Stiefschwestern wurden mit der Zeit etwas freundlicher, weil Aschenputtel ihnen immer wieder verzieh. Und wenn Aschenputtel zu Besuch bei ihrem alten Zuhause war, ging sie zuerst zum Haselnussbaum. Sie legte eine Hand auf die Rinde und sagte leise: "Danke, liebe Mama."
+
+Im Baum zwitscherte jedes Mal ein kleines weisses Vöglein.

--- a/stories/grimm/hansel_und_gretel/adaptions/contemporary/content.md
+++ b/stories/grimm/hansel_und_gretel/adaptions/contemporary/content.md
@@ -5,28 +5,114 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Hänsel und Gretel waren Geschwister. Sie wohnten in einem kleinen Haus am Rand eines grossen Waldes. Manchmal hatten sie nicht viel zu essen, aber sie hatten sich lieb.
+Am Rand eines grossen, dunklen Waldes stand ein kleines Haus aus Holz. In diesem Haus wohnte ein Holzfäller mit seinen zwei Kindern. Der Junge hiess Hänsel, und seine Schwester hiess Gretel. Die beiden hatten sich sehr lieb. Wenn es regnete, sassen sie am Fenster und schauten den Tropfen zu. Wenn die Sonne schien, rannten sie zwischen die Bäume und suchten Tannzapfen. Im Sommer pflückten sie Himbeeren, im Herbst sammelten sie Pilze, und im Winter bauten sie kleine Schneemänner vor der Tür. Sie waren nicht reich, aber sie hatten einander.
 
-Eines Tages gingen Hänsel und Gretel in den Wald, um Beeren zu suchen. Hänsel steckte vorsichtig Brotkrumen in seine Tasche. "Damit wir wieder nach Hause finden", sagte er klug. Unterwegs streute er die Krumen auf den Weg.
+Ihre richtige Mama war schon vor langer Zeit gestorben. Der Papa hatte dann eine neue Frau geheiratet, damit Hänsel und Gretel nicht ganz ohne Mutter aufwuchsen. Die neue Frau war nicht gemein, aber sie war auch nicht besonders freundlich. Sie hatte keine Geduld mit Kindern und seufzte oft. Der Papa liebte seine Kinder über alles. Er war ein guter Mann, aber er war auch ein bisschen ängstlich, und manchmal wagte er es nicht, der Stiefmutter zu widersprechen.
 
-Sie pflückten Beeren, lachten und spielten zwischen den Bäumen. Doch als sie zurück wollten, waren die Brotkrumen weg. Ein paar hungrige Vögel hatten sie aufgepickt!
+Eines Tages wurde es im Dorf schwierig. Die Ernte war schlecht. Die Felder waren leer. Im Bach gab es fast keine Fische. In vielen Häusern fehlte das Brot. Auch beim Holzfäller stand bald nur noch ein kleiner trockener Laib auf dem Tisch. Die Stiefmutter machte ein sorgenvolles Gesicht. "Wir haben nicht genug für alle vier", sagte sie am Abend leise zum Vater. "Wir müssen etwas tun."
 
-"Wir haben uns verirrt", sagte Gretel. Der Wald wurde dunkel. Hänsel nahm die Hand seiner Schwester.
+Der Papa schwieg lange. "Was meinst du?"
 
-Plötzlich sahen sie etwas Merkwürdiges zwischen den Bäumen. Ein Haus! Aber was für ein Haus! Die Wände waren aus Lebkuchen. Das Dach bestand aus Schokolade. Die Fenster glitzerten wie Zuckerguss.
+"Wir bringen die Kinder morgen in den Wald", flüsterte die Stiefmutter. "Ganz tief hinein. Dort finden sie schon etwas zu essen. Besser, sie lernen selbst für sich zu sorgen, als dass wir alle vier hungern."
 
-Hänsel und Gretel waren hungrig. Ganz vorsichtig brachen sie ein kleines Stück vom Dach ab und probierten. "Mmm, süss!" riefen sie.
+"Aber sie sind doch noch so klein", sagte der Papa und rieb sich die Augen. Doch die Stiefmutter liess nicht locker, und am Ende gab der Papa ihr traurig nach.
 
-Die Tür öffnete sich. Eine alte Frau kam heraus. Sie schaute ein bisschen streng. "Kommt mit rein", sagte sie. "Ich habe Milch und Kuchen für euch."
+Hänsel und Gretel lagen hellwach in ihrem Bett und hörten alles. Gretel bekam feuchte Augen. "Hänsel, was sollen wir machen?"
 
-Die Kinder gingen hinein. Die Frau gab ihnen Essen, aber sie sagte komisch: "Bleibt nur hier, ich brauche Hilfe im Haus."
+"Keine Sorge, kleine Schwester", flüsterte Hänsel. "Ich habe eine Idee." Als die Erwachsenen endlich eingeschlafen waren, schlich Hänsel leise aus dem Haus. Der Mond schien hell wie eine grosse silberne Münze. Vor der Tür glitzerten weisse Kieselsteine wie kleine Sterne. Hänsel steckte sich die Taschen voll Kieselsteine. Er sammelte so viele, wie nur in seine beiden Hosentaschen und in die Jackentasche passten. Dann schlich er zurück, legte sich zu seiner Schwester und flüsterte: "Schlaf gut. Ich passe auf uns auf."
 
-Gretel merkte schnell, dass die Frau sie gar nicht mehr gehen lassen wollte. "Wir müssen doch nach Hause zum Papa!", sagte sie mutig.
+Am Morgen, noch bevor die Sonne ganz aufgegangen war, weckte die Stiefmutter sie. "Steht auf, ihr Faulpelze! Wir gehen in den Wald Holz holen." Sie gab jedem Kind ein kleines Stück Brot. "Das ist für den Mittag. Esst es nicht vorher auf."
 
-Die Frau murmelte und wollte sie nicht ziehen lassen. Da hatte Gretel eine Idee. "Können Sie mir bitte zeigen, wo der Backofen ist?" fragte sie höflich. Als die Frau sich bückte, um den Ofen zu zeigen, sprangen Hänsel und Gretel durch die Tür und rannten weg, so schnell sie konnten.
+Die Familie machte sich auf den Weg. Immer wieder blieb Hänsel stehen und schaute zurück zum Haus. "Was guckst du denn dauernd, Hänsel?" fragte der Vater.
 
-Sie liefen und liefen, bis sie einen Bach fanden. Auf dem Bach schwamm eine weisse Ente. "Liebe Ente, hilfst du uns über das Wasser?" fragte Gretel. Die Ente nickte und brachte sie sicher ans andere Ufer.
+"Ich schau nur zum weissen Kätzchen auf dem Dach, das mir Tschüss winkt", sagte Hänsel.
 
-Am Waldrand stand ihr Papa. Er hatte sie lange gesucht und rief: "Meine Kinder!" Er nahm beide in die Arme und drückte sie fest.
+"Ach Unsinn", sagte die Stiefmutter. "Das ist doch nur die Morgensonne auf dem Schornstein." Dabei warf Hänsel heimlich einen Kieselstein nach dem anderen auf den Weg. Klick. Klick. Klick. Immer wenn niemand schaute.
 
-Hänsel und Gretel zeigten ihm Nüsse und Beeren, die sie im Wald gefunden hatten. Von nun an hatten sie immer genug zu essen. Und nie mehr gingen sie ohne den Papa in den Wald.
+Im tiefen Wald machte der Vater ein kleines Feuer aus Ästen. "Bleibt hier sitzen und wärmt euch", sagte er leise, und seine Stimme zitterte ein wenig. "Wir gehen nur Holz hacken und kommen gleich zurück." Dann ging er mit der Stiefmutter weg.
+
+Hänsel und Gretel warteten. Sie assen ihr trockenes Brot in kleinen Bissen, damit es länger reichte. Die Sonne wanderte. In der Ferne hörten sie Schläge wie von einer Axt. Aber in Wirklichkeit war es nur ein loser Ast, den die Stiefmutter an einen Baum gebunden hatte, damit er im Wind hin- und herschlug. Vögel riefen. Schmetterlinge flatterten. Niemand kam zurück. Irgendwann fielen den Kindern die Augen zu, und sie schliefen am Feuer ein. Als sie aufwachten, war es schon dunkel.
+
+Gretel begann zu weinen. "Hänsel, wir sind allein!"
+
+"Hab keine Angst", sagte Hänsel und nahm ihre Hand. "Warte, bis der Mond aufgeht." Und wirklich, als der Mond durch die Baumkronen leuchtete, blitzten unten auf dem Waldboden die Kieselsteine. Sie schimmerten wie kleine Sterne. Hänsel und Gretel gingen von Stein zu Stein, Hand in Hand, die ganze Nacht hindurch. Als die Sonne wieder aufging, standen sie vor ihrem eigenen Haus.
+
+Der Vater erschrak fast vor Freude, als er sie sah. Er riss die Tür auf, lief ihnen entgegen und umarmte beide Kinder ganz fest. "Meine Kinder! Ich habe die ganze Nacht nicht geschlafen! Ich dachte schon, ich sehe euch nie wieder!" Er hatte Tränen in den Augen. Auch die Stiefmutter war überrascht – aber nicht ganz glücklich. Sie sagte nur spitz: "Da seid ihr ja endlich. Das nächste Mal bleibt ihr nicht so lange weg."
+
+Eine Weile ging es wieder. Das bisschen Brot reichte für einige Tage. Hänsel und Gretel halfen, wo sie konnten: Sie sammelten Tannzapfen für das Feuer, und Gretel flickte kleine Löcher im Hemd des Vaters. Aber das Essen wurde immer weniger. Wieder schmolzen die Vorräte zusammen. Eines Abends hörten die Kinder die Stiefmutter wieder leise reden: "Morgen müssen sie mit uns weiter in den Wald, noch tiefer diesmal. Diesmal sollen sie den Weg nicht mehr finden." Der Vater seufzte, aber er sagte nichts. Er wagte es nicht, ihr zu widersprechen.
+
+Hänsel wollte wieder Kieselsteine holen. Er stand leise auf und ging zur Tür. Doch die Tür war abgeschlossen! Hänsel drückte an der Klinke. Nichts. Er seufzte und kroch zurück ins Bett. "Keine Angst", sagte er zu Gretel. "Morgen denke ich mir etwas anderes aus."
+
+Am nächsten Morgen bekam jedes Kind ein kleines Stück Brot für den Weg. Das Brot war diesmal noch kleiner als beim letzten Mal. Hänsel steckte es in die Tasche, aber er ass es nicht. Stattdessen krümelte er es heimlich: er brach kleine Bröckchen ab und liess sie auf dem Weg fallen. Bröckchen um Bröckchen, sehr vorsichtig, damit niemand es sah.
+
+"Hänsel, was bleibst du denn immer stehen?" fragte der Vater.
+
+"Ich schau nur zu meinem Täubchen auf dem Dach", antwortete Hänsel.
+
+"Das ist dein Täubchen nicht", zischte die Stiefmutter. "Das ist die Morgensonne auf dem Schornstein. Geh weiter!"
+
+Es wurde diesmal viel länger gelaufen. Die Bäume wurden immer dicker, und der Pfad wurde immer schmaler. Schliesslich kamen sie an eine Stelle, an der Hänsel und Gretel noch nie gewesen waren. Hier machte der Vater wieder ein Feuer. "Ruht euch aus", sagte er leise. "Wir kommen bald zurück." Aber Hänsel merkte an seiner Stimme, dass er traurig war.
+
+Die Kinder warteten. Sie teilten sich das letzte Stück Brot, das Gretel noch hatte. Dann schliefen sie ein. Als sie aufwachten, war es dunkle Nacht. "Schnell", sagte Hänsel, "wir folgen den Brotkrumen." Aber – oh weh! Die Brotkrumen waren weg. Kleine Waldvögel hatten jeden Krümel aufgepickt. Auf dem Weg lag nur noch Erde.
+
+Gretel setzte sich auf einen Baumstamm. "Wir sind verloren, Hänsel."
+
+Hänsel setzte sich neben sie. "Wir finden einen Weg", sagte er. "Wir halten zusammen. Immer." Sie gingen los, einen Tag, dann noch einen Tag. Sie assen ein paar wilde Beeren. Sie tranken aus einem kleinen Bach. Ihre Füsse wurden müde, ihre Augen schwer. Manchmal hörte Gretel ein Rascheln und hatte Angst. Hänsel drückte dann ihre Hand.
+
+Am dritten Morgen sahen sie ein weisses Vögelchen auf einem Ast. Es sang ein so fröhliches Lied, dass Hänsel und Gretel stehen blieben, um zuzuhören. "Schau!" rief Gretel und zeigte mit dem Finger nach oben. Das Vögelchen schaute sie mit freundlichen Augen an, flog ein Stück, landete auf dem nächsten Ast und schaute wieder zurück, als ob es sagen wollte: "Kommt mit." Die Kinder liefen hinterher. Das Vögelchen hüpfte von Baum zu Baum, und Hänsel und Gretel folgten ihm immer tiefer in den Wald. Nach einer Weile kamen sie auf eine helle Lichtung. Und dort – ein kleines Haus! Aber was für ein Haus!
+
+Die Wände waren aus Lebkuchen. Das Dach war aus Schokolade. Die Fenster glitzerten wie Zuckerguss. An der Tür hingen Gummibärchen und Bonbons. Hänsel und Gretel schauten einander mit grossen Augen an.
+
+"Oh!" rief Hänsel. "Ich habe so Hunger!"
+
+"Ich auch!" rief Gretel.
+
+Sie brachen ganz vorsichtig ein kleines Stück vom Dach ab. Süss! Herrlich süss! Sie kauten und kauten. Hänsel griff nach einem Stück Schokoladenziegel, und Gretel knabberte an einer Fensterscheibe aus Zucker. Plötzlich hörten sie eine feine Stimme aus dem Haus rufen:
+
+"Knusper, knusper, knäuschen, wer knuspert an meinem Häuschen?"
+
+Hänsel und Gretel wussten keine Antwort und riefen einfach lustig: "Der Wind, der Wind, das himmlische Kind!" Sie assen weiter.
+
+Da öffnete sich die Tür, und eine alte Frau kam heraus. Sie stützte sich auf einen krummen Stock. Sie trug eine grosse Brille, ihre Haare waren weiss, und ihr Lächeln war ein wenig komisch. "Ei, ei, liebe Kinder", sagte sie mit süsser Stimme. "Habt ihr Hunger? Kommt herein, ich habe noch viel mehr zu essen."
+
+Hänsel und Gretel folgten ihr. Im Haus roch es wunderbar nach Pfannkuchen und Apfelmus. Auf dem Tisch standen Milch, Kekse und Obst. Die Kinder assen sich satt. Dann zeigte ihnen die Frau zwei kleine Betten. "Schlaft", sagte sie. "Hier seid ihr sicher."
+
+In der Nacht aber konnte Gretel nicht gut schlafen. Sie hatte ein komisches Gefühl. Die alte Frau murmelte im Nebenzimmer seltsame Worte. Am Morgen war plötzlich alles anders. Die freundliche Frau lachte gar nicht mehr. Sie schob Hänsel in ein kleines Zimmer mit einer Gittertür. "Du bleibst hier, Junge. Iss schön alles auf. Und du, Mädchen, du machst im Haus sauber. Hol Wasser, koch für deinen Bruder, damit er gross und satt wird!"
+
+Gretel begriff: Die Frau war eine Hexe. Sie wollte Hänsel nicht mehr gehen lassen. Gretels Herz schlug schnell. Aber sie zeigte es nicht. "Ja, ich helfe", sagte sie höflich und machte sich an die Arbeit.
+
+Jeden Morgen kam die Hexe zu Hänsels Türchen und rief: "Streck mal einen Finger raus. Ich will sehen, ob du schon kräftig bist."
+
+Hänsel war klug. Statt seines Fingers streckte er einen kleinen dünnen Zweig heraus, den er auf dem Boden gefunden hatte. Die Hexe sah nicht gut – Hexen haben oft schlechte Augen. Sie befühlte den Zweig und dachte: "Ach, der Junge ist ja immer noch so dünn! Das kann doch nicht sein." So ging Tag um Tag, dann Woche um Woche. Hänsel bekam jeden Morgen ein gutes Frühstück mit Milch, Pfannkuchen und Apfelkompott, und Gretel bekam nur harte Brotrinden und ein paar Krebsschalen. Gretel war manchmal so müde, dass sie sich beim Putzen hinsetzen und kurz ausruhen musste, aber sie dachte jeden Tag an Hänsel und machte weiter.
+
+Nach einigen Wochen wurde die Hexe ungeduldig. "Heute morgen", rief sie, "backe ich grosse Brote im Ofen. Und danach ist Schluss mit dem Warten!" Sie heizte den Backofen richtig ein. Flammen züngelten heraus.
+
+"Mädchen", sagte die Hexe, "geh mal hinein und schau nach, ob der Ofen heiss genug ist."
+
+Gretel schaute den Ofen an. Sie spürte: Das ist eine Falle. Die Hexe wollte sie in den Ofen schieben. Aber Gretel tat so, als wäre sie ganz dumm. "Oh, liebe Frau", sagte sie unschuldig, "ich weiss gar nicht, wie das geht. Wie kommt man da hinein? Zeig es mir bitte."
+
+"Dummes Mädchen!" schnaufte die Hexe. "Schau her, so!" Sie beugte sich weit vor, bis fast ihr ganzer Kopf im Ofen war.
+
+Gretel atmete tief durch. Dann gab sie der Hexe einen ganz kleinen Schubs, und die Hexe rutschte in den Ofen hinein. Gretel schlug die Ofentür zu und schob einen Riegel davor. Die Hexe konnte nicht mehr heraus. So etwas Böses hätte sie mit den Kindern tun wollen, und nun blieb sie dort.
+
+Gretel rannte zu Hänsels Türchen. "Hänsel, Hänsel, die Hexe ist weg, wir sind frei!" Sie öffnete die Gittertür, und Hänsel sprang heraus wie ein junger Vogel, der aus dem Käfig darf. Die beiden fielen sich in die Arme, lachten und weinten zugleich.
+
+Dann schauten sie sich im Haus der Hexe um. Überall standen kleine Kisten. In den Kisten waren Perlen, bunte Steine und sogar richtige Goldstücke. "Die nehmen wir mit", sagte Hänsel. "Die sind besser als Kieselsteine." Sie füllten sich die Taschen und Gretels Schürze.
+
+Dann machten sie sich auf den Weg nach Hause. Sie wanderten stundenlang durch den Wald. Am Mittag assen sie Beeren und tranken aus einem kleinen Bach. Gretel pflückte einen Strauss Wiesenblumen für den Papa. Nach einer Weile kamen sie an einen breiten Bach. "Wie kommen wir da hinüber?" fragte Hänsel. Es gab keine Brücke, keinen Steg und kein Boot.
+
+Da sahen sie eine weisse Ente auf dem Wasser. Sie hatte einen freundlichen Blick. "Liebes Entchen", sagte Gretel, "kannst du uns bitte über das Wasser tragen?"
+
+"Quak!" machte die Ente und schwamm ans Ufer. Hänsel setzte sich als Erster auf ihren Rücken, und die Ente brachte ihn sicher auf die andere Seite. Dann kam sie zurück und holte auch Gretel. "Danke, liebes Entchen", riefen die Kinder und winkten.
+
+Der Weg wurde wieder vertrauter. Bäume, die sie schon kannten. Pfade, die sie schon gegangen waren. Und endlich – da war es! Das kleine Holzhaus am Waldrand.
+
+Sie rannten auf die Tür zu. "Papa! Papa!"
+
+Der Vater öffnete und schrie fast vor Freude. Er umarmte Hänsel und Gretel ganz fest. "Meine Kinder! Ich habe jeden Tag an euch gedacht! Ich habe euch gesucht und gesucht!" Er hatte Tränen in den Augen. Die Stiefmutter war nicht mehr da. Sie war in der Zwischenzeit weggezogen.
+
+Gretel schüttelte die Schürze aus. Perlen und kleine Goldstücke rollten über den Boden. Hänsel leerte seine Taschen. "Jetzt haben wir genug", sagte er. "Jetzt müssen wir nie mehr hungern."
+
+Der Vater lachte und weinte zugleich. Er setzte die Kinder an den Tisch und kochte eine warme Suppe. Draussen ging die Sonne unter, und durch das Fenster kam ein leises Zwitschern. Auf dem Fensterbrett sass ein kleines weisses Vögelchen. Vielleicht war es dasselbe, das sie damals zu dem Lebkuchenhaus gebracht hatte. Oder ein anderes. Es zwitscherte fröhlich – so als würde es sagen: "Jetzt seid ihr daheim."
+
+Von da an gingen Hänsel und Gretel nie wieder allein in den tiefen Wald. Sie wanderten nur noch mit dem Papa, und wenn Gretel manchmal ein bisschen Angst bekam, nahm Hänsel ihre Hand und flüsterte: "Wir halten zusammen. Immer."

--- a/stories/grimm/rapunzel/adaptions/contemporary/content.md
+++ b/stories/grimm/rapunzel/adaptions/contemporary/content.md
@@ -5,32 +5,94 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal ein Mädchen mit Haaren so lang und gold wie Sonnenstrahlen. Sein Name war Rapunzel. Rapunzel wohnte in einem hohen Turm mitten im Wald. Eine strenge Fee hatte sie vor langer Zeit dorthin gebracht und passte auf sie auf.
+Vor vielen Jahren lebten einmal ein Mann und eine Frau in einem kleinen Haus am Rand eines Dorfes. Sie hatten sich lieb, und sie wünschten sich nichts sehnlicher als ein Kind. Aber lange, lange blieb dieser Wunsch unerfüllt.
 
-Der Turm hatte keine Tür. Nur ein kleines Fenster ganz oben. Wenn die Fee Rapunzel besuchen wollte, rief sie:
+Hinter ihrem Haus stand eine hohe Mauer. Dahinter lag ein wunderschöner Garten. In diesem Garten wuchsen die buntesten Blumen und die saftigsten Kräuter. Der Garten gehörte einer alten Zauberin. Alle im Dorf hatten grossen Respekt vor ihr, denn sie konnte wirklich zaubern. Niemand ging freiwillig in ihren Garten.
+
+Eines Tages schaute die Frau aus dem Fenster und sah ein Beet voll frischer, grüner Rapunzelblätter. Die Blätter sahen so saftig und köstlich aus, dass die Frau plötzlich grossen Hunger darauf bekam. "Ich muss ein paar davon haben", sagte sie leise. "Sonst werde ich noch krank vor Sehnsucht."
+
+Der Mann hatte seine Frau sehr lieb. Er wollte nicht, dass sie traurig war. Also wartete er bis zum Abend, als es langsam dunkel wurde. Dann kletterte er ganz vorsichtig über die Mauer in den Garten. Er zupfte schnell eine Handvoll Rapunzelblätter ab und kletterte wieder zurück. Seine Frau machte sich einen Salat und ass ihn mit grossem Appetit. "Das ist das Beste, was ich je gegessen habe!" rief sie.
+
+Am nächsten Tag hatte sie schon wieder Hunger auf Rapunzeln. Also ging der Mann am Abend noch einmal los. Doch diesmal stand plötzlich die Zauberin vor ihm. Ihre Augen blitzten. "Was machst du in meinem Garten?" fragte sie streng. "Das sind meine Rapunzeln!"
+
+Der Mann zitterte vor Schreck. "Bitte verzeihen Sie mir! Meine Frau wollte so gern davon essen. Ich habe Angst gehabt, dass sie sonst krank wird."
+
+Die Zauberin schaute ihn lange an. Dann sagte sie: "Also gut. Du darfst so viele Rapunzeln haben, wie deine Frau möchte. Aber ich habe eine Bedingung. Wenn ihr eines Tages ein Kind bekommt, dann darf ich es bei mir aufnehmen. Ich werde gut auf es aufpassen, das verspreche ich."
+
+Der Mann war so erschrocken, dass er ohne nachzudenken "Ja" sagte. Er nahm ein paar Rapunzelblätter mit und ging nach Hause.
+
+Einige Monate später bekamen der Mann und die Frau tatsächlich ein kleines Mädchen. Sie freuten sich sehr. Aber gleich am nächsten Tag klopfte die Zauberin an die Tür. "Ich komme, um das Kind zu holen", sagte sie freundlich. "So wie ihr es versprochen habt."
+
+Der Mann und die Frau waren sehr traurig. Aber die Zauberin sagte: "Ich werde das Mädchen Rapunzel nennen, nach den Blättern aus meinem Garten. Und ich werde sie lieb haben wie eine eigene Tochter." Dann nahm sie das Baby und ging fort.
+
+Rapunzel wuchs heran. Sie hatte lange, goldene Haare, die immer länger wurden. Sie hatte eine fröhliche Stimme und lachte gerne. Die Zauberin passte gut auf sie auf, aber sie war auch ziemlich streng. "Die Welt draussen ist gefährlich", sagte sie oft. "Ich will nicht, dass dir etwas passiert."
+
+Als Rapunzel zwölf Jahre alt war, brachte die Zauberin sie in einen hohen Turm mitten im Wald. Der Turm hatte keine Treppe und keine Tür. Ganz oben gab es nur ein einziges Fenster. Im Turm war ein gemütliches Zimmer mit einem weichen Bett, einem Tisch, einem Stuhl und vielen Büchern.
+
+"Hier bist du sicher", sagte die Zauberin. "Hier kann dir nichts passieren." Und so blieb Rapunzel im Turm.
+
+Wenn die Zauberin ihre Pflegetochter besuchen wollte, stellte sie sich unten vor den Turm und rief hinauf:
 
 "Rapunzel, Rapunzel, lass dein Haar herunter!"
 
-Dann liess Rapunzel ihre goldenen Zöpfe aus dem Fenster fallen, und die Fee kletterte hinauf.
+Dann knüpfte Rapunzel ihre langen, goldenen Zöpfe an einen Haken am Fenster und liess sie lang herunterhängen. Sie waren so lang, dass sie bis auf den Boden reichten. Die Zauberin griff zu und kletterte daran hinauf, wie an einer goldenen Leiter. Sie brachte Essen, Bücher und manchmal auch neue Kleider.
 
-Rapunzel war oft einsam im Turm. Sie sang jeden Tag aus dem Fenster. Die Vögel kamen und sangen mit ihr. Ihre Stimme war so schön wie Musik.
+Rapunzel war oft allein. Aber sie war nicht traurig. Sie schaute aus dem Fenster und sah die Vögel, die Wolken, die Sterne. Und sie sang. Jeden Tag sang sie Lieder. Ihre Stimme war so klar und süss wie ein kleiner Bach, der über Steine plätschert. Die Vögel kamen und setzten sich auf das Fenster, um zuzuhören.
 
-Eines Tages ritt ein junger Prinz durch den Wald. Er hörte Rapunzels Lied und blieb stehen. Noch nie hatte er so etwas Schönes gehört! Er suchte und suchte und fand endlich den hohen Turm.
+Eines Tages ritt ein junger Prinz durch den Wald. Er hatte sich beim Reiten verirrt. Plötzlich hörte er eine Stimme, die so schön war, dass er sofort anhielt. "Was ist das für ein wunderbares Lied?" dachte er. Er stieg vom Pferd und folgte der Stimme. Endlich stand er vor einem hohen Turm. "Wer singt da drinnen?" fragte er sich. Er suchte eine Tür, aber er fand keine.
 
-"Wie kommt man dort hinauf?" fragte er sich. Da versteckte er sich hinter einem Busch und wartete.
+Der Prinz ritt nach Hause. Aber die Stimme ging ihm nicht aus dem Kopf. Am nächsten Tag kam er wieder. Und am übernächsten Tag auch. Jedes Mal stand er am Turm und hörte dem Gesang zu.
 
-Bald kam die Fee und rief: "Rapunzel, Rapunzel, lass dein Haar herunter!" Der Prinz sah, wie die Fee an den Zöpfen hinaufkletterte.
-
-Am nächsten Tag stellte der Prinz sich selbst vor den Turm. Mit freundlicher Stimme rief er:
+Einmal versteckte er sich hinter einem Busch. Da sah er, wie die Zauberin zum Turm kam und rief:
 
 "Rapunzel, Rapunzel, lass dein Haar herunter!"
 
-Rapunzel liess ihr Haar fallen, und der Prinz stieg hinauf. Sie erschrak ein wenig, doch der Prinz lächelte und sagte: "Ich wollte deine schöne Stimme kennen lernen. Möchtest du mein Freund sein?"
+Und er sah, wie lange goldene Zöpfe aus dem Fenster fielen, und wie die Zauberin daran hinaufkletterte. "Aha!" dachte der Prinz. "So kommt man hinauf."
 
-Rapunzel freute sich sehr. Endlich hatte sie jemanden zum Sprechen. Jeden Tag kam der Prinz heimlich vorbei, und die beiden lachten und erzählten sich Geschichten.
+Am nächsten Abend, als die Zauberin fort war, stellte sich der Prinz selbst an den Turm. Er räusperte sich und rief mit freundlicher Stimme:
 
-Als die Fee davon hörte, wurde sie böse. Sie schnitt Rapunzels lange Zöpfe ab und schickte sie weit weg in einen einsamen Wald. Der Prinz suchte Rapunzel überall. Lange, lange irrte er durch die Wälder.
+"Rapunzel, Rapunzel, lass dein Haar herunter!"
 
-Eines Morgens hörte er wieder eine Stimme singen. Es war Rapunzel! Er folgte der Stimme und fand sie auf einer Lichtung.
+Rapunzel dachte, es wäre die Zauberin. Sie liess ihre Zöpfe fallen, und der Prinz kletterte hinauf.
 
-"Da bist du ja!" riefen sie beide. Sie nahmen sich bei der Hand und gingen zusammen zum Schloss des Prinzen. Dort wohnten sie glücklich zusammen, und Rapunzel sang jeden Tag ihr schönstes Lied.
+Als er oben am Fenster erschien, erschrak Rapunzel zuerst. So einen Menschen hatte sie noch nie gesehen. "Bitte hab keine Angst", sagte der Prinz sanft. "Ich wollte nur deine wunderschöne Stimme kennenlernen. Jeden Tag höre ich dich singen. Du machst mich glücklich."
+
+Rapunzel schaute ihn lange an. Er hatte ein freundliches Gesicht und warme Augen. Langsam verlor sie ihre Angst. Sie zeigte ihm ihre Bücher. Sie erzählte ihm, wie es ist, den ganzen Tag oben im Turm zu sein. Der Prinz erzählte von der Welt draussen, vom Meer, von grossen Festen, von Pferden und Hunden.
+
+"Komm doch morgen wieder", sagte Rapunzel, als er ging. "Aber bitte, bitte, lass dich nicht von Frau Gothel sehen."
+
+Von da an kam der Prinz jeden Abend. Am Tag besuchte die Zauberin Rapunzel. Am Abend der Prinz. Rapunzel lachte und sang mehr als je zuvor. Die beiden wurden gute Freunde und machten zusammen Pläne: Rapunzel würde aus dem Turm herauskommen und die Welt sehen.
+
+Aber eines Tages, als die Zauberin gerade oben war, sagte Rapunzel aus Versehen: "Frau Gothel, warum sind Sie eigentlich immer so viel schwerer zu ziehen als der Prinz?"
+
+Die Zauberin wurde rot im Gesicht. "Was? Welcher Prinz? Du hast mich betrogen!" rief sie. Sie war so wütend, dass sie eine Schere nahm und, ritsch ratsch, Rapunzels lange goldene Zöpfe abschnitt. Die Zöpfe fielen auf den Boden.
+
+Dann brachte die Zauberin Rapunzel weit weg, in einen einsamen Wald am Rand eines Flusses. "Hier bleibst du jetzt", sagte sie traurig. "Ich wollte dich nur beschützen, und du bist mir weggelaufen." Dann verschwand die Zauberin.
+
+Rapunzel sass allein am Wasser und weinte. Aber nicht lange. Dann wischte sie sich die Tränen ab und dachte: "Ich finde einen Weg."
+
+Am Abend kam der Prinz wie immer zum Turm. Er rief: "Rapunzel, Rapunzel, lass dein Haar herunter!"
+
+Die Zauberin hatte die abgeschnittenen Zöpfe am Fensterhaken befestigt. Sie liess sie herunterfallen. Der Prinz kletterte hinauf. Aber oben am Fenster stand nicht Rapunzel, sondern die Zauberin. "Du willst Rapunzel sehen?" sagte sie. "Rapunzel ist weg, weit weg. Du wirst sie nie mehr finden!"
+
+Der Prinz war so traurig, dass er vor Schreck den Halt verlor und vom Fenster sprang. Zum Glück fiel er in einen grossen Dornenstrauch, der seinen Fall weich auffing. Aber ein paar Dornen kratzten seine Augen, und er konnte fast nichts mehr sehen.
+
+So wanderte der Prinz durch den Wald. Er konnte die Bäume nur noch schemenhaft erkennen. Er ass Beeren und Wurzeln. Er schlief unter Sternen. Monatelang war er unterwegs. Dabei dachte er die ganze Zeit nur an Rapunzel und ihr schönes Lied.
+
+Eines Morgens, als er ganz müde war, hörte er in der Ferne etwas Vertrautes. Eine Stimme, die sang. Ein Lied, das er kannte. Sein Herz sprang vor Freude. "Rapunzel!" rief er.
+
+Der Prinz tastete sich langsam weiter. Die Stimme wurde lauter. Endlich stand er vor einer kleinen Lichtung. Dort sass Rapunzel unter einem Apfelbaum.
+
+"Du?" rief Rapunzel. "Du bist es wirklich?" Sie sprang auf und rannte zu ihm. Sie umarmte ihn ganz fest, und dabei fielen zwei Tränen aus ihren Augen genau in seine verletzten Augen. Und in diesem Moment geschah etwas Wunderbares: Die Kratzer heilten. Der Prinz konnte wieder klar sehen. Er schaute Rapunzel an und lachte.
+
+"Ich habe dich gefunden", flüsterte er.
+
+"Ich wusste, dass du mich findest", sagte Rapunzel.
+
+Der Prinz und Rapunzel gingen zusammen in sein Schloss. Auf dem Weg sahen sie die Zauberin am Rand des Waldes stehen. Sie schaute die beiden lange an. Dann sagte sie leise: "Verzeih mir, Rapunzel. Ich wollte nur, dass dir nichts Schlimmes passiert. Aber ich habe dir die Welt weggenommen, und das war falsch."
+
+Rapunzel schaute sie an. Dann ging sie zu ihr und umarmte sie kurz. "Ich verzeihe dir", sagte sie. "Aber jetzt möchte ich selbst entscheiden, wo ich lebe."
+
+Von da an lebten Rapunzel und der Prinz zusammen im Schloss. Sie sang jeden Tag, und manchmal, wenn sie Lust hatte, besuchte sie die alte Zauberin. Die Zauberin hatte ein kleines Häuschen mit einem neuen Garten, und sie war freundlicher geworden. Sie schenkte Rapunzel jedes Mal einen kleinen Strauss frische Rapunzelblätter, und die beiden assen zusammen Salat und lachten.
+
+Und Rapunzels Haare? Die wuchsen wieder. Aber sie wurden nie mehr ganz so lang wie früher. Das war Rapunzel auch recht. Zöpfe sind praktisch – aber nicht, wenn man die Welt sehen will.

--- a/stories/grimm/rotkaeppchen/adaptions/contemporary/content.md
+++ b/stories/grimm/rotkaeppchen/adaptions/contemporary/content.md
@@ -5,42 +5,102 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal ein kleines Mädchen, das immer eine rote Mütze trug. Alle nannten es Rotkäppchen.
+Es war einmal ein kleines Mädchen, das in einem Dorf am Rand eines Waldes wohnte. Alle Menschen im Dorf hatten das Mädchen lieb, denn es war fröhlich und freundlich. Am allerliebsten hatte es seine Grossmutter, die in einem kleinen Haus mitten im Wald wohnte. Die Grossmutter konnte nicht mehr gut laufen, aber sie kochte die beste Apfelsuppe der Welt, und sie konnte wunderbare Geschichten erzählen.
 
-Eines Morgens sagte die Mama zu Rotkäppchen: "Die Oma ist krank. Bitte bring ihr diesen Korb mit Kuchen und Saft. Aber bleib auf dem Weg, und sprich mit niemand Fremdem."
+Eines Tages schenkte die Grossmutter dem Mädchen eine Mütze aus weichem roten Samt. Das Mädchen war so begeistert davon, dass es die Mütze jeden Tag trug. Im Winter und im Sommer, zu Hause und auf der Strasse. So kam es, dass bald niemand mehr den richtigen Namen des Mädchens sagte. Alle nannten es einfach "Rotkäppchen".
 
-Rotkäppchen versprach es. Fröhlich lief es los. Die Sonne schien, die Vögel zwitscherten, und am Wegrand blühten bunte Blumen.
+Eines Morgens kam die Mama zu Rotkäppchen in die Küche. Sie hatte einen Korb in der Hand, und darin lagen ein frischer Kuchen, eine Flasche Apfelsaft und ein kleines Glas Honig.
 
-Mitten im Wald traf Rotkäppchen einen grossen Wolf. Der Wolf zeigte ein breites Lächeln.
+"Rotkäppchen", sagte die Mama, "die Oma ist ein bisschen krank. Sie hat Husten und bleibt im Bett. Bitte bring ihr diesen Korb. Der Kuchen und der Honig werden ihr gut tun."
 
-"Guten Tag, kleines Mädchen", sagte der Wolf freundlich. "Wohin gehst du denn?"
+"Ja, Mama, das mache ich gern", sagte Rotkäppchen und setzte ihre rote Mütze auf.
 
-Rotkäppchen hatte noch nie einen Wolf gesehen und erschrak nicht. "Ich besuche meine Oma", antwortete es.
+Die Mama schaute sie ernst an. "Aber hör gut zu: Bleib auf dem Weg. Geh nicht durch den Wald neben dem Weg. Renne nicht. Und vor allem – sprich nicht mit Fremden. Es gibt im Wald manchmal Tiere, die gefährlich sein können. Versprich mir das!"
 
-"Oh, wie schön", sagte der Wolf. "Schau, dort auf der Wiese, wie bunt die Blumen sind. Warum pflückst du nicht ein paar für die Oma?"
+Rotkäppchen nickte. "Ich verspreche es, Mama. Ich bleibe auf dem Weg." Sie nahm den Korb, winkte der Mama und lief fröhlich los.
 
-Rotkäppchen dachte: "Ein Blumenstrauss würde Oma freuen!" So ging es von Blume zu Blume und kam immer weiter vom Weg ab.
+Der Weg zur Grossmutter war schön. Die Sonne schien warm. Schmetterlinge flatterten zwischen den Blumen. Vögel zwitscherten in den Bäumen. Rotkäppchen sang ein Lied und hüpfte von Stein zu Stein.
 
-Der Wolf aber rannte schnell zu Omas Haus. Er klopfte an die Tür. "Oma, mach auf!" Doch die Oma wusste gleich: Das ist nicht Rotkäppchen! Flink versteckte sie sich im Schrank und schloss ihn fest von innen.
+Mitten im Wald, an einer Stelle, wo der Pfad zwischen hohen Bäumen lief, stand plötzlich ein grosser Wolf vor Rotkäppchen. Er hatte zottiges graues Fell und einen langen, buschigen Schwanz. Seine Zähne waren sehr spitz, aber er lachte so freundlich, dass Rotkäppchen gar keine Angst bekam. Sie hatte noch nie einen Wolf gesehen und wusste nicht, dass Wölfe gefährlich sein können.
 
-Da kam der Wolf herein. Er schaute ins Bett – leer. Er schaute unter den Tisch – leer. "Die Oma muss im Wald sein", brummte er und legte sich wartend ins Bett.
+"Guten Morgen, kleines Mädchen", sagte der Wolf mit honigsüsser Stimme. "Wohin gehst du denn so früh?"
 
-Bald klopfte Rotkäppchen an der Tür. "Ich bin's!" Es trat ein und sah das komische Bild: Etwas Haariges lag unter Omas Decke.
+"Guten Morgen", antwortete Rotkäppchen höflich. "Ich gehe zu meiner Grossmutter. Sie ist krank, und ich bringe ihr Kuchen und Honig."
 
-"Oma, warum hast du so grosse Ohren?"
+"Oh, wie lieb von dir!" sagte der Wolf. "Und wo wohnt deine Grossmutter denn?"
 
-"Damit ich dich besser hören kann!"
+"Sie wohnt mitten im Wald, unter den drei grossen Eichen. Das Haus hat grüne Fensterläden, und davor steht ein Zwetschgenbaum."
 
-"Oma, warum hast du so grosse Augen?"
+Der Wolf dachte heimlich: "Oh, wie fein! Das Mädchen ist zart und frisch, und die alte Grossmutter ist bestimmt auch ein feiner Bissen. Ich mache einen Plan, dann kann ich beide haben."
 
-"Damit ich dich besser sehen kann!"
+Laut aber sagte er nur ganz freundlich: "Schau, Rotkäppchen, schau doch einmal, wie schön die Blumen am Waldrand blühen! Gelbe Butterblumen, blaue Glockenblumen, rote Mohnblumen! Wäre es nicht wunderbar, wenn du deiner Grossmutter einen schönen Strauss mitbringen würdest? Hörst du auch, wie die Vögel singen? Warum rennst du so schnell? Ein bisschen spielen ist doch auch erlaubt."
 
-"Oma, warum hast du so einen grossen Mund?"
+Rotkäppchen schaute sich um. Und tatsächlich – die Blumen waren wirklich wunderschön. "Ein Blumenstrauss würde Oma bestimmt froh machen", dachte sie. "Und ich habe ja noch viel Zeit."
 
-"Damit ich—" Und da sprang der Wolf aus dem Bett!
+Sie vergass, was ihre Mama gesagt hatte. Sie lief vom Weg ab, tief in den Wald hinein, pflückte hier eine Blume und dort eine Blume. Jede schien schöner als die vorige. So geriet sie immer weiter weg vom Pfad.
 
-Rotkäppchen schrie laut. Zum Glück kam gerade der Jäger vorbei. Er hörte den Schrei und lief schnell ins Haus. Der Wolf erschrak so sehr, dass er aus dem Fenster sprang und weit, weit weg in den Wald rannte. Dort blieb er.
+Der Wolf aber lief, so schnell er konnte, geradewegs zum Haus der Grossmutter. An der Tür klopfte er an. Klopf, klopf, klopf.
 
-"Oma! Wo bist du?" rief Rotkäppchen. Ein kleines Klopfen kam aus dem Schrank. Die Oma öffnete die Tür und umarmte Rotkäppchen ganz fest.
+"Wer ist da?" fragte die Grossmutter mit müder Stimme aus dem Bett.
 
-Zusammen assen sie den Kuchen und tranken den Saft. Und Rotkäppchen versprach: "Nie mehr gehe ich vom Weg ab, und nie mehr spreche ich mit Fremden im Wald."
+Der Wolf machte seine Stimme so fein und hell wie er konnte: "Ich bin's, Rotkäppchen. Ich bringe dir Kuchen und Honig."
+
+"Drück nur die Klinke runter!" rief die Grossmutter. "Ich bin zu schwach, um aufzustehen."
+
+Der Wolf drückte die Klinke herunter, die Tür ging auf, und er kam in die Stube. Die Grossmutter sah gleich: Das ist kein kleines Mädchen! Das ist ein grosser Wolf! Sie erschrak fürchterlich und rutschte, so leise sie konnte, aus dem Bett. Flink, flink, flink – sie versteckte sich im grossen Schrank und zog die Tür von innen zu. "Hoffentlich findet mich der Wolf nicht", flüsterte sie und hielt den Atem an.
+
+Der Wolf rannte ins Schlafzimmer. Aber das Bett war leer. "Wo ist die alte Frau?" knurrte er. Er schaute unter den Tisch, hinter den Vorhang, sogar in den Küchenschrank. Aber die Grossmutter hatte sich so klein wie möglich in den grossen Kleiderschrank gedrückt. Der Wolf fand sie nicht.
+
+"Ach, was soll's", brummte er. "Die alte Frau kommt sicher bald nach Hause. Jetzt warte ich einfach auf das Mädchen." Er zog schnell Grossmutters weisse Nachthaube an, legte ihr geblümtes Nachthemd darüber und kroch ins Bett. Dann zog er die Bettdecke hoch bis unter die Nase und wartete.
+
+Unterdessen hatte Rotkäppchen einen riesigen Blumenstrauss gepflückt. Als der Strauss so gross war, dass sie kaum noch zwei Blumen dazu halten konnte, fiel ihr plötzlich ein: "Oh weh! Ich wollte doch schnell zur Grossmutter!" Sie rannte zurück auf den Weg und eilte zum Haus im Wald.
+
+Als sie ankam, war die Tür offen. Das war komisch. Rotkäppchen wurde ein bisschen mulmig. "Guten Morgen, Oma!" rief sie, aber niemand antwortete. Sie ging leise ins Schlafzimmer. Dort lag jemand im Bett, das Gesicht fast ganz unter der Decke. Nur die Augen, Ohren und Nase schauten heraus, und sie sahen heute sehr seltsam aus.
+
+"Ei, Oma", sagte Rotkäppchen, "was hast du für grosse Ohren?"
+
+"Damit ich dich besser hören kann", antwortete die tiefe Stimme aus dem Bett.
+
+"Ei, Oma, was hast du für grosse Augen?"
+
+"Damit ich dich besser sehen kann."
+
+"Ei, Oma, was hast du für grosse Hände?"
+
+"Damit ich dich besser halten kann."
+
+"Aber Oma, was hast du für einen ENTSETZLICH grossen Mund?"
+
+"Damit ich dich besser—"
+
+Da sprang der Wolf mit einem Satz aus dem Bett! Rotkäppchen schrie laut vor Schreck und rannte in die Ecke. Der Wolf war fast bei ihr.
+
+Zum Glück kam in diesem Moment ein Jäger am Fenster vorbei. Er hatte Rotkäppchens Schrei gehört. Er riss die Tür auf und stürmte hinein. "Halt! Was machst du da, du alter Sünder?"
+
+Der Wolf erschrak so furchtbar, dass er mitsamt Nachthaube und Nachthemd aus dem offenen Fenster sprang. Er rannte, so schnell er konnte, in den Wald hinein und wurde nie mehr gesehen. Vielleicht lebt er noch heute irgendwo ganz weit weg, wo er keine kleinen Mädchen und Grossmütter mehr ärgert.
+
+"Rotkäppchen! Bist du verletzt?" fragte der Jäger besorgt.
+
+"Nein", sagte Rotkäppchen, aber ihr Herz klopfte noch ganz laut. "Aber wo ist meine Oma?"
+
+Sie hörten ein leises Pochen aus dem grossen Schrank. Klopf, klopf. Rotkäppchen öffnete die Tür, und da sass die Oma ganz klein zusammengekauert drin. Sie war ein bisschen müde, aber sonst ging es ihr gut. Sie umarmte Rotkäppchen ganz fest.
+
+"Oh, mein Kind, ich bin so froh, dass du hier bist!" rief die Grossmutter.
+
+Der Jäger schaute freundlich zu. "Pass das nächste Mal besser auf, Rotkäppchen. Und bleib auf dem Weg."
+
+Rotkäppchen nickte. "Das werde ich, versprochen. Nie wieder spreche ich mit einem Fremden im Wald."
+
+Dann setzten sich alle zusammen an den Tisch. Rotkäppchen packte den Kuchen aus, schenkte Apfelsaft ein und stellte das Glas Honig neben die Grossmutter. Sie stellte auch den grossen Blumenstrauss in eine Vase. "Der ist für dich, Oma."
+
+"Oh, wie schön!" sagte die Grossmutter und lachte endlich wieder. "Meine Husten ist schon halb weg, einfach weil du da bist."
+
+Sie assen zusammen. Der Jäger erzählte lustige Geschichten vom Wald. Die Grossmutter erzählte von früher. Und Rotkäppchen versprach sich selbst ganz fest: Wenn ich das nächste Mal zur Oma gehe, dann bleibe ich auf dem Weg. Ich spreche nicht mit Fremden. Und ich renne, wenn ein Fremder mich vom Weg weglocken will, direkt zu einem Menschen, dem ich vertraue.
+
+Am Abend brachte der Jäger Rotkäppchen nach Hause. Die Mama umarmte sie ganz fest, als sie die Geschichte hörte.
+
+Und es wird erzählt, dass Rotkäppchen einige Zeit später wieder den Korb zur Oma bringen sollte. Da kam ihr tatsächlich noch ein anderer Wolf entgegen. Dieser Wolf tat auch ganz freundlich, aber Rotkäppchen war jetzt klüger. Sie schaute ihn gar nicht erst an, sie blieb auf dem Weg und rannte, so schnell sie konnte. Diesmal liess sie sich nicht weglocken.
+
+Als sie bei der Oma ankam, schlossen sie gleich die Tür ab. "Komm", sagte die Grossmutter, "heute bleiben wir schön drinnen." Der Wolf schlich ums Haus herum, aber er konnte nichts machen, denn die Tür war zu und die Fenster waren zu. Schliesslich gab er auf und trottete enttäuscht davon.
+
+Und Rotkäppchen? Sie wurde eine kluge, mutige junge Frau. Die rote Mütze trug sie noch viele Jahre lang, und wenn sie jemandem Kindern davon erzählte, dann fing sie immer so an: "Das Wichtigste, wenn ihr in den Wald geht, ist: Bleibt auf dem Weg und sprecht nicht mit Fremden."

--- a/stories/grimm/schneewittchen/adaptions/contemporary/content.md
+++ b/stories/grimm/schneewittchen/adaptions/contemporary/content.md
@@ -5,36 +5,168 @@ adaption: "Moderne Fassung"
 ageMin: 4
 ---
 
-Es war einmal eine Prinzessin mit Haaren schwarz wie die Nacht, Lippen rot wie eine Erdbeere und Haut weiss wie Schnee. Alle nannten sie Schneewittchen. Sie war freundlich zu allen Menschen und auch zu allen Tieren.
+Es war einmal ein strenger Winter. Die Schneeflocken fielen wie weisse Federn vom Himmel. Eine Königin sass an einem Fenster mit einem schwarzen Holzrahmen und nähte an einem feinen Kleid. Sie schaute immer wieder hinaus in den Schnee. Dabei stach sie sich mit der Nadel in den Finger, und drei kleine Tropfen Blut fielen in den weissen Schnee.
 
-Schneewittchens Stiefmutter, die Königin, war sehr stolz. Jeden Morgen schaute sie in ihren Zauberspiegel und fragte:
+"Wie schön das rot im weissen Schnee aussieht", dachte die Königin. "Wenn ich ein Kind hätte, dann sollte es Haut so weiss wie Schnee, Lippen so rot wie Blut und Haare so schwarz wie der Rahmen aus Ebenholz haben."
+
+Nicht lange danach bekam die Königin tatsächlich ein Töchterchen. Das Baby hatte Haut so weiss wie Schnee, Lippen so rot wie Himbeeren und Haare so schwarz wie die Nacht. Die Königin nannte es Schneewittchen. Alle im Schloss freuten sich.
+
+Aber kurz darauf wurde die Königin sehr krank. Sie hielt Schneewittchen noch einmal in den Armen und flüsterte: "Bleib immer gut und freundlich, mein Kind." Dann schlief sie für immer ein. Der König war sehr traurig, und das ganze Schloss war traurig mit ihm.
+
+Nach einem Jahr heiratete der König wieder. Seine neue Frau war auch schön. Sie hatte lange dunkle Haare, ein edles Gesicht und einen strengen Blick. Aber sie war sehr stolz und eitel. Sie konnte es nicht ertragen, wenn jemand schöner war als sie. In ihrem Zimmer hing ein grosser, verzauberter Spiegel. Vor diesem Spiegel stand sie jeden Morgen und jeden Abend. Sie sprach zu ihm:
 
 "Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
 
-Viele Jahre antwortete der Spiegel: "Du, meine Königin." Doch eines Tages sagte der Spiegel:
+Und der Spiegel antwortete jedes Mal:
 
-"Schneewittchen ist tausendmal schöner als Ihr."
+"Frau Königin, du bist die Schönste im Land."
 
-Da wurde die Königin sehr neidisch. Sie wollte Schneewittchen fortschicken. Schneewittchen lief in den Wald und lief und lief, bis es müde wurde.
+Darüber freute sich die Königin, denn sie wusste: Der Spiegel sagt immer die Wahrheit.
 
-Plötzlich sah es ein winziges Häuschen. Schneewittchen klopfte. Niemand antwortete, also ging es hinein. Im Zimmer standen sieben kleine Stühle, auf dem Tisch sieben kleine Teller, und im Schlafzimmer waren sieben kleine Betten. Schneewittchen ass ein bisschen, trank ein bisschen und legte sich auf das letzte Bett. Schon schlief es fest.
+So ging es eine Weile. Schneewittchen wuchs zu einem fröhlichen Mädchen heran. Sie war nicht nur schön, sondern auch sehr freundlich. Sie lachte viel. Sie sang im Schlossgarten. Sie streichelte die Pferde im Stall und fütterte die Vögel am Fenster. Alle im Schloss mochten Schneewittchen.
 
-Am Abend kamen die sieben Zwerge von der Arbeit nach Hause. Sie arbeiteten in einem Bergwerk und sammelten funkelnde Steine. "Wer hat auf unseren Stühlen gesessen? Wer hat von unseren Tellern gegessen? Wer liegt in meinem Bett?" fragte der siebte, kleinste Zwerg staunend.
+Als Schneewittchen sieben Jahre alt war, stand die Königin wieder vor ihrem Spiegel.
 
-Da wachte Schneewittchen auf. Es erzählte alles. Die Zwerge waren gute Kerle und sagten: "Du darfst bei uns bleiben. Wir passen auf dich auf."
+"Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
 
-Schneewittchen wohnte nun bei den Zwergen. Sie kochte Suppe, putzte das Häuschen und sang mit den Vögeln.
+Diesmal antwortete der Spiegel nicht wie sonst. Er sagte:
 
-Die Königin aber hörte vom Spiegel, dass Schneewittchen noch lebte. Sie verkleidete sich als alte Frau und kam mit einem roten Apfel zum Häuschen. "Guten Tag, möchtest du einen süssen Apfel?"
+"Frau Königin, du bist schön, aber Schneewittchen ist tausendmal schöner als du."
 
-Schneewittchen biss vorsichtig hinein. Im Apfel war ein Zaubertrank. Schneewittchen wurde so müde, dass es in einen tiefen Zauberschlaf fiel.
+Die Königin wurde gelb und grün vor Neid. "Ein Kind? Schöner als ich?" rief sie. Von diesem Tag an konnte sie Schneewittchen nicht mehr sehen. Jedes Mal, wenn sie Schneewittchen lachen hörte, bekam sie schlechte Laune. Sie schmiedete einen bösen Plan.
 
-Als die Zwerge heimkamen, fanden sie Schneewittchen schlafend. Sie bauten für sie ein Bett aus Glas, damit alle Vögel und Tiere sie sehen konnten.
+Die Königin rief einen jungen Jäger zu sich. "Nimm das Mädchen mit in den Wald", befahl sie. "Sie soll aus meinem Schloss verschwinden. Und bring mir ihre rote Mütze als Beweis, dass sie nicht mehr zurückkommt."
 
-Eines Tages ritt ein Prinz vorbei. Er sah Schneewittchen und die sieben Zwerge, die traurig dabeistanden. Vorsichtig berührte der Prinz das Glas.
+Der Jäger erschrak, aber er musste der Königin gehorchen. Er nahm Schneewittchen mit zu einem Spaziergang im Wald. Als sie tief zwischen den Bäumen waren, drehte sich der Jäger um und sagte traurig: "Schneewittchen, du musst weglaufen. Die Königin hat mir etwas Schlimmes befohlen. Aber ich kann dir das nicht antun. Lauf, und komm niemals mehr zurück zum Schloss!"
 
-Da rutschte ein Stück vom Zauberapfel aus Schneewittchens Mund. Es öffnete die Augen und lächelte!
+Schneewittchen erschrak fürchterlich. "Aber wohin soll ich laufen?"
 
-"Willst du mit mir kommen?" fragte der Prinz.
+"Irgendwohin, wo die Königin dich nicht findet. Vielleicht tiefer in den Wald. Und pass auf dich auf!" Dann legte der Jäger die rote Mütze auf den Boden und versteckte sich ein bisschen, um zu warten. Er wollte die Mütze schmutzig machen und so tun, als wäre alles erledigt.
 
-Schneewittchen umarmte die Zwerge zum Abschied. "Ich besuche euch bald wieder, versprochen!" Und so tat es. Sie lebten alle glücklich, und der Zauberspiegel flüsterte nie wieder böse Dinge.
+Schneewittchen rannte, so schnell sie konnte. Sie rannte durch Dornen und über Wurzeln. Vögel flogen auf. Rehe sprangen zur Seite. Die wilden Tiere taten ihr aber nichts, denn sie spürten, dass sie Angst hatte. Schneewittchen rannte den ganzen Tag, bis ihre Füsse wehtaten. Als die Sonne unterging, stand sie plötzlich auf einer kleinen Lichtung. Dort stand ein winziges Häuschen. Es war so klein, dass der Türgriff nur knapp bis an Schneewittchens Schulter reichte.
+
+Schneewittchen klopfte. Niemand antwortete. Die Tür war nicht abgeschlossen. Sie öffnete sie vorsichtig und ging hinein.
+
+Im Haus war alles klein, aber sehr sauber und gemütlich. Auf dem Tisch standen sieben kleine Teller, sieben kleine Löffel und sieben kleine Becher. An der Wand hingen sieben kleine Mützen an sieben kleinen Haken. Im Nebenzimmer standen sieben kleine Betten, alle hübsch mit weissen Laken zugedeckt.
+
+Schneewittchen hatte Hunger und Durst. Sie nahm von jedem Teller ein kleines bisschen, damit niemand etwas vermissen würde, und sie trank aus jedem Becher einen kleinen Schluck. Dann war sie so müde, dass sie sich in eines der Betten legte. Das erste war zu lang, das zweite zu kurz, das dritte zu hart. Erst das siebte Bett war genau richtig. Schneewittchen schlief schnell ein.
+
+Als es dunkel war, kamen die Besitzer des Häuschens heim. Es waren sieben Zwerge. Sie arbeiteten in einem Bergwerk und suchten im Berg nach glitzernden Steinen. Jeder trug einen kleinen Rucksack und eine kleine Lampe. Als sie ins Haus kamen, bemerkten sie gleich: Hier ist jemand gewesen!
+
+"Wer hat auf meinem Stuhl gesessen?" fragte der erste.
+
+"Wer hat von meinem Teller gegessen?" fragte der zweite.
+
+"Wer hat aus meinem Becher getrunken?" fragte der dritte.
+
+"Wer hat mein Kissen verschoben?" fragte der vierte.
+
+Die anderen schauten sich auch um. Schliesslich fand der siebte Zwerg Schneewittchen, die in seinem Bett schlief. "Seht mal hier!" rief er leise. Alle sieben Zwerge kamen mit ihren Lampen ans Bett und staunten. "Was für ein schönes Kind!" flüsterten sie. Sie weckten Schneewittchen nicht auf.
+
+Als Schneewittchen am Morgen die Augen öffnete, sah sie sieben kleine Gesichter, die sie freundlich anlachten. Zuerst erschrak sie ein bisschen. Aber dann sagte der kleinste Zwerg mit heller Stimme: "Hab keine Angst. Wir tun dir nichts. Wer bist du, und wie kommst du hierher?"
+
+Schneewittchen erzählte alles: Von der bösen Königin, vom Jäger, vom langen Lauf durch den Wald. Die Zwerge hörten mit grossen Augen zu.
+
+"Du kannst bei uns bleiben", sagte der älteste Zwerg. "Aber du musst uns dafür im Haushalt helfen. Kannst du kochen, waschen, nähen und Betten machen?"
+
+"Gern", sagte Schneewittchen. "Ich helfe, so gut ich kann."
+
+So wurde Schneewittchen die Freundin der sieben Zwerge. Jeden Morgen gingen die Zwerge mit ihren Lampen und Werkzeugen in den Berg. Schneewittchen blieb zu Hause, machte die Betten, fegte den Boden, kochte Suppe und sang dabei. Am Abend kamen die Zwerge heim. Sie setzten sich alle an den kleinen Tisch, erzählten Geschichten und lachten viel. Es war ein gutes Leben.
+
+Bevor die Zwerge jeden Morgen das Haus verliessen, sagten sie: "Pass auf dich auf, Schneewittchen. Lass niemand herein, egal wer klopft. Die böse Königin könnte dich hier finden."
+
+Im Schloss stand die Königin eines Tages wieder vor ihrem Spiegel. "Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
+
+Der Spiegel antwortete:
+
+"Frau Königin, du bist schön, aber über den Bergen, bei den sieben Zwergen, wohnt Schneewittchen, und sie ist tausendmal schöner als du."
+
+Die Königin bekam einen Schreck. "Was? Schneewittchen lebt noch?" Sie war ausser sich vor Wut. Sie dachte lange nach. Dann ging sie in ihre geheime Kammer und mischte einen Zaubertrank. Sie zog ein altes Kleid an, setzte einen grauen Schleier auf und nahm einen Korb mit Hübschmacher-Bändern mit. So verkleidet sah sie aus wie eine alte Hausiererin.
+
+Über sieben Berge und sieben Täler wanderte die Königin bis zum Haus der Zwerge. Sie klopfte an die Tür. "Schöne Bänder! Hübsche Schnüre! Feil, feil!"
+
+Schneewittchen schaute aus dem Fenster. "Guten Tag, liebe Frau!"
+
+"Oh, schau nur, was für wunderschöne Schnürsenkel ich habe", sagte die Hausiererin. "Darf ich dir einen zeigen?"
+
+Schneewittchen dachte: "Die alte Frau sieht doch ganz freundlich aus." Sie öffnete die Tür einen Spalt. Die Frau zeigte ihr einen schönen bunten Schnürsenkel. "Komm, ich schnüre dir das Kleid ganz schön. Dann siehst du noch hübscher aus."
+
+Schneewittchen liess sie herein. Aber die böse Königin zog die Schnur so fest, dass Schneewittchen fast keine Luft mehr bekam. Sie fiel in den Stuhl und konnte sich nicht mehr bewegen. Die Königin lachte leise und verschwand.
+
+Am Abend kamen die Zwerge heim. Sie fanden Schneewittchen reglos auf dem Stuhl. "Oh nein!" riefen sie. Zum Glück sahen sie die zu fest gebundene Schnur. Der kleinste Zwerg schnitt sie mit einer Schere durch. Schneewittchen holte tief Luft und kam langsam wieder zu sich.
+
+"Das war sicher die Königin!" sagten die Zwerge. "Nie, nie wieder lass jemanden herein, Schneewittchen. Egal, was er sagt oder zeigt!"
+
+Im Schloss stand die Königin wieder vor dem Spiegel. Sie war sicher, dass jetzt sie wieder die Schönste war. Aber der Spiegel sagte:
+
+"Frau Königin, du bist schön, aber über den Bergen, bei den sieben Zwergen, wohnt Schneewittchen, und sie ist tausendmal schöner als du."
+
+Die Königin wurde fuchsteufelswild. "Sie lebt? Schon wieder?" Sie machte einen neuen Plan. Sie bastelte einen hübschen Kamm und mischte einen Schlaftrank in den Kamm hinein. Dann verkleidete sie sich als eine andere alte Frau und wanderte wieder über die Berge.
+
+"Schöne Kämme! Hübsche Haarschmucke!" rief sie vor der Tür.
+
+Schneewittchen schaute vorsichtig hinaus. "Nein, danke. Ich darf niemanden hereinlassen."
+
+"Kein Problem, schau doch nur durchs Fenster", sagte die Frau. Sie hielt einen wunderhübschen bunten Kamm in die Höhe. Er glitzerte in der Sonne. Schneewittchen schaute ihn an, und der Wunsch, ihn in den Haaren zu tragen, wurde zu gross. Sie öffnete die Tür einen Spalt. Die Frau zog den Kamm schnell durch Schneewittchens Haare, und im selben Augenblick fiel Schneewittchen um und lag ganz still.
+
+Die Königin lachte höhnisch und eilte fort.
+
+Am Abend kamen die Zwerge nach Hause. Sie sahen Schneewittchen am Boden liegen und hatten gleich einen Verdacht. Sie suchten und fanden den Kamm in ihren Haaren. Kaum hatten sie ihn herausgezogen, da öffnete Schneewittchen die Augen. "Oh, wie mir schwindlig war", flüsterte sie.
+
+"Schneewittchen!" riefen die Zwerge. "Du musst wirklich sehr, sehr vorsichtig sein. Öffne niemand die Tür! Schau auch nicht durchs Fenster, wenn ein Fremder etwas zeigen will!"
+
+Im Schloss fragte die Königin zum dritten Mal den Spiegel. Und zum dritten Mal sagte er:
+
+"Frau Königin, du bist schön, aber über den Bergen, bei den sieben Zwergen, wohnt Schneewittchen, und sie ist tausendmal schöner als du."
+
+Jetzt wurde die Königin vor Zorn richtig krank. "Diesmal", flüsterte sie, "diesmal bin ich klüger." Sie ging in die dunkelste Kammer des Schlosses und machte einen grossen roten Apfel. Der Apfel war wunderschön – eine Hälfte war rot wie Glut, die andere weiss wie Sahne. Aber die rote Hälfte war mit einem Zaubertrank getränkt. Wer davon ass, würde in einen tiefen Zauberschlaf fallen.
+
+Die Königin verkleidete sich als Bauersfrau. Einen Korb voller Äpfel nahm sie mit, und mitten unter ihnen legte sie den verzauberten Apfel. Dann wanderte sie noch einmal über die sieben Berge.
+
+"Äpfel! Frische Äpfel!" rief sie vor dem Haus der Zwerge.
+
+Schneewittchen blickte vorsichtig aus dem Fenster. "Nein, ich darf keinen Fremden hereinlassen. Das haben mir die Zwerge gesagt."
+
+"Du sollst ja gar nichts hereinlassen!" sagte die Bauersfrau. "Schau, ich werfe dir einfach einen Apfel zum Probieren herein. Ich habe zu viele, und ich teile gern." Sie teilte den Apfel mit einem Messer in zwei Hälften. Die weisse Hälfte biss sie selber an. "Siehst du? Ganz köstlich und ungefährlich. Hier, die andere Hälfte ist für dich."
+
+Schneewittchen dachte: "Die Frau isst doch selbst davon. Der Apfel kann nicht schlecht sein." Sie streckte die Hand aus dem Fenster, nahm die rote Hälfte und biss hinein. Sofort spürte sie, wie ihr alles schwer wurde. Der Raum drehte sich. Sie fiel zu Boden und lag ganz still. Nur ein Stückchen Apfel war in ihrem Hals steckengeblieben.
+
+"Endlich!" lachte die Königin. "Jetzt bin ich wieder die Schönste." Sie eilte zurück ins Schloss und fragte sofort den Spiegel. Diesmal antwortete er:
+
+"Frau Königin, du bist die Schönste im Land."
+
+Am Abend kamen die Zwerge heim. Sie fanden Schneewittchen am Boden. Sie war ganz blass. "Schneewittchen, Schneewittchen, wach auf!" riefen sie. Sie rüttelten sie, schoben ihr Wasser an die Lippen, suchten nach einem Gift – nichts half. Schneewittchen wachte nicht auf.
+
+Die Zwerge weinten lange. Drei Tage hielten sie Trauer. Aber Schneewittchen sah nicht tot aus. Sie sah aus, als würde sie nur schlafen. Ihre Wangen waren noch rosa, ihre Haare noch schwarz, ihre Haut noch weiss.
+
+"Wir können sie nicht einfach in die Erde legen", sagte der älteste Zwerg. "Sie ist zu schön dafür."
+
+Die Zwerge bauten einen Sarg aus klarem Glas, damit man Schneewittchen von allen Seiten sehen konnte. Mit goldenen Buchstaben schrieben sie ihren Namen auf den Deckel: Schneewittchen, Königstochter. Sie stellten den Sarg auf einen kleinen Hügel im Wald. Rund um den Hügel sassen jeden Tag zwei oder drei Zwerge und wachten. Auch die Tiere kamen. Eine Eule sass auf einem Ast. Ein Rabe schaute vom Felsen herab. Eine weisse Taube flog um den Sarg. Alle trauerten um Schneewittchen.
+
+Viele Jahre vergingen. Schneewittchen lag immer noch im Glassarg, und sie sah immer noch aus, als würde sie nur schlafen.
+
+Eines Tages ritt ein junger Prinz durch den Wald. Er hatte sich verirrt und kam zum Häuschen der Zwerge. Er sah den Sarg auf dem Hügel und trat näher. Lange schaute er das schlafende Mädchen an. "Was für ein wunderschönes Kind", flüsterte er. "Was für eine traurige Geschichte."
+
+Der Prinz sprach mit den Zwergen. Er bat: "Darf ich den Sarg mit in mein Schloss nehmen? Ich möchte Schneewittchen in Ehren halten."
+
+Die Zwerge waren erst traurig. Aber dann dachten sie: "Vielleicht ist es gut für Schneewittchen, wenn sie nicht mehr allein im Wald liegt." Sie sagten ja.
+
+Der Prinz liess den Sarg auf ein Pferd laden und ritt langsam davon. Als das Pferd auf dem holprigen Waldweg einmal stolperte, rüttelte der Sarg heftig. Und dabei geschah das Wunder: Das Stückchen Apfel, das in Schneewittchens Hals steckengeblieben war, rutschte heraus. Schneewittchen holte tief Luft und öffnete langsam die Augen.
+
+"Wo bin ich?" fragte sie leise.
+
+"Du bist bei mir", sagte der Prinz. "Und du lebst." Er lachte vor Freude, und Schneewittchen lachte mit. Er erzählte ihr alles, was passiert war. Sie weinten und lachten zugleich.
+
+Der Prinz brachte Schneewittchen in sein Schloss. Es wurde ein grosses Fest gefeiert. Die sieben Zwerge kamen auch. Sie trugen ihre besten Mützen und tanzten, obwohl sie das sonst nie taten. Schneewittchen umarmte jeden einzelnen. "Ihr habt mich gerettet, und ich vergesse euch nie."
+
+Und was war mit der bösen Königin? Sie hörte im Schloss von einer neuen, wunderschönen Prinzessin. Sie fragte wie immer ihren Spiegel:
+
+"Spieglein, Spieglein an der Wand, wer ist die Schönste im ganzen Land?"
+
+Der Spiegel sagte:
+
+"Frau Königin, du bist schön, aber die junge Königin ist tausendmal schöner als du."
+
+Da wurde die Königin blass. Sie ahnte, wer diese junge Königin war. Sie ritt zum Schloss, um es mit eigenen Augen zu sehen. Als sie Schneewittchen in einem weissen Kleid auf der Treppe stehen sah, bekam sie einen so grossen Schreck, dass sie am liebsten davongerannt wäre. Aber es war zu spät: Die Wachen erkannten sie, und sie musste das Schloss verlassen. Sie ging weit fort und kam nie mehr zurück.
+
+Schneewittchen aber lebte im Schloss mit dem Prinzen. Sie besuchte die Zwerge oft. Sie fütterte wieder die Vögel am Fenster. Und sie streichelte wieder die Pferde im Stall. Der Zauberspiegel wurde in eine dunkle Kammer gestellt, und niemand sprach mehr mit ihm. Im Schloss lachten und sangen die Menschen, und Schneewittchen blieb freundlich zu allen, so wie ihre Mama es sich gewünscht hatte.


### PR DESCRIPTION
The age-4+ Moderne Fassung for the top 5 Grimm tales was only
~360-400 words, while the originals run 1,300-2,850 words. Expand
each adaption with extra scenes, dialogue, and details so it is
comparable in length to the original while keeping modern German
and gentle, child-appropriate tone.

Word counts (adaption / original):
- Aschenputtel:     2206 / 2429
- Hänsel und Gretel: 2355 / 2678
- Rapunzel:         1605 / 1341
- Rotkäppchen:      1504 / 1286
- Schneewittchen:   2551 / 2849

Mirrors each expanded file into packages/collection-grimm-top5
so the workspace collection stays in sync.

https://claude.ai/code/session_016t9FbMN59p1H6AswC8g6Eo