### PR TITLE
enhanced-gestures: default on + structured interaction logging

### DIFF
--- a/api/log.js
+++ b/api/log.js
@@ -1,0 +1,48 @@
+/**
+ * Serverless log sink.
+ *
+ * Accepts POST /api/log with JSON body `{ entries: [...] }` (also handles
+ * `navigator.sendBeacon` which sends application/json with no preflight).
+ * Each entry is printed to stdout as a JSON line — Vercel captures this in
+ * the Runtime Logs tab where it can be filtered, streamed, and downloaded
+ * (NDJSON). No persistence here; the Vercel log drain is the store.
+ *
+ * Kept deliberately minimal: no auth, no schema validation, no rate limit.
+ * Client-side `gestureLog` batches and throttles so the endpoint is hit at
+ * most once every ~750ms per tab during active gesture activity.
+ */
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'method not allowed' });
+    return;
+  }
+
+  try {
+    // sendBeacon delivers the body as a Blob; Node parses it if
+    // `content-type: application/json`. Fall back to manual parse for
+    // environments that don't.
+    let payload = req.body;
+    if (typeof payload === 'string') payload = JSON.parse(payload);
+    if (!payload || typeof payload !== 'object') {
+      res.status(400).json({ error: 'bad body' });
+      return;
+    }
+
+    const entries = Array.isArray(payload.entries) ? payload.entries : [];
+    const ip =
+      req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() ||
+      req.socket?.remoteAddress ||
+      null;
+    const ua = req.headers['user-agent'] || null;
+
+    for (const entry of entries) {
+      const line = JSON.stringify({ ...entry, ip, ua });
+      console.log(`[gestureLog] ${line}`);
+    }
+
+    res.status(204).end();
+  } catch (err) {
+    console.error('[gestureLog] sink error', err?.message);
+    res.status(500).json({ error: 'sink error' });
+  }
+}

--- a/components/GestureDrawerViewport.jsx
+++ b/components/GestureDrawerViewport.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { EdgeDrawer, DrawerBackdrop, ReloadIndicator } from './GestureDrawers';
 import DrawerIndicators from './DrawerIndicators';
 import { useGestureDrawers } from './GestureDrawerContext';
