### PR TITLE
fix(vercel): exclude static assets from SPA rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "rewrites": [
     { "source": "/.well-known/vercel/flags", "destination": "/api/.well-known/vercel/flags" },
-    { "source": "/((?!api/|_vercel/|.well-known/).*)", "destination": "/" }
+    { "source": "/((?!api/|_vercel/|assets/|.*\\.).*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Problem
The SPA fallback rewrite in `vercel.json` did not exclude `/assets/`, so any request for a hashed JS chunk not present in the current deployment fell through to the catch-all and returned `index.html` (`200 text/html`) instead of a real `404`. The browser then tried to execute HTML as a JS module:

> Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"

Result: **white screen** in production. Verified live: a missing `/assets/*.js` returned `200 text/html`, while the referenced chunk returned `application/javascript`.

## Fix
Tighten the rewrite so anything under `assets/` or containing a file extension (a dot) is never rewritten to `index.html` — it serves statically or returns an honest 404 the browser can recover from. Clean routes (`/app`, `/pricing`, …) still fall back correctly; `.well-known/vercel/flags` keeps its dedicated rewrite.

```diff
-    { "source": "/((?!api/|_vercel/|.well-known/).*)", "destination": "/" }
+    { "source": "/((?!api/|_vercel/|assets/|.*\.).*)", "destination": "/" }
```