+import { gestureLog, describeTarget } from '../src/lib/gestureLog';
 import {
   CLOSE_AXIS,
   EDGE_CLOSED_TRANSFORM,
@@ -159,6 +160,14 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
       // `noBackdrop` slots keep the global backdrop dormant even when open.
       const writeBackdrop = backdropRef.current && !d.noBackdrop;
 
+      gestureLog('gesture.commit-decision', {
+        mode: d.mode,
+        edge: d.edge,
+        finalProgress: Math.round(finalProgress * 100) / 100,
+        aligned: Math.round(aligned * 1000) / 1000,
+        shouldCommit,
+      });
+
       if (d.mode === 'close') {
         // Close-drag: committing means fully closing; aborting springs back open.
         if (shouldCommit) {
@@ -167,6 +176,7 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
             backdropRef.current.style.opacity = '0';
             backdropRef.current.style.pointerEvents = 'none';
           }
+          gestureLog('drawer.close', { edge: d.edge, source: 'gesture' });
           closeDrawer();
         } else {
           drawerEl.style.transform = 'translate3d(0, 0, 0)';
@@ -185,6 +195,7 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
           backdropRef.current.style.opacity = '0.3';
           backdropRef.current.style.pointerEvents = 'auto';
         }
+        gestureLog('drawer.open', { edge: d.edge, source: 'gesture' });
         openDrawer(d.edge);
       } else {
         drawerEl.style.transform = EDGE_CLOSED_TRANSFORM[d.edge] ?? '';
@@ -210,6 +221,7 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
   const suppressNextClick = useCallback(() => {
     if (typeof window === 'undefined') return;
     const suppress = (e) => {
+      gestureLog('gesture.click-suppressed', { target: describeTarget(e.target) });
       e.preventDefault();
       e.stopPropagation();
       window.removeEventListener('click', suppress, true);
@@ -221,11 +233,22 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
   // Window pointerdown — decide whether a drag starts at all.
   useEffect(() => {
     if (!enabled) {
+      gestureLog('viewport.disabled', { anyDrawerOpen: anyGestureDrawerOpen });
       setPreview(null);
       setReloadProgress(0);
       return undefined;
     }
     if (typeof window === 'undefined') return undefined;
+    gestureLog('viewport.enabled', {
+      slots: {
+        top: !!slots.top,
+        bottom: !!slots.bottom,
+        left: !!slots.left,
+        right: !!slots.right,
+      },
+      anyDrawerOpen: anyGestureDrawerOpen,
+      openEdge,
+    });
 
     const onPointerDown = (e) => {
       if (e.pointerType === 'mouse' && e.button !== 0) return;
@@ -234,13 +257,34 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
       const existing = dragRef.current;
       if (existing) {
         const age = performance.now() - (existing.lastT ?? 0);
-        if (age > STALE_DRAG_MS) dragRef.current = null;
-        else return;
+        if (age > STALE_DRAG_MS) {
+          gestureLog('gesture.stale-drag.cleared', { ageMs: Math.round(age) });
+          dragRef.current = null;
+        } else {
+          gestureLog('gesture.pointerdown.blocked-by-active-drag', {
+            ageMs: Math.round(age),
+          });
+          return;
+        }
       }
 
       const { vw, vh, rect } = resolveBounds();
       const x = e.clientX;
       const y = e.clientY;
+      gestureLog('gesture.pointerdown', {
+        x: Math.round(x),
+        y: Math.round(y),
+        pointerType: e.pointerType,
+        target: describeTarget(e.target),
+        anyDrawerOpen: anyGestureDrawerOpen,
+        openEdge,
+        readerRect: {
+          top: Math.round(rect.top),
+          left: Math.round(rect.left),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+        },
+      });
 
       // If a drawer is already open, figure out whether this pointerdown is
       // on the drawer itself (possible close-drag gated by direction + scroll
@@ -281,6 +325,13 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
         size: 0,
         progress: 0,
         committedAxis: false,
+        // Diagnostic peak: max travel distance + smallest cone deviation
+        // seen during the drag. Logged on pointerup if the gesture never
+        // committed, so we can see whether the gate rejected or the finger
+        // simply didn't move far enough.
+        peakDist: 0,
+        peakSpeed: 0,
+        peakDeviationRad: Math.PI / 2,
       };
     };
 
@@ -308,11 +359,14 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
         // a fast flick commits immediately; above FALLBACK_DIST a deliberate
         // slow drag commits even without velocity.
         const dist = Math.hypot(dx, dy);
+        if (dist > d.peakDist) d.peakDist = dist;
         if (dist < MIN_DIST) return;
 
         const { vx, vy } = computeVelocity(d.samples);
         const speed = Math.hypot(vx, vy);
         const deviation = axisDeviationRad(dx, dy);
+        if (speed > d.peakSpeed) d.peakSpeed = speed;
+        if (deviation < d.peakDeviationRad) d.peakDeviationRad = deviation;
         const withinCone = deviation <= ANGLE_CONE_RAD;
         const fastPath = withinCone && speed >= MIN_VELOCITY;
         const slowPath = withinCone && dist >= FALLBACK_DIST;
@@ -329,6 +383,7 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
           const edge = d.edge;
           const closeAxis = CLOSE_AXIS[edge];
           if (!closeAxis) {
+            gestureLog('gesture.abort', { reason: 'no-close-axis', edge });
             dragRef.current = null;
             return;
           }
@@ -340,11 +395,26 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
               : Math.sign(dx) === closeAxis.sign;
           if (!axisMatches || !signMatches) {
             // Wrong direction — abort so native handling (scroll, tap) wins.
+            gestureLog('gesture.abort', {
+              reason: 'close-wrong-direction',
+              edge,
+              dx: Math.round(dx),
+              dy: Math.round(dy),
+              axisMatches,
+              signMatches,
+            });
             dragRef.current = null;
             return;
           }
           const openDrawerEl = drawerRefs.current[edge];
           if (d.insideOpenDrawer && scrollableAncestorCanAbsorb(d.targetEl, openDrawerEl, dx, dy)) {
+            gestureLog('gesture.abort', {
+              reason: 'scroll-ancestor-absorb',
+              edge,
+              dx: Math.round(dx),
+              dy: Math.round(dy),
+              target: describeTarget(d.targetEl),
+            });
             dragRef.current = null;
             return;
           }
@@ -353,9 +423,28 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
           d.size = sizeOf(edge, slots[edge]);
           d.noBackdrop = !!slots[edge]?.noBackdrop;
           d.committedAxis = true;
+          gestureLog('gesture.commit', {
+            mode: 'close',
+            edge,
+            dx: Math.round(dx),
+            dy: Math.round(dy),
+            speed: Math.round(speed * 1000) / 1000,
+          });
         } else {
           const edge = edgeForSwipe(dx, dy);
           if (!slots[edge]) {
+            gestureLog('gesture.abort', {
+              reason: 'no-slot',
+              edge,
+              dx: Math.round(dx),
+              dy: Math.round(dy),
+              registeredSlots: {
+                top: !!slots.top,
+                bottom: !!slots.bottom,
+                left: !!slots.left,
+                right: !!slots.right,
+              },
+            });
             dragRef.current = null;
             return;
           }
@@ -365,6 +454,14 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
           d.size = sizeOf(edge, slots[edge]);
           d.noBackdrop = !!slots[edge]?.noBackdrop;
           d.committedAxis = true;
+          gestureLog('gesture.commit', {
+            mode: 'open',
+            edge,
+            dx: Math.round(dx),
+            dy: Math.round(dy),
+            speed: Math.round(speed * 1000) / 1000,
+            path: fastPath ? 'fast' : 'slow',
+          });
         }
       }
 
@@ -389,12 +486,41 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
       // also trigger whatever button it started on.
       if (d.committedAxis) suppressNextClick();
 
+      // Log the outcome. If the gesture never committed, the peak telemetry
+      // tells us why: too little travel, too slow, or angle outside the cone.
+      if (!d.committedAxis) {
+        gestureLog('gesture.never-committed', {
+          peakDist: Math.round(d.peakDist),
+          peakSpeed: Math.round(d.peakSpeed * 1000) / 1000,
+          peakDeviationDeg: Math.round((d.peakDeviationRad * 180) / Math.PI),
+          closeMode: d.closeMode,
+          edge: d.edge,
+          insideOpenDrawer: d.insideOpenDrawer,
+          reason:
+            d.peakDist < MIN_DIST
+              ? 'below-min-dist'
+              : (d.peakDeviationRad * 180) / Math.PI > 35
+                ? 'outside-angle-cone'
+                : d.peakSpeed < MIN_VELOCITY && d.peakDist < FALLBACK_DIST
+                  ? 'below-speed-and-fallback'
+                  : 'unknown',
+        });
+      } else {
+        gestureLog('gesture.release', {
+          mode: d.mode,
+          edge: d.edge,
+          progress: Math.round(d.progress * 100) / 100,
+          velocity: Math.round((d.velocity ?? 0) * 1000) / 1000,
+        });
+      }
+
       // Reload intent: swipe-down that armed near the top edge and crossed
       // RELOAD_RATIO of reader height. Only for open-drags on the top edge;
       // close-drags on the already-open top drawer never trigger reload.
       if (d.mode === 'open' && d.edge === 'top' && d.startedNearTop) {
         const dy = d.lastY - d.startY;
         if (dy > d.readerHeight * RELOAD_RATIO) {
+          gestureLog('gesture.reload-triggered', { dy: Math.round(dy) });
           const drawerEl = drawerRefs.current[d.edge];
           if (drawerEl) {
             drawerEl.style.transition = 'transform 400ms cubic-bezier(0.32, 0.72, 0.36, 1)';
@@ -422,6 +548,11 @@ export default function GestureDrawerViewport({ enabled, readerAreaRef }) {
     const onPointerCancel = (e) => {
       const d = dragRef.current;
       if (!d || e.pointerId !== d.pointerId) return;
+      gestureLog('gesture.pointercancel', {
+        committedAxis: d.committedAxis,
+        mode: d.mode,
+        edge: d.edge,
+      });
       dragRef.current = null;
       setPreview(null);
       setReloadProgress(0);

--- a/components/SidebarV2.jsx
+++ b/components/SidebarV2.jsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Heart, User, LogOut, Sparkles, X, ListCollap
 import { useTheme } from '../ui/ThemeContext';
 import SearchInput from '../ui/SearchInput';
 import StoryButton from '../ui/StoryButton';
+import { gestureLog } from '../src/lib/gestureLog';
 
 const CHILD_AGE_OPTIONS = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
@@ -136,8 +137,12 @@ export default function SidebarV2({
   // where the sidebar is statically visible. When `externalGestures` is true,
   // GestureLayer owns the gesture lifecycle and this hook is a no-op.
   useEffect(() => {
-    if (externalGestures) return undefined;
+    if (externalGestures) {
+      gestureLog('sidebarv2.swipe-handler.skip', { reason: 'external-gestures' });
+      return undefined;
+    }
     if (typeof window === 'undefined') return;
+    gestureLog('sidebarv2.swipe-handler.install', {});
     const EDGE_PX = 44;
     const MIN_DX = 40;
     const MAX_DY = 80;
@@ -151,12 +156,29 @@ export default function SidebarV2({
 
     const onStart = (e) => {
       if (e.touches.length !== 1) { tracking = false; return; }
-      if (isDesktop()) { tracking = false; return; }
+      if (isDesktop()) {
+        gestureLog('sidebarv2.swipe.skip', { reason: 'desktop' });
+        tracking = false;
+        return;
+      }
       const t = e.touches[0];
       // To open: gesture must start near the left edge.
       // To close: only meaningful while the sidebar is open; the sidebar
       // covers the left side up to w-80 (~320px), so accept from anywhere.
-      if (!menuOpen && t.clientX > EDGE_PX) { tracking = false; return; }
+      if (!menuOpen && t.clientX > EDGE_PX) {
+        gestureLog('sidebarv2.swipe.skip', {
+          reason: 'outside-edge-zone',
+          clientX: Math.round(t.clientX),
+          edgePx: EDGE_PX,
+        });
+        tracking = false;
+        return;
+      }
+      gestureLog('sidebarv2.swipe.start', {
+        x: Math.round(t.clientX),
+        y: Math.round(t.clientY),
+        menuOpen,
+      });
       startX = t.clientX;
       startY = t.clientY;
       startTime = Date.now();
@@ -170,12 +192,35 @@ export default function SidebarV2({
       const dx = t.clientX - startX;
       const dy = t.clientY - startY;
       const dt = Date.now() - startTime;
-      if (dt > MAX_DT) return;
-      if (Math.abs(dy) > MAX_DY) return;
-      if (Math.abs(dx) < MIN_DX) return;
+      if (dt > MAX_DT) {
+        gestureLog('sidebarv2.swipe.reject', {
+          reason: 'too-slow',
+          dt,
+          dx: Math.round(dx),
+          dy: Math.round(dy),
+        });
+        return;
+      }
+      if (Math.abs(dy) > MAX_DY) {
+        gestureLog('sidebarv2.swipe.reject', {
+          reason: 'too-diagonal',
+          dx: Math.round(dx),
+          dy: Math.round(dy),
+        });
+        return;
+      }
+      if (Math.abs(dx) < MIN_DX) {
+        gestureLog('sidebarv2.swipe.reject', {
+          reason: 'too-short',
+          dx: Math.round(dx),
+        });
+        return;
+      }
       if (dx > 0 && !menuOpen) {
+        gestureLog('sidebarv2.swipe.open', { dx: Math.round(dx) });
         onMenuOpenChange?.(true);
       } else if (dx < 0 && menuOpen) {
+        gestureLog('sidebarv2.swipe.close', { dx: Math.round(dx) });
         onMenuOpenChange?.(false);
       }
     };

--- a/components/TapZones.jsx
+++ b/components/TapZones.jsx
@@ -1,3 +1,5 @@
+import { gestureLog } from '../src/lib/gestureLog';
+
 /**
  * Left and right tap zones for page navigation.
  * Two invisible 30%-width divs on the sides that call prev/next on click.
@@ -14,22 +16,31 @@ export default function TapZones({ onPrev, onClick, onNext }) {
         data-testid="tap-zone-left"
         className="absolute left-0 top-0 bottom-0 z-10 cursor-pointer"
         style={{ width: '30%' }}
-        onClick={onPrev}
+        onClick={(e) => {
+          gestureLog('tap.zone.left', { x: e.clientX, y: e.clientY });
+          onPrev?.();
+        }}
       />
 
       {/* Middle: 40% */}
-      <div 
-        data-testid="tap-zone-middle" 
-        className="absolute left-[30%] right-[30%] top-0 bottom-0 z-10 cursor-pointer" 
-        onClick={onClick} 
+      <div
+        data-testid="tap-zone-middle"
+        className="absolute left-[30%] right-[30%] top-0 bottom-0 z-10 cursor-pointer"
+        onClick={(e) => {
+          gestureLog('tap.zone.middle', { x: e.clientX, y: e.clientY });
+          onClick?.();
+        }}
       />
-      
+
       {/* Right tap zone - next page */}
       <div
         data-testid="tap-zone-right"
         className="absolute right-0 top-0 bottom-0 z-10 cursor-pointer"
         style={{ width: '30%' }}
-        onClick={onNext}
+        onClick={(e) => {
+          gestureLog('tap.zone.right', { x: e.clientX, y: e.clientY });
+          onNext?.();
+        }}
       />
     </>
   );

--- a/docs/features/enhanced-gestures.md
+++ b/docs/features/enhanced-gestures.md
@@ -4,7 +4,7 @@ name: "Enhanced Gestures"
 type: "app"
 flag_key: "enhanced-gestures"
 lifecycle: "EXPERIMENT"
-flag_default: "off"
+flag_default: "on"
 category: "reader-ui"
 personas:
   - "09-seniors"
@@ -18,7 +18,7 @@ children: []
 
 # Enhanced Gestures
 
-**Flag:** `enhanced-gestures` · **Lifecycle:** EXPERIMENT · **Default:** off
+**Flag:** `enhanced-gestures` · **Lifecycle:** EXPERIMENT · **Default:** on
 
 Multi-direction swipe gestures inside the reader viewport. Layered on top
 of tap zones and pinch-to-zoom: taps keep driving page navigation, gestures

--- a/flags.json
+++ b/flags.json
@@ -185,7 +185,7 @@
     }
   },
   "enhanced-gestures": {
-    "defaultVariant": "off",
+    "defaultVariant": "on",
     "variants": {
       "on": true,
       "off": false

--- a/grimm-reader.jsx
+++ b/grimm-reader.jsx
@@ -28,6 +28,7 @@ import GestureDrawerViewport from './components/GestureDrawerViewport';
 import { GestureDrawerProvider } from './components/GestureDrawerContext';
 import { SidebarLeftSlot } from './components/SidebarDrawerBridge';
 import { useIsMobile } from './hooks/useIsMobile';
+import { gestureLog } from './src/lib/gestureLog';
 import { getStoryIndex, getCollectionIndex, loadStoryById, loadStoryMetadataById, loadAdaptionsByStoryId, loadStoryAudioMap } from './src/lib/storyLibrary';
 
 const SPEED_READER_FONT_SIZE = {
@@ -547,6 +548,7 @@ const GrimmMarchenApp = () => {
 
     const onTouchStart = (event) => {
       if (event.touches.length !== 2) return;
+      gestureLog('pinch.start', { startFontSize: fontSizeRef.current });
       pinchGestureRef.current = {
         active: true,
         startDistance: distance(event.touches),
@@ -556,6 +558,8 @@ const GrimmMarchenApp = () => {
 
     const onTouchMove = (event) => {
       if (!pinchGestureRef.current.active || event.touches.length !== 2) return;
+      // preventDefault here is the suspected culprit for "pointer events on the
+      // reader don't reach window listeners" — log when it fires.
       event.preventDefault();
       const currentDistance = distance(event.touches);
       if (pinchGestureRef.current.startDistance <= 0) return;
@@ -568,7 +572,8 @@ const GrimmMarchenApp = () => {
     };
 
     const onTouchEnd = (event) => {
-      if (event.touches.length < 2) {
+      if (pinchGestureRef.current.active && event.touches.length < 2) {
+        gestureLog('pinch.end', {});
         pinchGestureRef.current.active = false;
       }
     };

--- a/src/lib/featureRegistry.jsx
+++ b/src/lib/featureRegistry.jsx
@@ -461,7 +461,7 @@ export const FEATURE_REGISTRY = [
     label: 'Erweiterte Gesten',
     description: 'Wischgesten aus allen Richtungen öffnen Drawer, ein langer Zug nach unten lädt die Seite neu.',
     Icon: () => <Move size={20} strokeWidth={1.75} />,
-    flag: bool('off'),
+    flag: bool('on'),
     status: 'beta',
     roles: ['subscriber', 'tester'],
     group: 'navigation',

--- a/src/lib/gestureLog.js
+++ b/src/lib/gestureLog.js
@@ -1,0 +1,116 @@
+/**
+ * Client-side gesture/interaction logger.
+ *
+ * Emits structured events from anywhere pointer / touch / click handling
+ * happens in the app. Each entry is buffered and batch-POSTed to `/api/log`
+ * where the serverless sink prints to stdout — Vercel captures that stream
+ * in the Logs tab, downloadable as NDJSON.
+ *
+ * Also logs to `console.debug` so the same trace is visible in DevTools
+ * during local repro. Safe to call at human-interaction frequency; do NOT
+ * call on every pointermove (that would flood the batch).
+ *
+ * Enable/disable at runtime via `localStorage['wr-gesture-log'] = '0'` to
+ * silence, `'1'` to force on. Default is on.
+ */
+const ENDPOINT = '/api/log';
+const FLUSH_INTERVAL_MS = 750;
+const MAX_BATCH = 40;
+
+let buffer = [];
+let flushTimer = null;
+let sessionId = null;
+
+function getSessionId() {
+  if (sessionId) return sessionId;
+  try {
+    let sid = sessionStorage.getItem('wr-gesture-session');
+    if (!sid) {
+      sid = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+      sessionStorage.setItem('wr-gesture-session', sid);
+    }
+    sessionId = sid;
+  } catch {
+    sessionId = `ephemeral-${Math.random().toString(36).slice(2, 10)}`;
+  }
+  return sessionId;
+}
+
+function isEnabled() {
+  if (typeof window === 'undefined') return false;
+  try {
+    const v = localStorage.getItem('wr-gesture-log');
+    if (v === '0') return false;
+  } catch {
+    // fall through
+  }
+  return true;
+}
+
+function scheduleFlush() {
+  if (flushTimer !== null) return;
+  flushTimer = setTimeout(flush, FLUSH_INTERVAL_MS);
+}
+
+function flush() {
+  flushTimer = null;
+  if (buffer.length === 0) return;
+  const entries = buffer;
+  buffer = [];
+  const body = JSON.stringify({ entries });
+  try {
+    if (navigator.sendBeacon) {
+      const blob = new Blob([body], { type: 'application/json' });
+      const ok = navigator.sendBeacon(ENDPOINT, blob);
+      if (ok) return;
+    }
+    fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // Network down is fine — DevTools console still has the entries.
+  }
+}
+
+if (typeof window !== 'undefined') {
+  // Make sure in-flight entries escape the page before unload.
+  window.addEventListener('pagehide', flush);
+  window.addEventListener('beforeunload', flush);
+}
+
+/**
+ * Record a single interaction event.
+ *
+ * @param {string} name  Dotted name, e.g. 'gesture.pointerdown', 'tap.zone.left'
+ * @param {object} [data] Arbitrary serializable payload. Keep small.
+ */
+export function gestureLog(name, data = {}) {
+  if (!isEnabled()) return;
+  const entry = {
+    t: Date.now(),
+    sid: getSessionId(),
+    name,
+    ...data,
+  };
+  buffer.push(entry);
+  // Mirror to DevTools so local repro doesn't need the network round-trip.
+  if (typeof console !== 'undefined' && console.debug) {
+    console.debug(`[gl] ${name}`, data);
+  }
+  if (buffer.length >= MAX_BATCH) flush();
+  else scheduleFlush();
+}
+
+export function describeTarget(el) {
+  if (!el || !(el instanceof Element)) return null;
+  const id = el.id ? `#${el.id}` : '';
+  const testId = el.getAttribute?.('data-testid');
+  const cls =
+    typeof el.className === 'string' && el.className
+      ? `.${el.className.split(/\s+/).slice(0, 2).join('.')}`
+      : '';
+  return `${el.tagName.toLowerCase()}${id}${testId ? `[tid=${testId}]` : ''}${cls}`;
+}


### PR DESCRIPTION
- Flip `enhanced-gestures` flag_default to `on` (flags.json, registry, docs)
  so the multi-edge drawer gesture system is active for every user without
  requiring the toggle.
- Add `src/lib/gestureLog.js`: batching client logger that mirrors entries
  to console.debug and POSTs batches to `/api/log` (sendBeacon fallback,
  keepalive flush on pagehide). Session id per tab.
- Add `api/log.js` serverless sink: prints every entry as a JSON line to
  stdout so Vercel captures the stream in the Runtime Logs tab (downloadable
  as NDJSON). No persistence — the log drain is the store.
- Instrument the interaction code paths where handlers are most likely to
  fight each other:
    * `GestureDrawerViewport`: viewport enable/disable, pointerdown,
      stale-drag clears and blocks, commit gate aborts (no-close-axis,
      close-wrong-direction, scroll-ancestor-absorb, no-slot), commit,
      never-committed peak telemetry, commit-decision, drawer open/close,
      click suppression, pointercancel.
    * `SidebarV2` swipe handler: install vs skip (external-gestures),
      start, every reject reason, open/close decisions.
    * `TapZones`: left/middle/right taps.
    * `grimm-reader` pinch handler: start/end.

Peak telemetry on `gesture.never-committed` (peakDist, peakSpeed,
peakDeviationDeg + reason) is the key signal: it tells us whether a swipe
didn't open a drawer because it was too short, too slow, too diagonal,
or because another handler consumed the pointer events before our gate
saw them.

https://claude.ai/code/session_011E64b14c7CDuVdTN1eUPh3